### PR TITLE
Add a global mode and a keymap for the completion overlay

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -478,6 +478,10 @@ Use this for custom bindings in `copilot-mode'.")
   (advice-add 'posn-at-point :before-until 'copilot--posn-advice)
   (add-hook 'post-command-hook 'copilot--complete-post-command))
 
+;;;###autoload
+(define-global-minor-mode global-copilot-mode
+    copilot-mode copilot-mode)
+
 (defun copilot--complete-post-command ()
   "Complete in post-command hook."
   (when (and copilot-mode this-command)

--- a/copilot.el
+++ b/copilot.el
@@ -322,6 +322,11 @@ To work around posn problems with after-string property.")
                (eq pos (car copilot--real-posn)))
       (cdr copilot--real-posn))))
 
+(defconst copilot-completion-map (make-sparse-keymap)
+  "Keymap for Copilot completion overlay.")
+
+(define-key copilot-completion-map [tab] #'copilot-accept-completion)
+
 (defun copilot-display-overlay-completion (completion uuid line col user-pos)
   "Show COMPLETION with UUID in overlay at LINE and COL.
 For Copilot, COL is always 0. USER-POS is the cursor position (for verification only)."
@@ -349,7 +354,7 @@ For Copilot, COL is always 0. USER-POS is the cursor position (for verification 
                    (and (< (point) user-pos) ; special case for removing indentation
                         (s-blank-p (s-trim (buffer-substring-no-properties (point) user-pos))))))
       (let* ((p-completion (propertize completion 'face 'copilot-overlay-face))
-             (ov (make-overlay (point) (point-at-eol) nil t t)))
+             (ov (make-overlay (point) (point-at-eol) nil nil t)))
         (if (= (overlay-start ov) (overlay-end ov)) ; end of line
             (progn
               (setq copilot--real-posn (cons (point) (posn-at-point)))
@@ -360,6 +365,7 @@ For Copilot, COL is always 0. USER-POS is the cursor position (for verification 
         (overlay-put ov 'completion completion)
         (overlay-put ov 'start (point))
         (overlay-put ov 'uuid uuid)
+        (overlay-put ov 'keymap copilot-completion-map)
         (setq copilot--overlay ov)
         (copilot--async-request 'notifyShown (list :uuid uuid))))))
 

--- a/copilot.el
+++ b/copilot.el
@@ -325,8 +325,6 @@ To work around posn problems with after-string property.")
 (defconst copilot-completion-map (make-sparse-keymap)
   "Keymap for Copilot completion overlay.")
 
-(define-key copilot-completion-map [tab] #'copilot-accept-completion)
-
 (defun copilot-display-overlay-completion (completion uuid line col user-pos)
   "Show COMPLETION with UUID in overlay at LINE and COL.
 For Copilot, COL is always 0. USER-POS is the cursor position (for verification only)."


### PR DESCRIPTION
Hey @zerolfx. Amazing work on this plugin. After using VSCode Copilot extension I was very impressed by how easy it was to achieve a similar experience in Emacs as a result of your efforts.

As a token of appreciation, I'd like to propose following changes, which I think could improve this experience even more:

- Define `global-copilot-mode` to enable `copilot-mode` in all buffers, which could be convenient if you want to use copilot suggestions for text as well as code.
- Define `copilot-suggestion-map`, which becomes active while suggestion overlay is shown, changing overlay's `FRONT-ADVANCE` arg to nil in order for the point to be inside overlay boundaries.

By default it binds **`TAB`** to `copilot-accept-completion`, but it can also be used to bind other completion commands, e.g.:

```elisp
(use-package! copilot
  :config (global-copilot-mode)
  :bind (:map copilot-completion-map
         ("RET" . #'copilot-accept-completion)
         ("<tab>" . #'copilot-accept-completion-by-line)
         ("C-<tab>" . #'copilot-accept-completion-by-word)
         ("C-n" . #'copilot-next-completion)
         ("C-p" . #'copilot-previous-completion)))
```


