### PR TITLE
fix: global-copilot-mode don't enable when buffer is read-only

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -788,7 +788,12 @@ Use this for custom bindings in `copilot-mode'.")
 
 ;;;###autoload
 (define-global-minor-mode global-copilot-mode
-  copilot-mode copilot-mode)
+  copilot-mode copilot-turn-on-unless-buffer-read-only)
+
+(defun copilot-turn-on-unless-buffer-read-only ()
+  "Turn on `copilot-mode' if the buffer is writable."
+  (unless buffer-read-only
+    (copilot-mode 1)))
 
 (defun copilot--post-command ()
   "Complete in `post-command-hook' hook."


### PR DESCRIPTION
I disable it on non-editable screens because the candidates sometimes appear in non-editable situations, such as Magit's status mode.

There are some side effects, such as not being enabled when switching modes from dyed to wdired. However, in wdired, there is almost no new input, and most of the time you are editing an existing string. So I can't think of many situations where I would want to use Copilot with wdired. The user who wants to enable it can add it to the hook and enable it. It can also be enabled on the fly by running the command manually. So I consider this an acceptable side effect.