### PR TITLE
Enable workspace capabilites

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -159,7 +159,7 @@ Enabling event logging may slightly affect performance."
                                                          :stderr (get-buffer-create "*copilot stderr*")
                                                          :noquery t)))
              (message "Copilot agent started.")
-             (copilot--request 'initialize '(:capabilities 'nil))
+             (copilot--request 'initialize '(:capabilities (:workspace (:workspaceFolders t))))
              (copilot--async-request 'setEditorInfo
                                      `(:editorInfo (:name "Emacs" :version ,emacs-version)
                                        :editorPluginInfo (:name "copilot.el" :version ,copilot-version)


### PR DESCRIPTION
They are enabled in Copilot.vim https://github.com/github/copilot.vim/blob/1358e8e45ecedc53daf971924a0541ddf6224faf/autoload/copilot/agent.vim#L536
