### PR TITLE
Bugfix/diagnose on unloaded buffer

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -227,21 +227,27 @@ Enabling event logging may slightly affect performance."
     (jsonrpc-shutdown copilot--connection)
     (setq copilot--connection nil))
   (setq copilot--opened-buffers nil)
+  ;; We are going to send a test request for the current buffer so we have to activate the mode
+  ;; if it is not already activated.
+  ;; If it the mode is already active, we have to make sure the current buffer is loaded in the
+  ;; agent.
+  (if copilot-mode
+	  (copilot--on-doc-focus (selected-window))
+	(copilot-mode))
   (copilot--async-request 'getCompletions
-                          '(:doc (:version 0
-                                  :source "\n"
-                                  :path ""
-                                  :uri ""
-                                  :relativePath ""
-                                  :languageId "text"
-                                  :position (:line 0 :character 0)))
-                          :success-fn (lambda (_)
+						  `(:doc (:version 0
+										   :source "\n"
+										   :path ""
+										   :uri ,(copilot--get-uri)
+										   :relativePath ""
+										   :languageId "text"
+										   :position (:line 0 :character 0)))
+						  :success-fn (lambda (_)
                                         (message "Copilot OK."))
-                          :error-fn (lambda (err)
-                                      (message "Copilot error: %S" err))
-                          :timeout-fn (lambda ()
+						  :error-fn (lambda (err)
+									  (message "Copilot error: %S" err))
+						  :timeout-fn (lambda ()
                                         (message "Copilot agent timeout."))))
-
 
 ;;
 ;; Auto completion

--- a/copilot.el
+++ b/copilot.el
@@ -232,21 +232,21 @@ Enabling event logging may slightly affect performance."
   ;; If it the mode is already active, we have to make sure the current buffer is loaded in the
   ;; agent.
   (if copilot-mode
-	  (copilot--on-doc-focus (selected-window))
-	(copilot-mode))
+      (copilot--on-doc-focus (selected-window))
+    (copilot-mode))
   (copilot--async-request 'getCompletions
-						  `(:doc (:version 0
-										   :source "\n"
-										   :path ""
-										   :uri ,(copilot--get-uri)
-										   :relativePath ""
-										   :languageId "text"
-										   :position (:line 0 :character 0)))
-						  :success-fn (lambda (_)
+                          `(:doc (:version 0
+                                           :source "\n"
+                                           :path ""
+                                           :uri ,(copilot--get-uri)
+                                           :relativePath ""
+                                           :languageId "text"
+                                           :position (:line 0 :character 0)))
+                          :success-fn (lambda (_)
                                         (message "Copilot OK."))
-						  :error-fn (lambda (err)
-									  (message "Copilot error: %S" err))
-						  :timeout-fn (lambda ()
+                          :error-fn (lambda (err)
+                                      (message "Copilot error: %S" err))
+                          :timeout-fn (lambda ()
                                         (message "Copilot agent timeout."))))
 
 ;;


### PR DESCRIPTION
Fix the error caused by `copilot-diagnose` as reported in #171 by:

1. Activating `copilot-mode` for the current buffer if not already active.
2. Make sure that the current buffer is loaded by the agent (`didOpen` notification has been sent).
3. Use the current buffer's URI when making the test request instead of using an empty string as the URI.