### PR TITLE
Don't block Emacs exit on Copilot server shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fix Emacs hanging on exit when shutting down the Copilot server (the blocking `jsonrpc-shutdown` is now skipped at `kill-emacs` time). ([#469](https://github.com/copilot-emacs/copilot.el/issues/469))
 - Fix NES insertion text never rendering because its zero-width overlay was marked `evaporate` and got deleted immediately. ([#451](https://github.com/copilot-emacs/copilot.el/issues/451))
 - Suppress "Request was canceled" error messages in the echo area. ([#464](https://github.com/copilot-emacs/copilot.el/pull/464))
 

--- a/copilot.el
+++ b/copilot.el
@@ -517,11 +517,18 @@ Returns the request ID (a number) so callers can cancel the request later."
                                                                       ,method err)))
                                         ,@filtered-args))))))
 
-(defun copilot--shutdown-server ()
+(defun copilot--shutdown-server (&optional at-exit)
   "Shut down the Copilot server with the standard LSP shutdown sequence.
 Sends a `shutdown' request followed by an `exit' notification, then
 cleans up the connection and resets global state.  Safe to call when
-there is no active connection."
+there is no active connection.
+
+When AT-EXIT is non-nil, skip the final `jsonrpc-shutdown' call.  That
+function waits on `accept-process-output', which can busy-loop forever
+when several jsonrpc connections are alive at once, due to an Emacs bug
+fixed only on Emacs 31+ (see https://github.com/copilot-emacs/copilot.el/issues/469).
+At exit that would hang Emacs indefinitely, and the server process is
+reaped by Emacs anyway, so the `exit' notification is enough."
   (when copilot--connection
     (condition-case _err
         (jsonrpc-request copilot--connection 'shutdown nil :timeout 3)
@@ -529,11 +536,18 @@ there is no active connection."
     (condition-case _err
         (jsonrpc-notify copilot--connection 'exit nil)
       (error nil))
-    (jsonrpc-shutdown copilot--connection)
+    (unless at-exit
+      (jsonrpc-shutdown copilot--connection))
     (setq copilot--connection nil)
     (setq copilot--opened-buffers nil)
     (setq copilot--workspace-folders nil)
     (setq copilot--status nil)))
+
+(defun copilot--shutdown-server-at-exit ()
+  "Shut down the Copilot server from `kill-emacs-hook'.
+Skips the blocking `jsonrpc-shutdown' step so Emacs can exit without
+hanging.  See `copilot--shutdown-server'."
+  (copilot--shutdown-server t))
 
 (defun copilot--command ()
   "Return the command-line to start copilot server."
@@ -612,7 +626,7 @@ You can change the installed version with `M-x copilot-reinstall-server` or remo
               `(:networkProxy ,copilot-network-proxy))))))
     (copilot--notify 'initialized '())
     (copilot--notify 'workspace/didChangeConfiguration `(:settings ,(copilot--effective-lsp-settings)))
-    (add-hook 'kill-emacs-hook #'copilot--shutdown-server))))
+    (add-hook 'kill-emacs-hook #'copilot--shutdown-server-at-exit))))
 
 ;;
 ;; login / logout

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -934,7 +934,27 @@
         (expect copilot--connection :to-be nil)
         (expect copilot--opened-buffers :to-be nil)
         (expect copilot--workspace-folders :to-be nil)
-        (expect copilot--status :to-be nil))))
+        (expect copilot--status :to-be nil)))
+
+    (it "skips jsonrpc-shutdown at exit to avoid hanging Emacs"
+      (let* ((conn (make-symbol "fake-conn"))
+             (copilot--connection conn)
+             (copilot--opened-buffers '(buf1))
+             (copilot--workspace-folders '("file:///tmp")))
+        (spy-on 'jsonrpc-request)
+        (spy-on 'jsonrpc-notify)
+        (spy-on 'jsonrpc-shutdown)
+        (copilot--shutdown-server t)
+        ;; The blocking shutdown call must be skipped on exit ...
+        (expect 'jsonrpc-shutdown :not :to-have-been-called)
+        ;; ... but the server is still told to exit and state is reset.
+        (expect 'jsonrpc-notify :to-have-been-called-with conn 'exit nil)
+        (expect copilot--connection :to-be nil)))
+
+    (it "delegates to copilot--shutdown-server with at-exit from kill-emacs-hook"
+      (spy-on 'copilot--shutdown-server)
+      (copilot--shutdown-server-at-exit)
+      (expect 'copilot--shutdown-server :to-have-been-called-with t)))
 
   ;;
   ;; $/cancelRequest


### PR DESCRIPTION
`jsonrpc-shutdown` waits on `accept-process-output`, which can busy-loop forever when several jsonrpc connections are alive at once (an Emacs bug fixed only on Emacs 31+). Since we run it from `kill-emacs-hook`, daemon users get Emacs hanging on every exit until it's SIGKILLed.

This skips the blocking `jsonrpc-shutdown` at exit and relies on the `exit` notification instead - the server process gets reaped by Emacs on exit anyway. The interactive `copilot-diagnose` path keeps the full sequence so the server is cleanly replaced on restart.

Thanks to @real-or-random for the detailed diagnosis and @ncaq for confirming it reproduces with copilot alone.

Fixes #469