### PR TITLE
Substitute dummy parameters for nil in copilot requests

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -152,7 +152,7 @@ If username and password are not provided, they will be prompted for."
   (interactive)
   (copilot--dbind
       (:status :user :userCode user-code :verificationUri verification-uri)
-      (copilot--request 'signInInitiate ''nil)
+      (copilot--request 'signInInitiate '(:dummy "signInInitiate"))
     (when (s-equals-p status "AlreadySignedIn")
       (message "Already signed in as %s." user)
       (cl-return-from copilot-login))
@@ -169,13 +169,13 @@ If username and password are not provided, they will be prompted for."
         (copilot--request 'signInConfirm (list :userCode user-code))
       (jsonrpc-error
         (message "Authentication failure: %s" (alist-get 'jsonrpc-error-message (cddr err)))))
-    (copilot--dbind (:user) (copilot--request 'checkStatus ''nil)
+    (copilot--dbind (:user) (copilot--request 'checkStatus '(:dummy "checkStatus"))
       (message "Authenticated as GitHub user %s." user))))
 
 (defun copilot-logout ()
   "Logout from Copilot."
   (interactive)
-  (copilot--request 'signOut ''nil)
+  (copilot--request 'signOut '(:dummy "signOut"))
   (message "Logged out."))
 
 ;;


### PR DESCRIPTION
This forces json serialisation to produce an object as an argument; previously, on some machines it would serialise `''nil` as `["quote", null]`. It seems that all messages expect an object for parameters; it's just expected to be empty for sign-in, sign-out and checking status.

I don't know much about json serialisation in emacs, so it's possible that there's a way to configure jsonrpc differently, or that my setup has a bad combination of versions. This fix is more of a workaround.

Fixes #63