### PR TITLE
Add function to accept completion by paragraph

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -481,6 +481,18 @@ Use TRANSFORM-FN to transform completion if provided."
                                  (buffer-substring-no-properties (point-min) (point))))))
 
 
+(defun copilot-accept-completion-by-paragraph (&optional n-paragraphs)
+  "Accept first N-PARAGRAPHS of completion."
+  (interactive "p")
+  (setq n-paragraphs (or n-paragraphs 1))
+  (copilot-accept-completion (lambda (completion)
+                               (with-temp-buffer
+                                 (insert completion)
+                                 (goto-char (point-min))
+                                 (forward-paragraph n-paragraphs)
+                                 (buffer-substring-no-properties (point-min) (point))))))
+
+
 (defun copilot--show-completion (completion)
   "Show COMPLETION."
   (when (copilot--satisfy-display-predicates)

--- a/copilot.el
+++ b/copilot.el
@@ -458,7 +458,7 @@ Use TRANSFORM-FN to transform completion if provided."
         (copilot-complete))
       t)))
 
-(defun copilot-accept-completion-by-word (n-word)
+(defun copilot-accept-completion-by-word (&optional n-word)
   "Accept first N-WORD words of completion."
   (interactive "p")
   (setq n-word (or n-word 1))
@@ -469,7 +469,7 @@ Use TRANSFORM-FN to transform completion if provided."
                                  (forward-word n-word)
                                  (buffer-substring-no-properties (point-min) (point))))))
 
-(defun copilot-accept-completion-by-line (n-line)
+(defun copilot-accept-completion-by-line (&optional n-line)
   "Accept first N-LINE lines of completion."
   (interactive "p")
   (setq n-line (or n-line 1))


### PR DESCRIPTION
- Add helper function to accept completion by paragraph
  This is similar to the existing `accept-completion-by-word`, `accept-completion-by-line`
- Make `accept-completion-by-word`, `accept-completion-by-line` function arguments optional
  It already defaults to 1 when the `n-words`, `n-lines` args are `nil`