### PR TITLE
Add `copilot-mode-map`

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -446,6 +446,11 @@ For Copilot, COL is always 0. USER-POS is the cursor position (for verification 
   :type 'list
   :group 'copilot)
 
+(defvar copilot-mode-map (make-sparse-keymap)
+  "Keymap for Copilot minor mode.
+
+Use this for custom bindings in `copilot-mode'.")
+
 ;;;###autoload
 (define-minor-mode copilot-mode
   "Minor mode for Copilot."

--- a/readme.md
+++ b/readme.md
@@ -191,6 +191,25 @@ In general, you need to bind `copilot-accept-completion` to some key in order to
                                                              (indent-for-tab-command))))
 ```
 
+#### Example of defining tab in copilot-mode
+
+This is useful if you don't want to depend on a particular completion framework.
+
+```elisp
+(defun my/copilot-tab ()
+  (interactive)
+  (or (copilot-accept-completion)
+      (indent-for-tab-command)))
+
+(define-key copilot-mode-map (kbd "<tab>") #'my/copilot-tab)
+```
+
+Or with evil-mode:
+```elisp
+(evil-define-key 'insert copilot-mode-map
+  (kbd "<tab>") #'my/copilot-tab)
+```
+
 </details>
 
 ## Commands

--- a/readme.md
+++ b/readme.md
@@ -201,13 +201,15 @@ This is useful if you don't want to depend on a particular completion framework.
   (or (copilot-accept-completion)
       (indent-for-tab-command)))
 
-(define-key copilot-mode-map (kbd "<tab>") #'my/copilot-tab)
+(with-eval-after-load 'copilot
+  (define-key copilot-mode-map (kbd "<tab>") #'my/copilot-tab))
 ```
 
 Or with evil-mode:
 ```elisp
-(evil-define-key 'insert copilot-mode-map
-  (kbd "<tab>") #'my/copilot-tab)
+(with-eval-after-load 'copilot
+  (evil-define-key 'insert copilot-mode-map
+    (kbd "<tab>") #'my/copilot-tab))
 ```
 
 </details>


### PR DESCRIPTION
`copilot-mode` doesn't ship with a mode map.

Defining `copilot-mode-map` before `copilot-mode` should allow for defining user keybindings in this keymap. I've added an example to the README.