### PR TITLE
Replace manual change tracking with track-changes library

### DIFF
--- a/Eask
+++ b/Eask
@@ -18,5 +18,6 @@
 (depends-on "editorconfig")
 (depends-on "jsonrpc")
 (depends-on "f")
+(depends-on "track-changes" "1.4")
 
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432


### PR DESCRIPTION
Fixes #430.

* copilot.el (track-changes): New requirement. (copilot--lsp-pos): New helper function.
(copilot--generate-doc): Use it.
(copilot--on-doc-change): Remove.
(copilot--track-changes-id): New buffer-local variable. (copilot--lsp-range-end-from-oldtext): New helper function. (copilot--track-changes-signal): New function to fetch and forward buffer changes.
(copilot--mode-setup): Remove old before-change-functions and after-change-functions hooks, register with track-changes instead. (copilot--mode-teardown): Remove old cleanup code, unregister from track-changes.