### PR TITLE
fix: silence "Request was canceled" spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+## 0.5.1 (2026-03-18)
+
+### Bug Fixes
+- Suppress "Request was canceled" messages
+
 ## 0.5.0 (2026-03-16)
 
 ### New Features

--- a/copilot.el
+++ b/copilot.el
@@ -963,7 +963,11 @@ TRIGGER-KIND is 1 for invoked, 2 for automatic (default)."
   (setq copilot--completion-request-id
         (copilot--async-request 'textDocument/inlineCompletion
                                 (copilot--inline-completion-params (or trigger-kind 2))
-                                :success-fn callback)))
+                                :success-fn callback
+                                :error-fn (lambda (err)
+                                            (unless (= (plist-get err :code) -32800) ; Request canceled
+                                              (copilot--log 'error "textDocument/inlineCompletion failed: %S"
+                                                            err))))))
 
 (defun copilot--cycle-completion (direction)
   "Cycle completion with DIRECTION."


### PR DESCRIPTION
`copilot--get-completion` always cancels in-flight requests which results in a spam of

> Copilot: textDocument/inlineCompletion failed: (:code -32800 :message "Request was canceled")

messages in the echo area.

This PR adds an error-handler which ignores the [`-32800` error code](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes)