### PR TITLE
Fix invisible NES insertion overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fix NES insertion text never rendering because its zero-width overlay was marked `evaporate` and got deleted immediately. ([#451](https://github.com/copilot-emacs/copilot.el/issues/451))
 - Suppress "Request was canceled" error messages in the echo area. ([#464](https://github.com/copilot-emacs/copilot.el/pull/464))
 
 ## 0.5.0 (2026-03-16)

--- a/copilot-nes.el
+++ b/copilot-nes.el
@@ -181,13 +181,15 @@ Run `M-x copilot-reinstall-server' to upgrade."
           (overlay-put ov 'evaporate t)
           (overlay-put ov 'priority 100)
           (push ov copilot-nes--overlays)))
-      ;; Insertion overlay: show new text
+      ;; Insertion overlay: show new text.  The overlay is zero-width
+      ;; (it only carries an `after-string'), so it must NOT be marked
+      ;; `evaporate' — Emacs deletes an empty overlay the moment that
+      ;; property is set, which would make the insertion invisible.
       (when has-insertion
         (let* ((insertion-text (propertize text 'face 'copilot-nes-insertion-face))
                (ov (make-overlay end end nil nil nil)))
           (overlay-put ov 'after-string insertion-text)
           (overlay-put ov 'copilot-nes t)
-          (overlay-put ov 'evaporate t)
           (overlay-put ov 'priority 100)
           (push ov copilot-nes--overlays)))))
   ;; Record point so the post-command hook can detect actual movement

--- a/test/copilot-nes-test.el
+++ b/test/copilot-nes-test.el
@@ -94,7 +94,10 @@
           (copilot-nes--display edit)
           (expect (length copilot-nes--overlays) :to-equal 1)
           (let ((ov (car copilot-nes--overlays)))
-            (expect (overlay-get ov 'after-string) :to-be-truthy)))))
+            (expect (overlay-get ov 'after-string) :to-be-truthy)
+            ;; The overlay must stay attached to the buffer; an empty
+            ;; overlay marked `evaporate' would be detached and invisible.
+            (expect (overlay-buffer ov) :to-be-truthy)))))
 
     (it "sends didShowInlineEdit notification when command is present"
       (with-temp-buffer


### PR DESCRIPTION
NES suggestions only ever showed the deletion strikethrough, never the text to be inserted. The insertion overlay is zero-width (it only carries an `after-string`), and marking an empty overlay with `evaporate` makes Emacs detach it from the buffer the instant the property is set, so it never rendered.

This drops `evaporate` from the insertion overlay (it stays on the deletion overlay, which spans real text). The display test now also asserts the overlay stays attached to the buffer, since the `after-string` property lingers on a detached overlay and masked the bug.

Thanks to @bastianbeischer for the diagnosis in the issue.

Fixes #451