### PR TITLE
Add mapping from major mode to language ID

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -245,6 +245,10 @@ Enabling event logging may slightly affect performance."
 ;; Auto completion
 ;;
 
+(defvar copilot-major-mode-alist '(("rustic" . "rust")
+                                   ("cperl" . "perl"))
+  "Alist mapping major mode names (with -mode removed) to copilot language ID's.")
+
 (defconst copilot--indentation-alist
   (append '((latex-mode tex-indent-basic)
             (nxml-mode nxml-child-indent)
@@ -319,7 +323,8 @@ Enabling event logging may slightly affect performance."
 
 (defun copilot--get-language-id ()
   "Get language ID of current buffer."
-  (s-chop-suffix "-mode" (symbol-name major-mode)))
+  (let ((mode (s-chop-suffix "-mode" (symbol-name major-mode))))
+    (alist-get mode copilot-major-mode-alist mode nil 'equal)))
 
 (defun copilot--generate-doc ()
   "Generate doc parameters for completion request."


### PR DESCRIPTION
I have run into the issue where the major mode name does not map directly to the language name. For example [rustic-mode](https://github.com/brotzeit/rustic) is one of the most popular packages for Rust development, but the major mode name is "rustic" instead of "rust". This would lead to issues where sometimes copilot would suggest C code instead of rust code in a new file because it didn't recognize the language ID and there was no code in the buffer for it to guess the language. Adding this mapping has resolved that issue for me.