### PR TITLE
Add agent mode support for Copilot Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Add experimental Agent mode for Copilot Chat (`copilot-chat-use-agent-mode`). When enabled, Copilot can run client-side tools (`run_in_terminal`, `create_file`, `get_errors`, `fetch_web_page`); each invocation prompts for confirmation unless listed in `copilot-chat-auto-approve-tools`. ([#441](https://github.com/copilot-emacs/copilot.el/issues/441))
 - Add native binary installation support. `copilot-install-server` now falls back to downloading precompiled binaries when npm is unavailable, removing the Node.js requirement on supported platforms. A new `copilot-install-server-native` command is also available for explicit native installation.
 
 ### Changes

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -35,6 +35,10 @@
 
 (require 'copilot)
 
+(declare-function flymake-diagnostics "flymake")
+(declare-function flymake-diagnostic-beg "flymake")
+(declare-function flymake-diagnostic-text "flymake")
+
 ;;
 ;; Customization
 ;;
@@ -52,6 +56,18 @@ When nil, the server picks the default model."
   :group 'copilot-chat
   :package-version '(copilot . "0.5"))
 
+(defcustom copilot-chat-use-agent-mode nil
+  "When non-nil, use Agent mode for Copilot Chat conversations.
+Agent mode allows Copilot to execute tools such as shell commands
+and file edits."
+  :type 'boolean
+  :group 'copilot-chat)
+
+(defcustom copilot-chat-auto-approve-tools '("get_errors" "fetch_web_page")
+  "Tools that skip confirmation and execute automatically."
+  :type '(repeat string)
+  :group 'copilot-chat)
+
 (defface copilot-chat-error-face
   '((t :inherit error))
   "Face for error messages in the chat buffer."
@@ -60,6 +76,11 @@ When nil, the server picks the default model."
 (defface copilot-chat-follow-up-face
   '((t :inherit font-lock-comment-face :slant italic))
   "Face for follow-up suggestions in the chat buffer."
+  :group 'copilot-chat)
+
+(defface copilot-chat-tool-face
+  '((t :inherit font-lock-preprocessor-face))
+  "Face for tool invocation lines in the chat buffer."
   :group 'copilot-chat)
 
 ;;
@@ -202,6 +223,148 @@ Return editor context for the requested skill."
 (copilot-on-request 'conversation/context #'copilot-chat--handle-context)
 
 ;;
+;; Tool invocation handlers
+;;
+
+(defun copilot-chat--insert-tool-status (name detail)
+  "Insert a tool status line for tool NAME with DETAIL in the chat buffer."
+  (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (let ((inhibit-read-only t))
+          (goto-char (point-max))
+          (insert (propertize (format "[Tool: %s] %s\n" name detail)
+                              'face 'copilot-chat-tool-face))
+          (copilot-chat--scroll-to-bottom))))))
+
+(defun copilot-chat--handle-tool-confirmation (msg)
+  "Handle `conversation/invokeClientToolConfirmation' request MSG.
+Return \"Accept\" or \"Dismiss\" based on user confirmation."
+  (let ((name (plist-get msg :name))
+        (input (plist-get msg :input)))
+    (if (member name copilot-chat-auto-approve-tools)
+        "Accept"
+      (let ((approved (yes-or-no-p
+                       (format "Copilot wants to run tool '%s' with input: %S.  Allow? "
+                               name input))))
+        (if approved "Accept" "Dismiss")))))
+
+(copilot-on-request 'conversation/invokeClientToolConfirmation
+                    #'copilot-chat--handle-tool-confirmation)
+
+(defun copilot-chat--tool-result (status value)
+  "Build a LanguageModelToolResult with STATUS and text VALUE."
+  (list :status status
+        :content (vector (list :value value))))
+
+(defun copilot-chat--execute-run-in-terminal (input)
+  "Execute run_in_terminal tool with INPUT."
+  (let ((command (plist-get input :command)))
+    (copilot-chat--insert-tool-status "run_in_terminal" (format "Running: %s" command))
+    (condition-case err
+        (let ((output (shell-command-to-string command)))
+          (copilot-chat--insert-tool-status "run_in_terminal" "Done.")
+          (copilot-chat--tool-result "success" output))
+      (error
+       (copilot-chat--tool-result "error" (error-message-string err))))))
+
+(defun copilot-chat--execute-insert-edit (input)
+  "Execute insert_edit_into_file tool with INPUT."
+  (let ((file-path (plist-get input :filePath))
+        (code (plist-get input :code)))
+    (copilot-chat--insert-tool-status "insert_edit_into_file"
+                                      (format "Editing: %s" file-path))
+    (condition-case err
+        (let ((buf (find-file-noselect file-path)))
+          (with-current-buffer buf
+            (erase-buffer)
+            (insert code)
+            (save-buffer))
+          (copilot-chat--tool-result "success"
+                                    (format "File %s updated." file-path)))
+      (error
+       (copilot-chat--tool-result "error" (error-message-string err))))))
+
+(defun copilot-chat--execute-create-file (input)
+  "Execute create_file tool with INPUT."
+  (let ((file-path (plist-get input :filePath))
+        (content (plist-get input :content)))
+    (copilot-chat--insert-tool-status "create_file"
+                                      (format "Creating: %s" file-path))
+    (condition-case err
+        (progn
+          (let ((dir (file-name-directory file-path)))
+            (when dir (make-directory dir t)))
+          (with-temp-file file-path
+            (insert content))
+          (copilot-chat--tool-result "success"
+                                    (format "File %s created." file-path)))
+      (error
+       (copilot-chat--tool-result "error" (error-message-string err))))))
+
+(defun copilot-chat--execute-get-errors (input)
+  "Execute get_errors tool with INPUT."
+  (let ((file-paths (plist-get input :filePaths))
+        (results '()))
+    (copilot-chat--insert-tool-status "get_errors" "Collecting diagnostics...")
+    (dolist (path (append file-paths nil))
+      (let ((buf (find-buffer-visiting path)))
+        (if (and buf (buffer-live-p buf))
+            (with-current-buffer buf
+              (if (bound-and-true-p flymake-mode)
+                  (let ((diags (flymake-diagnostics)))
+                    (if diags
+                        (dolist (diag diags)
+                          (push (format "%s:%d: %s"
+                                        path
+                                        (line-number-at-pos
+                                         (flymake-diagnostic-beg diag))
+                                        (flymake-diagnostic-text diag))
+                                results))
+                      (push (format "%s: no errors" path) results)))
+                (push (format "%s: no diagnostics available" path) results)))
+          (push (format "%s: not open in editor" path) results))))
+    (copilot-chat--tool-result "success" (string-join (nreverse results) "\n"))))
+
+(defun copilot-chat--execute-fetch-web-page (input)
+  "Execute fetch_web_page tool with INPUT."
+  (let ((urls (plist-get input :urls))
+        (results '()))
+    (copilot-chat--insert-tool-status "fetch_web_page" "Fetching...")
+    (dolist (url (append urls nil))
+      (condition-case err
+          (let ((buf (url-retrieve-synchronously url t nil 30)))
+            (if buf
+                (with-current-buffer buf
+                  (goto-char (point-min))
+                  (when (re-search-forward "\n\n" nil t)
+                    (delete-region (point-min) (point)))
+                  (push (format "=== %s ===\n%s" url (buffer-string)) results)
+                  (kill-buffer))
+              (push (format "=== %s ===\nFailed to fetch" url) results)))
+        (error
+         (push (format "=== %s ===\nError: %s" url (error-message-string err))
+               results))))
+    (copilot-chat--tool-result "success" (string-join (nreverse results) "\n\n"))))
+
+(defun copilot-chat--handle-tool-invocation (msg)
+  "Handle `conversation/invokeClientTool' request MSG.
+Dispatch to the appropriate tool and return a LanguageModelToolResult."
+  (let ((name (plist-get msg :name))
+        (input (plist-get msg :input)))
+    (pcase name
+      ("run_in_terminal" (copilot-chat--execute-run-in-terminal input))
+      ("insert_edit_into_file" (copilot-chat--execute-insert-edit input))
+      ("create_file" (copilot-chat--execute-create-file input))
+      ("get_errors" (copilot-chat--execute-get-errors input))
+      ("fetch_web_page" (copilot-chat--execute-fetch-web-page input))
+      (_ (copilot-chat--tool-result "error"
+                                    (format "Unknown tool: %s" name))))))
+
+(copilot-on-request 'conversation/invokeClientTool
+                    #'copilot-chat--handle-tool-invocation)
+
+;;
 ;; Context doc generation
 ;;
 
@@ -223,6 +386,55 @@ Return editor context for the requested skill."
         (insert (propertize (format "\n[Error: %s]\n\n" error-msg)
                             'face 'copilot-chat-error-face))
         (copilot-chat--scroll-to-bottom)))))
+
+;;
+;; Tool registration
+;;
+
+(defun copilot-chat--tool-definitions ()
+  "Return the list of client tool definitions for agent mode."
+  (vector
+   (list :name "run_in_terminal"
+         :description "Run a shell command in the terminal."
+         :inputSchema (list :type "object"
+                            :properties (list :command (list :type "string")
+                                              :explanation (list :type "string"))
+                            :required ["command"]))
+   (list :name "insert_edit_into_file"
+         :description "Insert or edit code in a file."
+         :inputSchema (list :type "object"
+                            :properties (list :filePath (list :type "string")
+                                              :code (list :type "string")
+                                              :explanation (list :type "string"))
+                            :required ["filePath" "code"]))
+   (list :name "create_file"
+         :description "Create a new file with the given content."
+         :inputSchema (list :type "object"
+                            :properties (list :filePath (list :type "string")
+                                              :content (list :type "string"))
+                            :required ["filePath" "content"]))
+   (list :name "get_errors"
+         :description "Get diagnostics/errors for the given files."
+         :inputSchema (list :type "object"
+                            :properties (list :filePaths (list :type "array"
+                                                               :items (list :type "string")))
+                            :required ["filePaths"]))
+   (list :name "fetch_web_page"
+         :description "Fetch the content of web pages."
+         :inputSchema (list :type "object"
+                            :properties (list :urls (list :type "array"
+                                                          :items (list :type "string")))
+                            :required ["urls"]))))
+
+(defun copilot-chat--register-tools ()
+  "Register client tools with the server for agent mode."
+  (copilot--async-request
+   'conversation/registerTools
+   (list :tools (copilot-chat--tool-definitions))
+   :success-fn (lambda (_result)
+                 (copilot--log 'info "Agent tools registered"))
+   :error-fn (lambda (err)
+               (copilot--log 'error "Tool registration failed: %S" err))))
 
 ;;
 ;; Protocol methods
@@ -254,8 +466,14 @@ CALLBACK is called with the response containing conversationId and turnId."
                     (when-let* ((root (copilot--workspace-root)))
                       (list (list :uri (concat "file://" root)
                                   :name (file-name-nondirectory
-                                         (directory-file-name root))))))))
-            :success-fn callback
+                                         (directory-file-name root)))))))
+             (when copilot-chat-use-agent-mode
+               (list :chatMode "Agent"
+                     :needToolCallConfirmation t)))
+            :success-fn (lambda (result)
+                          (when copilot-chat-use-agent-mode
+                            (copilot-chat--register-tools))
+                          (funcall callback result))
             :error-fn (lambda (err)
                         (copilot-chat--handle-request-error err "create")))))
       (with-current-buffer (get-buffer copilot-chat--buffer-name)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -63,8 +63,12 @@ and file edits."
   :type 'boolean
   :group 'copilot-chat)
 
-(defcustom copilot-chat-auto-approve-tools '("get_errors" "fetch_web_page")
-  "Tools that skip confirmation and execute automatically."
+(defcustom copilot-chat-auto-approve-tools '("get_errors")
+  "Tools that skip confirmation and execute automatically.
+Only read-only, local tools should be auto-approved.  Tools that run
+shell commands, modify files, or reach the network (e.g.
+`fetch_web_page') are intentionally excluded so they always prompt
+for confirmation."
   :type '(repeat string)
   :group 'copilot-chat)
 
@@ -237,6 +241,23 @@ Return editor context for the requested skill."
                               'face 'copilot-chat-tool-face))
           (copilot-chat--scroll-to-bottom))))))
 
+(defun copilot-chat--tool-summary (name input)
+  "Return a concise, human-readable summary of tool NAME with INPUT.
+Used in confirmation prompts so the user can tell what they are
+approving without seeing a raw plist dump."
+  (pcase name
+    ("run_in_terminal"
+     (format "run shell command: %s" (plist-get input :command)))
+    ("create_file"
+     (format "create file: %s" (plist-get input :filePath)))
+    ("fetch_web_page"
+     (format "fetch: %s"
+             (string-join (append (plist-get input :urls) nil) ", ")))
+    ("get_errors"
+     (format "read diagnostics for: %s"
+             (string-join (append (plist-get input :filePaths) nil) ", ")))
+    (_ (format "%s with input %S" name input))))
+
 (defun copilot-chat--handle-tool-confirmation (msg)
   "Handle `conversation/invokeClientToolConfirmation' request MSG.
 Return \"Accept\" or \"Dismiss\" based on user confirmation."
@@ -244,10 +265,10 @@ Return \"Accept\" or \"Dismiss\" based on user confirmation."
         (input (plist-get msg :input)))
     (if (member name copilot-chat-auto-approve-tools)
         "Accept"
-      (let ((approved (yes-or-no-p
-                       (format "Copilot wants to run tool '%s' with input: %S.  Allow? "
-                               name input))))
-        (if approved "Accept" "Dismiss")))))
+      (if (yes-or-no-p (format "Copilot wants to %s.  Allow? "
+                               (copilot-chat--tool-summary name input)))
+          "Accept"
+        "Dismiss"))))
 
 (copilot-on-request 'conversation/invokeClientToolConfirmation
                     #'copilot-chat--handle-tool-confirmation)
@@ -259,29 +280,16 @@ Return \"Accept\" or \"Dismiss\" based on user confirmation."
 
 (defun copilot-chat--execute-run-in-terminal (input)
   "Execute run_in_terminal tool with INPUT."
-  (let ((command (plist-get input :command)))
+  (let ((command (plist-get input :command))
+        ;; Run in the workspace root rather than whatever buffer was
+        ;; current when the request arrived, so relative paths and build
+        ;; commands behave the way the user expects.
+        (default-directory (or (copilot--workspace-root) default-directory)))
     (copilot-chat--insert-tool-status "run_in_terminal" (format "Running: %s" command))
     (condition-case err
         (let ((output (shell-command-to-string command)))
           (copilot-chat--insert-tool-status "run_in_terminal" "Done.")
           (copilot-chat--tool-result "success" output))
-      (error
-       (copilot-chat--tool-result "error" (error-message-string err))))))
-
-(defun copilot-chat--execute-insert-edit (input)
-  "Execute insert_edit_into_file tool with INPUT."
-  (let ((file-path (plist-get input :filePath))
-        (code (plist-get input :code)))
-    (copilot-chat--insert-tool-status "insert_edit_into_file"
-                                      (format "Editing: %s" file-path))
-    (condition-case err
-        (let ((buf (find-file-noselect file-path)))
-          (with-current-buffer buf
-            (erase-buffer)
-            (insert code)
-            (save-buffer))
-          (copilot-chat--tool-result "success"
-                                    (format "File %s updated." file-path)))
       (error
        (copilot-chat--tool-result "error" (error-message-string err))))))
 
@@ -354,7 +362,6 @@ Dispatch to the appropriate tool and return a LanguageModelToolResult."
         (input (plist-get msg :input)))
     (pcase name
       ("run_in_terminal" (copilot-chat--execute-run-in-terminal input))
-      ("insert_edit_into_file" (copilot-chat--execute-insert-edit input))
       ("create_file" (copilot-chat--execute-create-file input))
       ("get_errors" (copilot-chat--execute-get-errors input))
       ("fetch_web_page" (copilot-chat--execute-fetch-web-page input))
@@ -400,13 +407,6 @@ Dispatch to the appropriate tool and return a LanguageModelToolResult."
                             :properties (list :command (list :type "string")
                                               :explanation (list :type "string"))
                             :required ["command"]))
-   (list :name "insert_edit_into_file"
-         :description "Insert or edit code in a file."
-         :inputSchema (list :type "object"
-                            :properties (list :filePath (list :type "string")
-                                              :code (list :type "string")
-                                              :explanation (list :type "string"))
-                            :required ["filePath" "code"]))
    (list :name "create_file"
          :description "Create a new file with the given content."
          :inputSchema (list :type "object"

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -522,6 +522,252 @@
                 (expect (buffer-string) :to-equal "")))
           (kill-buffer buf)))))
 
+  ;;
+  ;; Tool definitions
+  ;;
+
+  (describe "copilot-chat--tool-definitions"
+    (it "returns a vector of tool definitions"
+      (let ((tools (copilot-chat--tool-definitions)))
+        (expect (vectorp tools) :to-be-truthy)
+        (expect (length tools) :to-equal 5)))
+
+    (it "includes run_in_terminal tool"
+      (let* ((tools (append (copilot-chat--tool-definitions) nil))
+             (tool (cl-find "run_in_terminal" tools
+                            :key (lambda (tl) (plist-get tl :name))
+                            :test #'equal)))
+        (expect tool :to-be-truthy)
+        (expect (plist-get tool :description) :to-be-truthy)
+        (expect (plist-get tool :inputSchema) :to-be-truthy))))
+
+  ;;
+  ;; Tool result helper
+  ;;
+
+  (describe "copilot-chat--tool-result"
+    (it "builds a result with status and content"
+      (let ((result (copilot-chat--tool-result "success" "output")))
+        (expect (plist-get result :status) :to-equal "success")
+        (let ((content (plist-get result :content)))
+          (expect (vectorp content) :to-be-truthy)
+          (expect (plist-get (aref content 0) :value) :to-equal "output")))))
+
+  ;;
+  ;; Tool confirmation
+  ;;
+
+  (describe "copilot-chat--handle-tool-confirmation"
+    (it "auto-approves tools in copilot-chat-auto-approve-tools"
+      (let ((copilot-chat-auto-approve-tools '("get_errors" "fetch_web_page")))
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "get_errors"
+                       :input (list :filePaths ["foo.el"])))
+                :to-equal "Accept")))
+
+    (it "prompts for tools not in auto-approve list"
+      (let ((copilot-chat-auto-approve-tools '("get_errors")))
+        (spy-on 'yes-or-no-p :and-return-value t)
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "run_in_terminal"
+                       :input (list :command "ls")))
+                :to-equal "Accept")
+        (expect 'yes-or-no-p :to-have-been-called)))
+
+    (it "returns Dismiss when user declines"
+      (let ((copilot-chat-auto-approve-tools nil))
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "run_in_terminal"
+                       :input (list :command "rm -rf /")))
+                :to-equal "Dismiss"))))
+
+  ;;
+  ;; Tool invocation dispatch
+  ;;
+
+  (describe "copilot-chat--handle-tool-invocation"
+    (it "dispatches run_in_terminal"
+      (spy-on 'copilot-chat--execute-run-in-terminal
+              :and-return-value (copilot-chat--tool-result "success" "ok"))
+      (let ((result (copilot-chat--handle-tool-invocation
+                     (list :name "run_in_terminal"
+                           :input (list :command "echo hi")))))
+        (expect 'copilot-chat--execute-run-in-terminal :to-have-been-called)
+        (expect (plist-get result :status) :to-equal "success")))
+
+    (it "dispatches insert_edit_into_file"
+      (spy-on 'copilot-chat--execute-insert-edit
+              :and-return-value (copilot-chat--tool-result "success" "ok"))
+      (copilot-chat--handle-tool-invocation
+       (list :name "insert_edit_into_file"
+             :input (list :filePath "/tmp/test" :code "code")))
+      (expect 'copilot-chat--execute-insert-edit :to-have-been-called))
+
+    (it "dispatches create_file"
+      (spy-on 'copilot-chat--execute-create-file
+              :and-return-value (copilot-chat--tool-result "success" "ok"))
+      (copilot-chat--handle-tool-invocation
+       (list :name "create_file"
+             :input (list :filePath "/tmp/test" :content "content")))
+      (expect 'copilot-chat--execute-create-file :to-have-been-called))
+
+    (it "dispatches get_errors"
+      (spy-on 'copilot-chat--execute-get-errors
+              :and-return-value (copilot-chat--tool-result "success" "ok"))
+      (copilot-chat--handle-tool-invocation
+       (list :name "get_errors"
+             :input (list :filePaths ["foo.el"])))
+      (expect 'copilot-chat--execute-get-errors :to-have-been-called))
+
+    (it "dispatches fetch_web_page"
+      (spy-on 'copilot-chat--execute-fetch-web-page
+              :and-return-value (copilot-chat--tool-result "success" "ok"))
+      (copilot-chat--handle-tool-invocation
+       (list :name "fetch_web_page"
+             :input (list :urls ["https://example.com"])))
+      (expect 'copilot-chat--execute-fetch-web-page :to-have-been-called))
+
+    (it "returns error for unknown tools"
+      (let ((result (copilot-chat--handle-tool-invocation
+                     (list :name "unknown_tool"
+                           :input (list :foo "bar")))))
+        (expect (plist-get result :status) :to-equal "error"))))
+
+  ;;
+  ;; Tool execution
+  ;;
+
+  (describe "copilot-chat--execute-run-in-terminal"
+    (it "runs shell command and returns output"
+      ;; Suppress chat buffer insertion
+      (spy-on 'copilot-chat--insert-tool-status)
+      (let ((result (copilot-chat--execute-run-in-terminal
+                     (list :command "echo hello"))))
+        (expect (plist-get result :status) :to-equal "success")
+        (expect (plist-get (aref (plist-get result :content) 0) :value)
+                :to-match "hello"))))
+
+  (describe "copilot-chat--execute-create-file"
+    (it "creates a file with content"
+      (spy-on 'copilot-chat--insert-tool-status)
+      (let* ((tmp-file (make-temp-name
+                        (expand-file-name "copilot-test-" temporary-file-directory)))
+             (result (copilot-chat--execute-create-file
+                      (list :filePath tmp-file :content "test content"))))
+        (unwind-protect
+            (progn
+              (expect (plist-get result :status) :to-equal "success")
+              (expect (file-exists-p tmp-file) :to-be-truthy)
+              (expect (with-temp-buffer
+                        (insert-file-contents tmp-file)
+                        (buffer-string))
+                      :to-equal "test content"))
+          (when (file-exists-p tmp-file)
+            (delete-file tmp-file))))))
+
+  (describe "copilot-chat--execute-get-errors"
+    (it "reports files not open in editor"
+      (spy-on 'copilot-chat--insert-tool-status)
+      (let ((result (copilot-chat--execute-get-errors
+                     (list :filePaths ["/nonexistent/file.el"]))))
+        (expect (plist-get result :status) :to-equal "success")
+        (expect (plist-get (aref (plist-get result :content) 0) :value)
+                :to-match "not open in editor"))))
+
+  ;;
+  ;; Tool status display
+  ;;
+
+  (describe "copilot-chat--insert-tool-status"
+    (it "inserts tool status in chat buffer"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (copilot-chat--insert-tool-status "run_in_terminal" "Running: ls")
+              (with-current-buffer buf
+                (expect (buffer-string) :to-match "\\[Tool: run_in_terminal\\]")
+                (expect (buffer-string) :to-match "Running: ls")))
+          (kill-buffer buf))))
+
+    (it "does nothing when no chat buffer exists"
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name))
+      ;; Should not error
+      (copilot-chat--insert-tool-status "test" "noop")))
+
+  ;;
+  ;; Agent mode in copilot-chat--create
+  ;;
+
+  (describe "copilot-chat--create (agent mode)"
+    (it "includes agent mode params when enabled"
+      (let ((captured-params nil)
+            (copilot-chat-use-agent-mode t)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-get captured-params :chatMode) :to-equal "Agent")
+              (expect (plist-get captured-params :needToolCallConfirmation)
+                      :to-equal t))
+          (kill-buffer buf))))
+
+    (it "omits agent mode params when disabled"
+      (let ((captured-params nil)
+            (copilot-chat-use-agent-mode nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-member captured-params :chatMode)
+                      :not :to-be-truthy))
+          (kill-buffer buf))))
+
+    (it "registers tools after successful create"
+      (let ((copilot-chat-use-agent-mode t)
+            (callback-called nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--register-tools)
+              ;; Capture the success-fn and call it
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method _params &rest args)
+                        (let ((success-fn (plist-get args :success-fn)))
+                          (when success-fn
+                            (funcall success-fn
+                                     (list :conversationId "test"
+                                           :turnId "turn-1"))))
+                        (cons nil nil)))
+              (copilot-chat--create "hello"
+                                    (lambda (_r) (setq callback-called t)))
+              (expect 'copilot-chat--register-tools :to-have-been-called)
+              (expect callback-called :to-be-truthy))
+          (kill-buffer buf)))))
+
   (describe "copilot-chat-send-region"
     (it "formats code with language id"
       (with-temp-buffer

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -530,7 +530,7 @@
     (it "returns a vector of tool definitions"
       (let ((tools (copilot-chat--tool-definitions)))
         (expect (vectorp tools) :to-be-truthy)
-        (expect (length tools) :to-equal 5)))
+        (expect (length tools) :to-equal 4)))
 
     (it "includes run_in_terminal tool"
       (let* ((tools (append (copilot-chat--tool-definitions) nil))
@@ -580,7 +580,37 @@
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "run_in_terminal"
                        :input (list :command "rm -rf /")))
-                :to-equal "Dismiss"))))
+                :to-equal "Dismiss")))
+
+    (it "summarizes the tool in the confirmation prompt"
+      (let ((copilot-chat-auto-approve-tools nil)
+            (prompt nil))
+        (spy-on 'yes-or-no-p :and-call-fake
+                (lambda (msg) (setq prompt msg) nil))
+        (copilot-chat--handle-tool-confirmation
+         (list :name "run_in_terminal" :input (list :command "make test")))
+        ;; The raw command shows, not a plist dump.
+        (expect prompt :to-match "run shell command: make test"))))
+
+  ;;
+  ;; Tool summary
+  ;;
+
+  (describe "copilot-chat--tool-summary"
+    (it "describes a terminal command concisely"
+      (expect (copilot-chat--tool-summary
+               "run_in_terminal" (list :command "ls -la"))
+              :to-equal "run shell command: ls -la"))
+
+    (it "describes a file creation by path"
+      (expect (copilot-chat--tool-summary
+               "create_file" (list :filePath "/tmp/x.el" :content "huge"))
+              :to-equal "create file: /tmp/x.el"))
+
+    (it "joins multiple fetch URLs"
+      (expect (copilot-chat--tool-summary
+               "fetch_web_page" (list :urls ["https://a.com" "https://b.com"]))
+              :to-equal "fetch: https://a.com, https://b.com")))
 
   ;;
   ;; Tool invocation dispatch
@@ -595,14 +625,6 @@
                            :input (list :command "echo hi")))))
         (expect 'copilot-chat--execute-run-in-terminal :to-have-been-called)
         (expect (plist-get result :status) :to-equal "success")))
-
-    (it "dispatches insert_edit_into_file"
-      (spy-on 'copilot-chat--execute-insert-edit
-              :and-return-value (copilot-chat--tool-result "success" "ok"))
-      (copilot-chat--handle-tool-invocation
-       (list :name "insert_edit_into_file"
-             :input (list :filePath "/tmp/test" :code "code")))
-      (expect 'copilot-chat--execute-insert-edit :to-have-been-called))
 
     (it "dispatches create_file"
       (spy-on 'copilot-chat--execute-create-file


### PR DESCRIPTION
Agent mode lets the Copilot server invoke client-side tools during chat conversations — shell commands, file edits, file creation, diagnostics collection, and web page fetching.

Set `copilot-chat-use-agent-mode` to `t` to enable it. Tools require user confirmation via `yes-or-no-p` by default; safe read-only tools (`get_errors`, `fetch_web_page`) are auto-approved and can be customized via `copilot-chat-auto-approve-tools`.

Fixes #441

cc @tninja — would love it if you could give this a spin and report back!