### PR TITLE
Autoload `copilot-mode`

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -559,6 +559,7 @@
   :type 'list
   :group 'copilot)
 
+;;;###autoload
 (define-minor-mode copilot-mode
   "Minor mode for Copilot."
   :init-value nil


### PR DESCRIPTION
Removes the need to explicitly require copilot.el before enabling the mode