### PR TITLE
Add more major-mode -> language mappings

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -247,8 +247,28 @@ Enabling event logging may slightly affect performance."
 ;; Auto completion
 ;;
 
+;; based on https://code.visualstudio.com/docs/languages/identifiers
+;; (more here https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/)
 (defvar copilot-major-mode-alist '(("rustic" . "rust")
-                                   ("cperl" . "perl"))
+                                   ("cperl" . "perl")
+                                   ("c++" . "cpp")
+                                   ("objc" . "objective-c")
+                                   ("cuda" . "cuda-cpp")
+                                   ("docker-compose" . "dockercompose")
+                                   ("coffee" . "coffeescript")
+                                   ("js" . "javascript")
+                                   ("js2" . "javascript")
+                                   ("js2-jsx" . "javascriptreact")
+                                   ("typescript-tsx" . "typescriptreact")
+                                   ("rjsx" . "typescriptreact")
+                                   ("less-css" . "less")
+                                   ("text" . "plaintext")
+                                   ("ess-r" . "r")
+                                   ("enh-ruby" . "ruby")
+                                   ("shell-script" . "shellscript")
+                                   ("sh" . "shellscript")
+                                   ("visual-basic" . "vb")
+                                   ("nxml" . "xml"))
   "Alist mapping major mode names (with -mode removed) to copilot language ID's.")
 
 (defconst copilot--indentation-alist

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,15 @@ Use tab to accept completions (you may also want to bind `copilot-accept-complet
 
 </details>
 
+### Programming language detection
+
+Copilot.el detects the programming language of a buffer based on the major-mode name, stripping the `-mode` part. Resulting languageId should match table [here](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers).
+You can add unusual major-mode mappings to `copilot-major-mode-alist`. Without the proper language set suggestions may be of poorer quality.
+
+```elisp
+(add-to-list 'copilot-major-mode-alist '("enh-ruby" . "ruby"))
+```
+
 ## Commands
 
 #### copilot-diagnose


### PR DESCRIPTION
I'm using enh-ruby-mode for Ruby and have got much worse suggestions. It seems that without the proper language set, Copilot isn't able to bind the context of already opened files together.