### PR TITLE
[fix] Error indentation offset got with non-number type variable

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -292,7 +292,7 @@ Enabling event logging may slightly affect performance."
                     (setq mode (get mode 'derived-mode-parent))))
         (when mode
           (cl-some (lambda (s)
-                     (when (boundp s)
+                     (when (and (boundp s) (numberp (symbol-value s)))
                        (symbol-value s)))
                    (alist-get mode copilot--indentation-alist))))
       tab-width))


### PR DESCRIPTION
Some indent-offset variable is not a number type for default value. Example:
In c++-ts-mode, "c-basic-offset" is default type of "symbol"  and default value is "set-from-style". And in the function of "copilot--infer-indentation-offset" will return value of "set-from-style".

Change: Add a new judgment before returning indent-offset