### PR TITLE
Replace `warn` with `display-warning`

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -346,7 +346,8 @@ Enabling event logging may slightly affect performance."
          (pmin (point-min))
          (half-window (/ copilot-max-char 2)))
     (when (and (>= copilot-max-char 0) (> pmax copilot-max-char))
-      (warn "%s size exceeds 'copilot-max-char' (%s), copilot completions may not work" (current-buffer) copilot-max-char))
+      (display-warning '(copilot copilot-exceeds-max-char)
+                       (format "%s size exceeds 'copilot-max-char' (%s), copilot completions may not work" (current-buffer) copilot-max-char)))
     (cond
      ;; using whole buffer
      ((or (< copilot-max-char 0) (< pmax copilot-max-char))


### PR DESCRIPTION
The "size exceeds 'copilot-max-char'" warning message pops up whenever a large buffer is opened and there was no easy way to suppress it. I believe the idiomatic way of doing this is to use `display-warning` function with `type` argument (e.g. `'(copilot copilot-exceeds-max-char)`), so that user can choose to suppress this warning by adding the type to `warning-suppress-types`