### PR TITLE
Add Copilot Next Edit Suggestions (NES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,29 @@ To customize when completions trigger, see `copilot-enable-predicates` and `copi
 
 Alternatively, you can call `copilot-complete` manually and use `copilot-clear-overlay` in `post-command-hook` to dismiss completions.
 
+### Next Edit Suggestions (NES)
+
+NES predicts the next edit you'll want to make anywhere in the file, based on your recent editing patterns. Unlike inline completions (ghost text at the cursor), NES suggestions can replace or delete existing text at any location.
+
+> [!NOTE]
+>
+> NES requires `copilot-language-server` version 1.434.0 or newer. Run `M-x copilot-reinstall-server` to upgrade if needed.
+
+Enable `copilot-nes-mode` in a buffer to start receiving suggestions. It can coexist with `copilot-mode`:
+
+```elisp
+(add-hook 'prog-mode-hook #'copilot-nes-mode)
+```
+
+When a suggestion is pending:
+- **TAB** — accept the suggestion (jumps to it first if far away, applies on second press)
+- **C-g** — dismiss the suggestion
+
+Customization variables:
+- **`copilot-nes-idle-delay`** — seconds of idle time before requesting a suggestion (default `0.5`)
+- **`copilot-nes-auto-dismiss-move-count`** — cursor movements before auto-dismissing (default `3`)
+- **`copilot-nes-auto-dismiss-distance`** — max lines between point and suggestion before auto-dismissing (default `40`)
+
 ### Keybindings
 
 `copilot-mode` does not set any keybindings by default. Use `copilot-completion-map` (active while a completion overlay is visible) to bind keys:
@@ -331,6 +354,10 @@ For example:
 | **Navigation** | |
 | `copilot-next-completion` | Cycle to the next completion |
 | `copilot-previous-completion` | Cycle to the previous completion |
+| **Next Edit Suggestions** | |
+| `copilot-nes-mode` | Toggle NES in the current buffer |
+| `copilot-nes-accept` | Accept (or jump to) the current NES suggestion |
+| `copilot-nes-dismiss` | Dismiss the current NES suggestion |
 
 ## Customization
 
@@ -364,6 +391,7 @@ A few commonly tweaked variables:
 | `signInInitiate` / `signInConfirm` / `checkStatus` / `signOut` | Supported | Authentication flow |
 | `copilot/models` | Supported | Lists available completion models |
 | `getPanelCompletions` | Supported | Multiple suggestions in a panel buffer |
+| `textDocument/copilotInlineEdit` | Supported | Next Edit Suggestions (NES) |
 
 ### Client-to-Server Notifications
 
@@ -377,6 +405,7 @@ A few commonly tweaked variables:
 | `textDocument/didFocus` | Supported | |
 | `textDocument/didShowCompletion` | Supported | Telemetry when overlay is displayed |
 | `textDocument/didPartiallyAcceptCompletion` | Supported | Telemetry for partial acceptance |
+| `textDocument/didShowInlineEdit` | Supported | Telemetry when NES overlay is displayed |
 | `workspace/didChangeConfiguration` | Supported | Sent on settings change |
 | `workspace/didChangeWorkspaceFolders` | Supported | Dynamic workspace roots |
 | `$/cancelRequest` | Supported | Cancels stale completion requests |

--- a/copilot-nes.el
+++ b/copilot-nes.el
@@ -1,6 +1,6 @@
 ;;; copilot-nes.el --- Copilot Next Edit Suggestions -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2022-2025 copilot-emacs maintainers
+;; Copyright (C) 2022-2026 copilot-emacs maintainers
 
 ;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: https://github.com/copilot-emacs/copilot.el
@@ -47,6 +47,9 @@
 
 (require 'copilot)
 
+(defconst copilot-nes--min-server-version "1.434.0"
+  "Minimum copilot-language-server version required for NES support.")
+
 ;;
 ;; Customization
 ;;
@@ -74,7 +77,7 @@
 ;;
 
 (defface copilot-nes-deletion-face
-  '((t :inherit shadow :strike-through t))
+  '((t :inherit diff-removed :strike-through t))
   "Face for text that a NES suggestion would delete."
   :group 'copilot)
 
@@ -106,6 +109,19 @@ Contains keys :text, :range, :command, and :textDocument.")
 ;;
 ;; Internal helpers
 ;;
+
+(defun copilot-nes--check-server-version ()
+  "Warn if the installed copilot-language-server is too old for NES."
+  (let ((installed (copilot-installed-version)))
+    (when (and installed
+               (version-list-< (version-to-list installed)
+                                (version-to-list copilot-nes--min-server-version)))
+      (display-warning
+       'copilot-nes
+       (format "NES requires copilot-language-server >= %s, but %s is installed.
+Run `M-x copilot-reinstall-server' to upgrade."
+               copilot-nes--min-server-version installed)
+       :warning))))
 
 (defun copilot-nes--edit-start-line ()
   "Return the buffer line number where the current edit start, or nil."
@@ -163,6 +179,7 @@ Contains keys :text, :range, :command, and :textDocument.")
           (overlay-put ov 'face 'copilot-nes-deletion-face)
           (overlay-put ov 'copilot-nes t)
           (overlay-put ov 'evaporate t)
+          (overlay-put ov 'priority 100)
           (push ov copilot-nes--overlays)))
       ;; Insertion overlay: show new text
       (when has-insertion
@@ -171,6 +188,7 @@ Contains keys :text, :range, :command, and :textDocument.")
           (overlay-put ov 'after-string insertion-text)
           (overlay-put ov 'copilot-nes t)
           (overlay-put ov 'evaporate t)
+          (overlay-put ov 'priority 100)
           (push ov copilot-nes--overlays)))))
   ;; Record point so the post-command hook can detect actual movement
   (setq copilot-nes--last-point (point))
@@ -183,6 +201,20 @@ Contains keys :text, :range, :command, and :textDocument.")
 ;;
 ;; Request
 ;;
+
+(defun copilot-nes--handle-response (response expected-uri expected-version)
+  "Process RESPONSE from a NES request.
+Only display the suggestion when the document version matches
+EXPECTED-VERSION and the URI matches EXPECTED-URI."
+  (copilot--dbind (edits) response
+    (when (and edits (> (length edits) 0))
+      (let* ((edit (if (vectorp edits) (aref edits 0) (car edits))))
+        ;; Validate version matches
+        (copilot--dbind (textDocument) edit
+          (copilot--dbind (version (resp-version version)) textDocument
+            (when (and (= resp-version expected-version)
+                       (string= (plist-get textDocument :uri) expected-uri))
+              (copilot-nes--display edit))))))))
 
 (defun copilot-nes--request ()
   "Request a NES suggestion from the Copilot server."
@@ -198,15 +230,7 @@ Contains keys :text, :range, :command, and :textDocument.")
              :position pos)
        :success-fn
        (lambda (response)
-         (copilot--dbind (edits) response
-           (when (and edits (> (length edits) 0))
-             (let* ((edit (if (vectorp edits) (aref edits 0) (car edits))))
-               ;; Validate version matches
-               (copilot--dbind (textDocument) edit
-                 (copilot--dbind (version (resp-version version)) textDocument
-                   (when (and (= resp-version version)
-                              (string= (plist-get textDocument :uri) uri))
-                     (copilot-nes--display edit))))))))))))
+         (copilot-nes--handle-response response uri version))))))
 
 ;;
 ;; Accept
@@ -338,7 +362,9 @@ can replace or delete existing text.
   :lighter " NES"
   :keymap copilot-nes-mode-map
   (if copilot-nes-mode
-      (add-hook 'post-command-hook #'copilot-nes--post-command nil t)
+      (progn
+        (copilot-nes--check-server-version)
+        (add-hook 'post-command-hook #'copilot-nes--post-command nil t))
     (copilot-nes--cancel-timer)
     (copilot-nes--clear)
     (remove-hook 'post-command-hook #'copilot-nes--post-command t)))

--- a/test/copilot-nes-test.el
+++ b/test/copilot-nes-test.el
@@ -324,6 +324,9 @@
   ;;
 
   (describe "copilot-nes-mode"
+    (before-each
+      (spy-on 'copilot-nes--check-server-version))
+
     (it "can be enabled and disabled"
       (with-temp-buffer
         (copilot-nes-mode 1)
@@ -357,7 +360,13 @@
           (copilot-nes--display edit))
         (copilot-nes-mode -1)
         (expect copilot-nes--edit :to-equal nil)
-        (expect copilot-nes--overlays :to-equal nil))))
+        (expect copilot-nes--overlays :to-equal nil)))
+
+    (it "checks server version on activation"
+      (with-temp-buffer
+        (copilot-nes-mode 1)
+        (expect 'copilot-nes--check-server-version :to-have-been-called)
+        (copilot-nes-mode -1))))
 
   ;;
   ;; Distance check
@@ -389,6 +398,177 @@
               (list :range (list :start (list :line 0 :character 0)
                                   :end (list :line 0 :character 4))))
         (let ((copilot-nes-auto-dismiss-distance 40))
-          (expect (copilot-nes--too-far-p) :to-be-truthy))))))
+          (expect (copilot-nes--too-far-p) :to-be-truthy)))))
+
+  ;;
+  ;; Response handler
+  ;;
+
+  (describe "copilot-nes--handle-response"
+    (it "rejects a response with mismatched version"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello world\n")
+        (spy-on 'copilot-nes--display)
+        (let* ((edit (list :text "planet"
+                           :range (list :start (list :line 0 :character 6)
+                                        :end (list :line 0 :character 11))
+                           :textDocument (list :uri "file:///test.el" :version 5)))
+               (response (list :edits (vector edit))))
+          (copilot-nes--handle-response response "file:///test.el" 3)
+          (expect 'copilot-nes--display :not :to-have-been-called))))
+
+    (it "rejects a response with mismatched URI"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello world\n")
+        (spy-on 'copilot-nes--display)
+        (let* ((edit (list :text "planet"
+                           :range (list :start (list :line 0 :character 6)
+                                        :end (list :line 0 :character 11))
+                           :textDocument (list :uri "file:///other.el" :version 5)))
+               (response (list :edits (vector edit))))
+          (copilot-nes--handle-response response "file:///test.el" 5)
+          (expect 'copilot-nes--display :not :to-have-been-called))))
+
+    (it "accepts a response with matching version and URI"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello world\n")
+        (spy-on 'copilot-nes--display)
+        (let* ((edit (list :text "planet"
+                           :range (list :start (list :line 0 :character 6)
+                                        :end (list :line 0 :character 11))
+                           :textDocument (list :uri "file:///test.el" :version 5)))
+               (response (list :edits (vector edit))))
+          (copilot-nes--handle-response response "file:///test.el" 5)
+          (expect 'copilot-nes--display :to-have-been-called))))
+
+    (it "handles empty edits array"
+      (with-temp-buffer
+        (spy-on 'copilot-nes--display)
+        (copilot-nes--handle-response (list :edits []) "file:///test.el" 1)
+        (expect 'copilot-nes--display :not :to-have-been-called)))
+
+    (it "handles nil edits"
+      (with-temp-buffer
+        (spy-on 'copilot-nes--display)
+        (copilot-nes--handle-response (list :edits nil) "file:///test.el" 1)
+        (expect 'copilot-nes--display :not :to-have-been-called))))
+
+  ;;
+  ;; Server version check
+  ;;
+
+  (describe "copilot-nes--check-server-version"
+    (it "warns when server version is too old"
+      (spy-on 'copilot-installed-version :and-return-value "1.400.0")
+      (spy-on 'display-warning)
+      (copilot-nes--check-server-version)
+      (expect 'display-warning :to-have-been-called))
+
+    (it "is silent when server version is sufficient"
+      (spy-on 'copilot-installed-version :and-return-value "1.434.0")
+      (spy-on 'display-warning)
+      (copilot-nes--check-server-version)
+      (expect 'display-warning :not :to-have-been-called))
+
+    (it "is silent when server version is newer"
+      (spy-on 'copilot-installed-version :and-return-value "1.500.0")
+      (spy-on 'display-warning)
+      (copilot-nes--check-server-version)
+      (expect 'display-warning :not :to-have-been-called))
+
+    (it "is silent when version is nil (undetermined)"
+      (spy-on 'copilot-installed-version :and-return-value nil)
+      (spy-on 'display-warning)
+      (copilot-nes--check-server-version)
+      (expect 'display-warning :not :to-have-been-called)))
+
+  ;;
+  ;; Accept telemetry
+  ;;
+
+  (describe "copilot-nes-accept telemetry"
+    (it "sends workspace/executeCommand when command is present"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello world\n")
+        (goto-char (point-min))
+        (let* ((cmd (list :command "test-cmd" :arguments ["arg1"]))
+               (edit (list :text "planet"
+                           :range (list :start (list :line 0 :character 6)
+                                        :end (list :line 0 :character 11))
+                           :command cmd))
+               (copilot--connection t))
+          (spy-on 'jsonrpc--process :and-return-value t)
+          (spy-on 'process-exit-status :and-return-value 0)
+          (spy-on 'jsonrpc-notify)
+          (copilot-nes--display edit)
+          (copilot-nes-accept)
+          ;; Should have called jsonrpc-notify for both didShowInlineEdit and executeCommand
+          (expect 'jsonrpc-notify :to-have-been-called-times 2))))
+
+    (it "does not send workspace/executeCommand when command is absent"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello world\n")
+        (goto-char (point-min))
+        (let ((edit (list :text "planet"
+                          :range (list :start (list :line 0 :character 6)
+                                       :end (list :line 0 :character 11))
+                          :command nil)))
+          (spy-on 'copilot--notify)
+          (copilot-nes--display edit)
+          (spy-on 'jsonrpc-notify)
+          (copilot-nes-accept)
+          ;; No command means no executeCommand notification
+          (expect 'jsonrpc-notify :not :to-have-been-called)))))
+
+  ;;
+  ;; Mode coexistence
+  ;;
+
+  (describe "mode coexistence"
+    (before-each
+      (spy-on 'copilot-nes--check-server-version)
+      (spy-on 'copilot--on-doc-focus))
+
+    (it "copilot-nes-mode and copilot-mode can be enabled independently"
+      (with-temp-buffer
+        (copilot-nes-mode 1)
+        (copilot-mode 1)
+        (expect copilot-nes-mode :to-be-truthy)
+        (expect copilot-mode :to-be-truthy)
+        (copilot-mode -1)
+        (expect copilot-nes-mode :to-be-truthy)
+        (expect copilot-mode :not :to-be-truthy)
+        (copilot-nes-mode -1)))
+
+    (it "disabling copilot-mode does not affect copilot-nes-mode state"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello\n")
+        (copilot-nes-mode 1)
+        (let ((edit (list :text "x"
+                          :range (list :start (list :line 0 :character 0)
+                                       :end (list :line 0 :character 1))
+                          :command nil)))
+          (spy-on 'copilot--notify)
+          (copilot-nes--display edit))
+        (copilot-mode 1)
+        (copilot-mode -1)
+        ;; NES state should be unaffected
+        (expect copilot-nes-mode :to-be-truthy)
+        (expect copilot-nes--edit :to-be-truthy)
+        (copilot-nes-mode -1)))
+
+    (it "disabling copilot-nes-mode does not affect copilot-mode"
+      (with-temp-buffer
+        (copilot-mode 1)
+        (copilot-nes-mode 1)
+        (copilot-nes-mode -1)
+        (expect copilot-mode :to-be-truthy)
+        (copilot-mode -1)))))
 
 ;;; copilot-nes-test.el ends here


### PR DESCRIPTION
NES predicts edits the developer will want to make next, based on recent edit history. Unlike inline completions (ghost text at cursor), NES suggestions can appear anywhere in the file and can replace or delete existing text. Uses the `textDocument/copilotInlineEdit` LSP method — the same protocol the neovim community implemented in [copilot-lsp-nvim](https://github.com/copilotlsp-nvim/copilot-lsp).

Everything lives in a new `copilot-nes.el` — no changes to `copilot.el`. Enable with `(copilot-nes-mode 1)` or add to a hook. TAB accepts, C-g dismisses. Suggestions auto-dismiss after a few cursor movements.

Closes #374

cc @m-lce @dustinfarris @mortang2410 — would love your feedback and testing!