### PR TITLE
Fixed instructions for spacemacs setup.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,9 +86,9 @@ dotspacemacs-additional-packages
   ;; disable inline previews
   (delq 'company-preview-if-just-one-frontend company-frontends))
   
-(define-key copilot-completion-map (kbd "<tab>") 'copilot-accept-completion)
-(define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion)
-
+(with-eval-after-load 'copilot
+  (define-key copilot-completion-map (kbd "<tab>") 'copilot-accept-completion)
+  (define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion))
 
 (add-hook 'prog-mode-hook 'copilot-mode)
 


### PR DESCRIPTION
Thanks for this great plugin!

Following the instructions for spacemacs, I got an error saying that `copilot-completion-map` is not defined. Following advice in https://github.com/zerolfx/copilot.el/issues/53, I fixed it by ensuring that copilot is loaded before trying to access that variable!