### PR TITLE
Add get panel completions support

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -435,7 +435,7 @@ Enabling event logging may slightly affect performance."
      (lambda (res)
        (message "%s" res)))
     (switch-to-buffer
-     (get-buffer-create (concat "*copilot-panel*")))
+     (get-buffer-create "*copilot-panel*"))
     (funcall current-mode)))
 
 

--- a/copilot.el
+++ b/copilot.el
@@ -399,12 +399,18 @@ Enabling event logging may slightly affect performance."
 (defun copilot--handle-notification (_ method msg)
   "Handle MSG of type METHOD."
   (when (eql method 'PanelSolution)
-    (copilot--dbind (:completionText completion-text :score _) msg
+    (copilot--dbind (:completionText completion-text :score completion-score) msg
       (with-current-buffer "*copilot-panel*"
         (save-excursion
           (goto-char (point-max))
-          (insert "#+BEGIN_SRC " copilot--panel-lang "\n"
-                  completion-text "\n#+END_SRC\n\n")))))
+          (insert "* Solution\n"
+                  "  :PROPERTIES:\n"
+                  "  :SCORE: " (number-to-string completion-score) "\n"
+                  "  :END:\n"
+                  "#+BEGIN_SRC " copilot--panel-lang "\n"
+                  completion-text "\n#+END_SRC\n\n")
+                  (mark-whole-buffer)
+                  (org-sort-entries nil ?R nil nil "SCORE")))))
   (when (eql method 'PanelSolutionsDone)
     (message "Copilot: Finish synthesizing solutions.")
     (display-buffer "*copilot-panel*")

--- a/copilot.el
+++ b/copilot.el
@@ -428,13 +428,15 @@ Enabling event logging may slightly affect performance."
   (interactive)
   (setq copilot--last-doc-version copilot--doc-version)
 
-  (let ((called-interactively (called-interactively-p 'interactive)))
+  (let ((called-interactively (called-interactively-p 'interactive))
+        (current-mode major-mode))
     (copilot--sync-doc)
     (copilot--get-panel-completions
      (lambda (res)
        (message "%s" res)))
     (switch-to-buffer
-     (get-buffer-create (concat "*copilot-panel*")))))
+     (get-buffer-create (concat "*copilot-panel*")))
+    (funcall current-mode)))
 
 
 ;;

--- a/copilot.el
+++ b/copilot.el
@@ -401,9 +401,8 @@ Enabling event logging may slightly affect performance."
   (when (eql method 'PanelSolution)
     (copilot--dbind (:completionText completion-text :score completion-score) msg
       (with-current-buffer "*copilot-panel*"
-        (if (member (secure-hash 'sha256 completion-text)
-                    (org-map-entries (lambda () (org-entry-get nil "SHA"))))
-            (message "Copilot: Solution already exists.")
+        (unless (member (secure-hash 'sha256 completion-text)
+                        (org-map-entries (lambda () (org-entry-get nil "SHA"))))
           (save-excursion
             (goto-char (point-max))
             (insert "* Solution\n"


### PR DESCRIPTION
Add support for calling `getPanelCompletions`. 

In neovim this is called with `:Copilot panel` or `:Copilot`
> Open a window with up to 10 completions for the current buffer.