### PR TITLE
Get language ID for tree-sitter major modes

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -347,7 +347,7 @@ Enabling event logging may slightly affect performance."
 
 (defun copilot--get-language-id ()
   "Get language ID of current buffer."
-  (let ((mode (s-chop-suffix "-mode" (symbol-name major-mode))))
+  (let ((mode (s-chop-suffixes '("-ts-mode" "-mode") (symbol-name major-mode))))
     (alist-get mode copilot-major-mode-alist mode nil 'equal)))
 
 (defun copilot--generate-doc ()


### PR DESCRIPTION
Emacs 29 adds new major modes based on tree-sitter using the naming convention of `-ts-mode` instead of `-mode`. This change properly accounts for that.