### PR TITLE
Suggest setting `copilot-enable-predicates` to nil for spacemacs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ dotspacemacs-additional-packages
 
 (define-key evil-insert-state-map (kbd "C-<tab>") 'copilot-accept-completion-by-word)
 (define-key evil-insert-state-map (kbd "C-TAB") 'copilot-accept-completion-by-word)
+
+(setq copilot-enable-predicates nil)
 ```
 
 </details>


### PR DESCRIPTION
In order for this plugin to work with spacemacs we need to set `copilot-enable-predicates` to `nil`. This closes #123