### PR TITLE
hide copilot-balancer-debug-buffer

### DIFF
--- a/copilot-balancer.el
+++ b/copilot-balancer.el
@@ -35,7 +35,7 @@
     h)
   "Hash table of closing lisp pairs, such as right parenthese, etc.")
 
-(defvar copilot-balancer-debug-buffer (get-buffer-create "*copilot-balancer*")
+(defvar copilot-balancer-debug-buffer (get-buffer-create " *copilot-balancer*")
   "Buffer for debugging copilot-balancer.")
 
 (defmacro copilot-balancer-to-plist (&rest vars)


### PR DESCRIPTION
Buffer names starting with a space are considered hidden and not by default exposed to users by many commands. The user can still access them by manually adding a leading space in the interactive command prompt though.

This change can prevent mistakenly killing copilot-balancer-debug-buffer, only to be annoyed by infinite "Selecting deleted buffer" errors.