### PR TITLE
[fix] port must be a number

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,8 +234,12 @@ A list of commands that won't cause the overlay to be cleared.
 
 #### copilot-network-proxy
 
-Format: `'(:host "127.0.0.1" :port "7890" :username: "user" :password: "password")`, where `:username` and `:password` are optional.
+Format: `'(:host "127.0.0.1" :port 7890 :username: "user" :password: "password")`, where `:username` and `:password` are optional.
 
+For example:
+```elisp
+(setq copilot-network-proxy '(:host "127.0.0.1" :port 7890))
+```
 
 ## Known Issues
 


### PR DESCRIPTION
tried to configure copilot.el behind a corporate proxy and ran into issues with the port number not being a number. 

error message: 
`(:message "error ignored, status set (Invalid params: /networkProxy/port must be number)" :id 2 :error -32602)`

Fixed the documentation.

P.s. thanks for that great piece of code. 