### PR TITLE
Disable event logging by default to improve performance

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -28,8 +28,9 @@ Username and password are optional."
   :options '((:host string) (:port integer) (:username string) (:password string))
   :group 'copilot)
 
-(defcustom copilot-log-max 1000
-  "Max size of events buffer. 0 disables, nil means infinite."
+(defcustom copilot-log-max 0
+  "Max size of events buffer. 0 disables, nil means infinite.
+Enabling event logging may slightly affect performance."
   :group 'copilot
   :type 'integer)
 

--- a/readme.md
+++ b/readme.md
@@ -293,7 +293,7 @@ But I decided to allow them to coexist, allowing you to choose a better one at a
 ## Reporting Bugs
 
 + Make sure you have restarted your Emacs (and rebuild the plugin if necessary) after updating the plugin.
-+ Please paste related logs in the `*copilot events*` and `*copilot stderr*` buffer.
++ Please enable event logging by customize `copilot-log-max` (to e.g. 1000), then paste related logs in the `*copilot events*` and `*copilot stderr*` buffer.
 + If an exception is thrown, please also paste the stack trace (use `M-x toggle-debug-on-error` to enable stack trace).
 
 ## Roadmap


### PR DESCRIPTION
During profiling, I found that the event logging (which was enabled by default) actually takes the majority of the CPU time (in the image below, 13% of 18%. I'm using native-comp version of latest emacs):

![2023-04-17_00-24](https://user-images.githubusercontent.com/1308450/232326807-3c5a76e0-e599-40c2-9129-55d9dac1b5fb.png)

I could definitely feel the difference after disabling the event logging. No more perceivable input latency anymore.

For better out-of-the-box user experience, I think it would be good to disable event logging by default.