### PR TITLE
Allow disabling SSL cert verification when using a proxy

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -23,7 +23,14 @@
 (defcustom copilot-network-proxy nil
   "Network proxy to use for Copilot. Nil means no proxy.
 Format: '(:host \"127.0.0.1\" :port 80 :username \"username\" :password \"password\")
-Username and password are optional."
+Username and password are optional.
+
+If you are using a MITM proxy which intercepts TLS connections, you may need to disable
+TLS verification. This can be done by setting a pair ':rejectUnauthorized :json-false' 
+in the proxy plist. For example:
+
+  (:host \"127.0.0.1\" :port 80 :rejectUnauthorized :json-false)
+"
   :type '(plist :tag "Uncheck all to disable proxy" :key-type symbol)
   :options '((:host string) (:port integer) (:username string) (:password string))
   :group 'copilot)


### PR DESCRIPTION
Fixes #129.

I had to write a helper function to get the right json encoding, since we need a JSON `false` for `rejectUnauthorized`.

I haven't written much lisp so let me know if the copilot--proxy-param is a horrible way to do this. It sure feels ugly.