### PR TITLE
more lisp balancer fixes

### DIFF
--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -268,8 +268,7 @@ Special care has to be taken to ignore pairs in the middle of strings."
             (copilot-balancer-collapse-matching-pairs nil)))
 
        (infix-string-fixup-needed
-        (and in-string
-             (= start end)
+        (and (= start end)
              (eql (char-after end) ?\N{QUOTATION MARK})
              (copilot-balancer-odd-dquote-count-p completion)))
        (end (if infix-string-fixup-needed

--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -37,12 +37,24 @@
 (defvar copilot-balancer-debug-buffer (get-buffer-create "*copilot-balancer*")
   "Buffer for debugging copilot-balancer.")
 
-(defun copilot-balancer--debug
-    (start end prefix completion trimmed-completion suffix
-           prefix-pairs completion-pairs suffix-pairs
-           meta-prefix-pairs flipped-suffix-pairs
-           completion-suffix-str new-completion)
-  (let ((region-to-be-deleted (buffer-substring-no-properties start end)))
+(defmacro copilot-balancer-to-plist (&rest vars)
+  `(list ,@(mapcan (lambda (var) (list (intern (concat ":" (symbol-name var))) var)) vars)))
+
+(defun copilot-balancer--debug (args)
+  (let* ((start (plist-get args :start))
+         (end (plist-get args :end))
+         (completion (plist-get args :completion))
+         (trimmed-completion (plist-get args :trimmed-completion))
+         (prefix-pairs (plist-get args :prefix-pairs))
+         (completion-pairs (plist-get args :completion-pairs))
+         (meta-prefix-pairs (plist-get args :meta-prefix-pairs))
+         (suffix-pairs (plist-get args :suffix-pairs))
+         (flipped-suffix-pairs (plist-get args :flipped-suffix-pairs))
+         (completion-suffix-str (plist-get args :completion-suffix-str))
+         (new-completion (plist-get args :new-completion))
+         (prefix (plist-get args :prefix))
+         (suffix (plist-get args :suffix))
+         (region-to-be-deleted (buffer-substring-no-properties start end)))
     (with-current-buffer copilot-balancer-debug-buffer
       (erase-buffer)
       (insert "start end " (number-to-string start)
@@ -267,11 +279,14 @@ Special care has to be taken to ignore pairs in the middle of strings."
                
        (completion-suffix-str (apply #'string (nreverse completion-suffix)))
        (new-completion (concat trimmed-completion
-                               completion-suffix-str)))
-    (copilot-balancer--debug start end prefix completion trimmed-completion suffix
-                             prefix-pairs completion-pairs suffix-pairs
-                             meta-prefix-pairs flipped-suffix-pairs
-                             rem-flipped-completion-suffix new-completion)
+                               completion-suffix-str))
+
+       (debug-vars (copilot-balancer-to-plist
+                    start end prefix completion trimmed-completion suffix
+                    prefix-pairs completion-pairs suffix-pairs
+                    meta-prefix-pairs flipped-suffix-pairs
+                    rem-flipped-completion-suffix new-completion)))
+    (copilot-balancer--debug debug-vars)
     
     new-completion))
 

--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -259,8 +259,8 @@ Special care has to be taken to ignore pairs in the middle of strings."
                              (min (length meta-prefix-pairs) (length suffix))))
        (end-is-missing-double-quote
         (and in-string
-             (or (string-match-p (string ?\N{QUOTATION MARK}) deleted-text))
-             (not (copilot-balancer-see-string-end-p end point-upper-bound))))
+             (or (string-match-p (string ?\N{QUOTATION MARK}) deleted-text)
+                 (not (copilot-balancer-see-string-end-p end point-upper-bound)))))
 
        (`(,trimmed-completion ,meta-prefix-pairs ,in-string)
         (if end-is-missing-double-quote

--- a/copilot.el
+++ b/copilot.el
@@ -616,9 +616,10 @@ Use TRANSFORM-FN to transform completion if provided."
                           (funcall goto-line!)
                           (forward-char end-char)
                           (point)))
-                   (balanced-text (copilot-balancer-fix-completion start end text)))
+                   (fixed-completion (copilot-balancer-fix-completion start end text)))
               (goto-char p)
-              (copilot--display-overlay-completion balanced-text uuid start end))))))))
+              (pcase-let ((`(,start ,end ,balanced-text) fixed-completion))
+                (copilot--display-overlay-completion balanced-text uuid start end)))))))))
 
 (defun copilot--on-doc-focus (window)
   "Notify that the document has been focussed or opened."


### PR DESCRIPTION
These are a collection of fixes that I added the past few months while programming in Clojure for my day job.

These fixes usually involve completing something inside a string, usually the doc string.

Very recently, completions are starting to return stuff where the `start` == `end` but the completion needs to delete forward a character, i.e. some arbitrary pair forward characters are infix in the completion. I don't have any ideas how to solve this in the general case.

Given the nature of LLMs, sometimes it shifts from stuff that give the right start + end to delete, to the infix stuff mentioned above, even to respecting pairs balances. I have seen all three cases from copilot.

I use this every day wat work, so regressions should be minimal.