### PR TITLE
feat: add dwim functions which trigger or accept existing completion

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -508,6 +508,31 @@ Use TRANSFORM-FN to transform completion if provided."
               (message "No completion is available."))))))))
 
 ;;
+;; dwim - do what I mean
+;;
+
+(defun copilot-dwim ()
+  "Trigger or accept completion."
+  (interactive)
+  (if (copilot--overlay-visible)
+      (copilot-accept-completion)
+    (copilot-complete)))
+
+(defun copilot-dwim-by-word (n-word)
+  "Trigger or accept N-WORD words from current completion."
+  (interactive "p")
+  (if (copilot--overlay-visible)
+      (copilot-accept-completion-by-word n-word)
+    (copilot-complete)))
+
+(defun copilot-dwim-by-line (n-line)
+  "Trigger or accept N-LINE lines from current completion."
+  (interactive "p")
+  (if (copilot--overlay-visible)
+      (copilot-accept-completion-by-line n-line)
+    (copilot-complete)))
+
+;;
 ;; minor mode
 ;;
 


### PR DESCRIPTION
I find this behavior useful, either after having manually dismissed a completion with C-g, or on rare occasion when Copilot doesn't offer any completions, but forcing it to with copilot-complete does bring something up.

This is based on my [personal config](https://github.com/jimeh/.emacs.d/blob/a8e92eb311768e52d8452c7b10610c4b8eafe0ac/modules/completion/siren-copilot.el), where I use `<backtab>` (shift+tab) to both force-trigger and also accept Copilot completions. This leaves `<tab>` free to work like normal with lsp-mode/company-mode/etc.