### PR TITLE
Honor ignored prefixes when clearing overlay (fixes #434)

### DIFF
--- a/copilot.el
+++ b/copilot.el
@@ -1223,6 +1223,9 @@ Copilot will show completions only if all predicates return t."
                        (or
                         (string-prefix-p "copilot-" (symbol-name this-command))
                         (member this-command copilot-clear-overlay-ignore-commands)
+                        ;; `this-original-command' captures remapped helpers like
+                        ;; `universal-argument-more' and `digit-argument'.
+                        (member this-original-command copilot-clear-overlay-ignore-commands)
                         (copilot--self-insert this-command)))))
     (copilot-clear-overlay)
     (when copilot--post-command-timer


### PR DESCRIPTION
Prefix commands like C-u were clearing the Copilot overlay even when
their command symbols (e.g., 'universal-argument) were listed in
'copilot-clear-overlay-ignore-commands'.

* copilot.el (copilot--post-command): Check both 'this-command and the
command bound to the current key sequence.

* test/copilot-overlay-tests.el
(copilot-post-command-honors-key-binding-ignore)
(copilot-post-command-clears-when-not-ignored): New tests.

* Eask: Add script entry to run the tests.