### PR TITLE
Add requirement `use-package`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@ In general, you need to bind `copilot-accept-completion` to some key in order to
 This is useful if you don't want to depend on a particular completion framework.
 
 ```elisp
+(require 'use-package)
 (defun my/copilot-tab ()
   (interactive)
   (or (copilot-accept-completion)


### PR DESCRIPTION
It seems that `use-package` is required for this to work, at least for me this was the case.