### PR TITLE
[improvement] Improve active buffer context

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -618,9 +618,13 @@ Use TRANSFORM-FN to transform completion if provided."
               (goto-char p)
               (copilot--display-overlay-completion balanced-text uuid start end))))))))
 
-(defun copilot--on-doc-focus (&rest _args)
+(defun copilot--on-doc-focus (window)
   "Notify that the document has been focussed or opened."
-  (when copilot-mode
+  ;; When switching windows, this function is called twice, once for the
+  ;; window losing focus and once for the window gaining focus. We only want to
+  ;; send a notification for the window gaining focus and only if the buffer has
+  ;; copilot-mode enabled.
+  (when (and copilot-mode (eq window (selected-window)))
 	(if (-contains-p copilot--opened-buffers (current-buffer))
 		(progn
           (copilot--notify ':textDocument/didFocus

--- a/copilot.el
+++ b/copilot.el
@@ -738,7 +738,7 @@ Copilot will show completions only if all predicates return t."
   "Keymap for Copilot minor mode.
 Use this for custom bindings in `copilot-mode'.")
 
-(defun copilot-mode-enter ()
+(defun copilot--mode-enter ()
   "Set up copilot mode when entering."
   (add-hook 'post-command-hook #'copilot--post-command nil 'local)
   (add-hook 'before-change-functions #'copilot--on-doc-change nil 'local)
@@ -749,7 +749,7 @@ Use this for custom bindings in `copilot-mode'.")
   (add-hook 'window-buffer-change-functions #'copilot--on-doc-focus nil 'local)
   (add-hook 'kill-buffer-hook #'copilot--on-doc-close nil 'local))
 
-(defun copilot-mode-exit ()
+(defun copilot--mode-exit ()
   "Clean up copilot mode when exiting."
   (remove-hook 'post-command-hook #'copilot--post-command 'local)
   (remove-hook 'before-change-functions #'copilot--on-doc-change 'local)
@@ -768,8 +768,8 @@ Use this for custom bindings in `copilot-mode'.")
   (copilot-clear-overlay)
   (advice-add 'posn-at-point :before-until #'copilot--posn-advice)
   (if copilot-mode
-      (copilot-mode-enter)
-    (copilot-mode-exit)))
+      (copilot--mode-enter)
+    (copilot--mode-exit)))
 
 (defun copilot--posn-advice (&rest args)
   "Remap posn if in copilot-mode."

--- a/copilot.el
+++ b/copilot.el
@@ -313,7 +313,7 @@ Enabling event logging may slightly affect performance."
   "Get URI of current buffer."
   (cond
    ((not buffer-file-name)
-    "")
+	(concat "buffer://" (url-encode-url (buffer-name (current-buffer)))))
    ((and (eq system-type 'windows-nt)
          (not (s-starts-with-p "/" buffer-file-name)))
     (concat "file:///" (url-encode-url buffer-file-name)))

--- a/copilot.el
+++ b/copilot.el
@@ -743,6 +743,23 @@ Copilot will show completions only if all predicates return t."
   "Keymap for Copilot minor mode.
 Use this for custom bindings in `copilot-mode'.")
 
+(defun copilot-mode-enter ()
+  "Set up copilot mode when entering."
+  (add-hook 'post-command-hook #'copilot--post-command nil 'local)
+  (add-hook 'before-change-functions #'copilot--on-doc-change nil 'local)
+  (add-hook 'after-change-functions #'copilot--on-doc-change nil 'local)
+  (add-hook 'window-selection-change-functions #'copilot--on-doc-focus nil 'local)
+  (add-hook 'kill-buffer-hook #'copilot--on-doc-close nil 'local))
+
+(defun copilot-mode-exit ()
+  "Clean up copilot mode when exiting."
+  (remove-hook 'post-command-hook #'copilot--post-command 'local)
+  (remove-hook 'before-change-functions #'copilot--on-doc-change 'local)
+  (remove-hook 'after-change-functions #'copilot--on-doc-change 'local)
+  (remove-hook 'window-selection-change-functions #'copilot--on-doc-focus 'local)
+  (remove-hook 'kill-buffer-hook #'copilot--on-doc-close 'local)
+  (setq copilot--opened-buffers (delete (current-buffer) copilot--opened-buffers)))
+
 ;;;###autoload
 (define-minor-mode copilot-mode
   "Minor mode for Copilot."
@@ -751,17 +768,8 @@ Use this for custom bindings in `copilot-mode'.")
   (copilot-clear-overlay)
   (advice-add 'posn-at-point :before-until #'copilot--posn-advice)
   (if copilot-mode
-      (progn
-        (add-hook 'post-command-hook #'copilot--post-command nil 'local)
-        (add-hook 'before-change-functions #'copilot--on-doc-change nil 'local)
-        (add-hook 'after-change-functions #'copilot--on-doc-change nil 'local)
-        (add-hook 'window-selection-change-functions #'copilot--on-doc-focus nil 'local)
-        (add-hook 'kill-buffer-hook #'copilot--on-doc-close nil 'local))
-    (remove-hook 'post-command-hook #'copilot--post-command 'local)
-    (remove-hook 'before-change-functions #'copilot--on-doc-change 'local)
-    (remove-hook 'after-change-functions #'copilot--on-doc-change 'local)
-    (remove-hook 'window-selection-change-functions #'copilot--on-doc-focus 'local)
-    (remove-hook 'kill-buffer-hook #'copilot--on-doc-close 'local)))
+      (copilot-mode-enter)
+    (copilot-mode-exit)))
 
 (defun copilot--posn-advice (&rest args)
   "Remap posn if in copilot-mode."

--- a/copilot.el
+++ b/copilot.el
@@ -762,7 +762,9 @@ Use this for custom bindings in `copilot-mode'.")
   (remove-hook 'window-selection-change-functions #'copilot--on-doc-focus 'local)
   (remove-hook 'window-buffer-change-functions #'copilot--on-doc-focus 'local)
   (remove-hook 'kill-buffer-hook #'copilot--on-doc-close 'local)
-  (setq copilot--opened-buffers (delete (current-buffer) copilot--opened-buffers)))
+  ;; Send the close event for the active buffer since activating the mode will send
+  ;; open it again.
+  (copilot--on-doc-close))
 
 ;;;###autoload
 (define-minor-mode copilot-mode

--- a/copilot.el
+++ b/copilot.el
@@ -313,7 +313,7 @@ Enabling event logging may slightly affect performance."
   "Get URI of current buffer."
   (cond
    ((not buffer-file-name)
-	(concat "buffer://" (url-encode-url (buffer-name (current-buffer)))))
+    (concat "buffer://" (url-encode-url (buffer-name (current-buffer)))))
    ((and (eq system-type 'windows-nt)
          (not (s-starts-with-p "/" buffer-file-name)))
     (concat "file:///" (url-encode-url buffer-file-name)))

--- a/copilot.el
+++ b/copilot.el
@@ -326,6 +326,8 @@ Enabling event logging may slightly affect performance."
          (pmax (point-max))
          (pmin (point-min))
          (half-window (/ copilot-max-char 2)))
+    (when (and (>= copilot-max-char 0) (> pmax copilot-max-char))
+      (warn "%s size exceeds 'copilot-max-char' (%s), copilot completions may not work" (current-buffer) copilot-max-char))
     (cond
      ;; using whole buffer
      ((or (< copilot-max-char 0) (< pmax copilot-max-char))

--- a/copilot.el
+++ b/copilot.el
@@ -766,8 +766,7 @@ Use this for custom bindings in `copilot-mode'.")
   (remove-hook 'window-selection-change-functions #'copilot--on-doc-focus 'local)
   (remove-hook 'window-buffer-change-functions #'copilot--on-doc-focus 'local)
   (remove-hook 'kill-buffer-hook #'copilot--on-doc-close 'local)
-  ;; Send the close event for the active buffer since activating the mode will send
-  ;; open it again.
+  ;; Send the close event for the active buffer since activating the mode will open it again.
   (copilot--on-doc-close))
 
 ;;;###autoload

--- a/copilot.el
+++ b/copilot.el
@@ -623,11 +623,10 @@ Use TRANSFORM-FN to transform completion if provided."
 (defun copilot--sync-doc ()
   "Sync current buffer."
   (if (-contains-p copilot--opened-buffers (current-buffer))
-      (progn
-        (copilot--notify 'textDocument/didChange
-                          (list :textDocument (list :uri (copilot--get-uri)
-                                                    :version copilot--doc-version)
-                                :contentChanges (vector (list :text (copilot--get-source))))))
+      (copilot--notify 'textDocument/didChange
+                       (list :textDocument (list :uri (copilot--get-uri)
+                                                 :version copilot--doc-version)
+                             :contentChanges (vector (list :text (copilot--get-source)))))
     (add-to-list 'copilot--opened-buffers (current-buffer))
     (copilot--notify ':textDocument/didOpen
                       (list :textDocument (list :uri (copilot--get-uri)

--- a/copilot.el
+++ b/copilot.el
@@ -620,16 +620,17 @@ Use TRANSFORM-FN to transform completion if provided."
 
 (defun copilot--on-doc-focus (&rest _args)
   "Notify that the document has been focussed or opened."
-  (if (-contains-p copilot--opened-buffers (current-buffer))
-      (progn
-        (copilot--notify ':textDocument/didFocus
-                       (list :textDocument (list :uri (copilot--get-uri)))))
-    (add-to-list 'copilot--opened-buffers (current-buffer))
-    (copilot--notify ':textDocument/didOpen
-                     (list :textDocument (list :uri (copilot--get-uri)
-                                               :languageId (copilot--get-language-id)
-                                               :version copilot--doc-version
-                                               :text (copilot--get-source))))))
+  (when copilot-mode
+	(if (-contains-p copilot--opened-buffers (current-buffer))
+		(progn
+          (copilot--notify ':textDocument/didFocus
+						   (list :textDocument (list :uri (copilot--get-uri)))))
+      (add-to-list 'copilot--opened-buffers (current-buffer))
+      (copilot--notify ':textDocument/didOpen
+                       (list :textDocument (list :uri (copilot--get-uri)
+												 :languageId (copilot--get-language-id)
+												 :version copilot--doc-version
+												 :text (copilot--get-source)))))))
 
 (defun copilot--on-doc-change (&optional start end chars-replaced-length)
   "Notify that the document has changed."

--- a/copilot.el
+++ b/copilot.el
@@ -51,7 +51,7 @@ Enabling event logging may slightly affect performance."
   :type 'string)
 
 
-(defcustom copilot-max-char 30000
+(defcustom copilot-max-char 100000
   "Maximum number of characters to send to Copilot, -1 means no limit."
   :group 'copilot
   :type 'integer)

--- a/copilot.el
+++ b/copilot.el
@@ -564,7 +564,7 @@ Use TRANSFORM-FN to transform completion if provided."
             (vterm-insert t-completion))
         (delete-region start end)
         (insert t-completion))
-	  ;; if it is a partial completion
+      ;; if it is a partial completion
       (when (and (s-prefix-p t-completion completion)
                  (not (s-equals-p t-completion completion)))
         (copilot--set-overlay-text (copilot--get-overlay) (s-chop-prefix t-completion completion)))

--- a/copilot.el
+++ b/copilot.el
@@ -747,7 +747,9 @@ Use this for custom bindings in `copilot-mode'.")
   ;; since both are separate ways of 'focussing' a buffer.
   (add-hook 'window-selection-change-functions #'copilot--on-doc-focus nil 'local)
   (add-hook 'window-buffer-change-functions #'copilot--on-doc-focus nil 'local)
-  (add-hook 'kill-buffer-hook #'copilot--on-doc-close nil 'local))
+  (add-hook 'kill-buffer-hook #'copilot--on-doc-close nil 'local)
+  ;; The mode may be activated manually while focus remains on the current window/buffer.
+  (copilot--on-doc-focus (selected-window)))
 
 (defun copilot--mode-exit ()
   "Clean up copilot mode when exiting."

--- a/copilot.el
+++ b/copilot.el
@@ -206,7 +206,7 @@ Enabling event logging may slightly affect performance."
     (condition-case err
         (copilot--request 'signInConfirm (list :userCode user-code))
       (jsonrpc-error
-        (user-error "Authentication failure: %s" (alist-get 'jsonrpc-error-message (cddr err)))))
+       (user-error "Authentication failure: %s" (alist-get 'jsonrpc-error-message (cddr err)))))
     (copilot--dbind (:user) (copilot--request 'checkStatus '(:dummy "checkStatus"))
       (message "Authenticated as GitHub user %s." user))))
 
@@ -463,8 +463,8 @@ Enabling event logging may slightly affect performance."
   (setq copilot--panel-lang (copilot--get-language-id))
 
   (copilot--get-panel-completions
-    (jsonrpc-lambda (&key solutionCountTarget)
-      (message "Copilot: Synthesizing %d solutions..." solutionCountTarget)))
+   (jsonrpc-lambda (&key solutionCountTarget)
+     (message "Copilot: Synthesizing %d solutions..." solutionCountTarget)))
   (with-current-buffer (get-buffer-create "*copilot-panel*")
     (org-mode)
     (erase-buffer)))
@@ -564,7 +564,7 @@ Use TRANSFORM-FN to transform completion if provided."
             (vterm-insert t-completion))
         (delete-region start end)
         (insert t-completion))
-      ; if it is a partial completion
+	  ;; if it is a partial completion
       (when (and (s-prefix-p t-completion completion)
                  (not (s-equals-p t-completion completion)))
         (copilot--set-overlay-text (copilot--get-overlay) (s-chop-prefix t-completion completion)))
@@ -644,39 +644,30 @@ Use TRANSFORM-FN to transform completion if provided."
                            (and is-after-change (eq chars-replaced-length 0))))
          (is-deletion (not is-insertion)))
 
-    (when (or
-         (and is-before-change is-deletion)
-         (and is-after-change is-insertion))
-        (let* ((text (if is-insertion (buffer-substring-no-properties start end) ""))
-               (range-start (list :line
-                                  (- (line-number-at-pos start) copilot--line-bias)
-                                  :character
-                                  (- start (save-excursion (goto-char start) (line-beginning-position)))))
+    (when (or (and is-before-change is-deletion)
+			  (and is-after-change is-insertion))
+      (let* ((text (if is-insertion (buffer-substring-no-properties start end) ""))
+             (range-start (list :line (- (line-number-at-pos start) copilot--line-bias)
+                                :character (- start (save-excursion (goto-char start) (line-beginning-position)))))
 
-               (range-end (if is-insertion
-                              range-start
-                            (list :line
-                                  (- (line-number-at-pos end) copilot--line-bias)
-                                  :character
-                                  (- end (save-excursion (goto-char end) (line-beginning-position))))))
+             (range-end (if is-insertion
+                            range-start
+                          (list :line (- (line-number-at-pos end) copilot--line-bias)
+                                :character (- end (save-excursion (goto-char end) (line-beginning-position))))))
 
-               (content-changes (vector (list :range
-                                              (list :start range-start
-                                                    :end range-end)
-                                              :text text))))
+             (content-changes (vector (list :range (list :start range-start :end range-end)
+                                            :text text))))
 
-          (cl-incf copilot--doc-version)
-          (copilot--notify 'textDocument/didChange
-                           (list
-                            :textDocument (list :uri (copilot--get-uri)
-                                                :version copilot--doc-version)
-                            :contentChanges content-changes))))))
+        (cl-incf copilot--doc-version)
+        (copilot--notify 'textDocument/didChange
+                         (list :textDocument (list :uri (copilot--get-uri) :version copilot--doc-version)
+							   :contentChanges content-changes))))))
 
 (defun copilot--on-doc-close (&rest _args)
   "Notify that the document has been closed."
   (when (-contains-p copilot--opened-buffers (current-buffer))
     (copilot--notify 'textDocument/didClose
-                       (list :textDocument (list :uri (copilot--get-uri))))
+                     (list :textDocument (list :uri (copilot--get-uri))))
     (setq copilot--opened-buffers (delete (current-buffer) copilot--opened-buffers))))
 
 
@@ -691,12 +682,12 @@ Use TRANSFORM-FN to transform completion if provided."
 
   (let ((called-interactively (called-interactively-p 'interactive)))
     (copilot--get-completion
-      (jsonrpc-lambda (&key completions &allow-other-keys)
-        (let ((completion (if (seq-empty-p completions) nil (seq-elt completions 0))))
-          (if completion
-              (copilot--show-completion completion)
-            (when called-interactively
-              (message "No completion is available."))))))))
+     (jsonrpc-lambda (&key completions &allow-other-keys)
+       (let ((completion (if (seq-empty-p completions) nil (seq-elt completions 0))))
+         (if completion
+             (copilot--show-completion completion)
+           (when called-interactively
+             (message "No completion is available."))))))))
 
 ;;
 ;; minor mode
@@ -791,7 +782,7 @@ Use this for custom bindings in `copilot-mode'.")
 
 ;;;###autoload
 (define-global-minor-mode global-copilot-mode
-    copilot-mode copilot-mode)
+  copilot-mode copilot-mode)
 
 (defun copilot--post-command ()
   "Complete in `post-command-hook' hook."
@@ -832,7 +823,7 @@ command that triggered `post-command-hook'."
              (equal (current-buffer) buffer)
              copilot-mode
              (copilot--satisfy-trigger-predicates))
-        (copilot-complete)))
+    (copilot-complete)))
 
 (provide 'copilot)
 ;;; copilot.el ends here

--- a/copilot.el
+++ b/copilot.el
@@ -748,7 +748,10 @@ Use this for custom bindings in `copilot-mode'.")
   (add-hook 'post-command-hook #'copilot--post-command nil 'local)
   (add-hook 'before-change-functions #'copilot--on-doc-change nil 'local)
   (add-hook 'after-change-functions #'copilot--on-doc-change nil 'local)
+  ;; Hook onto both window-selection-change-functions and window-buffer-change-functions
+  ;; since both are separate ways of 'focussing' a buffer.
   (add-hook 'window-selection-change-functions #'copilot--on-doc-focus nil 'local)
+  (add-hook 'window-buffer-change-functions #'copilot--on-doc-focus nil 'local)
   (add-hook 'kill-buffer-hook #'copilot--on-doc-close nil 'local))
 
 (defun copilot-mode-exit ()
@@ -757,6 +760,7 @@ Use this for custom bindings in `copilot-mode'.")
   (remove-hook 'before-change-functions #'copilot--on-doc-change 'local)
   (remove-hook 'after-change-functions #'copilot--on-doc-change 'local)
   (remove-hook 'window-selection-change-functions #'copilot--on-doc-focus 'local)
+  (remove-hook 'window-buffer-change-functions #'copilot--on-doc-focus 'local)
   (remove-hook 'kill-buffer-hook #'copilot--on-doc-close 'local)
   (setq copilot--opened-buffers (delete (current-buffer) copilot--opened-buffers)))
 


### PR DESCRIPTION
Implement the following suggestions from #150:
- `textDocument/didFocus` on focus of already opened buffer (`window-selection-change-functions` hook)
- `textDocument/didOpen` on first focus of buffer (`window-selection-change-functions` hook)
- `textDocument/didClose` event on buffer kill (`kill-buffer-hook` hook)
- `textDocument/didChange` event on buffer change (`before-change-functions` hook for deletions and `after-change-functions` for insertions) with only data relevant to the change not the whole buffer.