### PR TITLE
Use cl-oddp from cl-lib

### DIFF
--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -1,5 +1,6 @@
 ;; -*- lexical-binding: t -*-
 
+(require 'cl-lib)
 (require 'pcase)
 (require 'dash)
 (require 'rx)
@@ -253,7 +254,7 @@ Special care has to be taken to ignore pairs in the middle of strings."
          ((= c ?\N{QUOTATION MARK})
           (setq count (1+ count)))))
       (setq i (1+ i)))
-    (oddp count)))
+    (cl-oddp count)))
 
 (defun copilot-balancer--fix-lisp (start end completion)
   (pcase-let*


### PR DESCRIPTION
oddp is undefined in at least Emacs 29.1.

This prevents a storm of messages like these while editing strings and especially comment strings in Clojure.
```
error in process filter: Symbol’s function definition is void: oddp
error in process filter: copilot-balancer-odd-dquote-count-p: Symbol’s function definition is void: oddp
```