### PR TITLE
Only attach file-visiting buffers as chat context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+- `copilot-chat` now only attaches the originating buffer as context when it is a file-visiting buffer, so invoking chat from an unrelated buffer (dired, `*scratch*`, etc.) no longer sends it as context. ([#470](https://github.com/copilot-emacs/copilot.el/issues/470))
+
 ### Bug Fixes
 
 - Fix NES insertion text never rendering because its zero-width overlay was marked `evaporate` and got deleted immediately. ([#451](https://github.com/copilot-emacs/copilot.el/issues/451))

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -389,7 +389,11 @@ Otherwise, create a new conversation."
             "Copilot Chat: "))))
   (when (string-empty-p message)
     (user-error "Empty message"))
-  (let ((source-buf (current-buffer))
+  ;; Only attach the originating buffer as context when it is a real
+  ;; file-visiting buffer.  `copilot-chat' can be invoked from anywhere
+  ;; (dired, *scratch*, the chat buffer itself, ...), and sending an
+  ;; unrelated buffer as context is just noise.  See issue #470.
+  (let ((source-buf (when (buffer-file-name) (current-buffer)))
         (chat-buf (get-buffer-create copilot-chat--buffer-name)))
     (with-current-buffer chat-buf
       (unless (derived-mode-p 'copilot-chat-mode)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -377,7 +377,39 @@
 
   (describe "copilot-chat (command)"
     (it "rejects empty messages"
-      (expect (copilot-chat "") :to-throw 'user-error)))
+      (expect (copilot-chat "") :to-throw 'user-error))
+
+    (it "attaches a file-visiting buffer as context source"
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name))
+      (spy-on 'copilot-chat--create)
+      (spy-on 'copilot-chat--send-turn)
+      (spy-on 'display-buffer)
+      (let ((src (get-buffer-create "*copilot-chat-test-src*")))
+        (unwind-protect
+            (with-current-buffer src
+              (setq buffer-file-name "/tmp/copilot-chat-test.el")
+              (copilot-chat "hello")
+              (expect (buffer-local-value 'copilot-chat--source-buffer
+                                          (get-buffer copilot-chat--buffer-name))
+                      :to-be src))
+          (with-current-buffer src (setq buffer-file-name nil))
+          (kill-buffer src))))
+
+    (it "does not attach a non-file buffer as context source"
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name))
+      (spy-on 'copilot-chat--create)
+      (spy-on 'copilot-chat--send-turn)
+      (spy-on 'display-buffer)
+      (let ((src (get-buffer-create "*copilot-chat-test-scratch*")))
+        (unwind-protect
+            (with-current-buffer src
+              (copilot-chat "hello")
+              (expect (buffer-local-value 'copilot-chat--source-buffer
+                                          (get-buffer copilot-chat--buffer-name))
+                      :to-be nil))
+          (kill-buffer src)))))
 
   (describe "copilot-chat-send"
     (it "rejects empty messages"


### PR DESCRIPTION
`copilot-chat` can be invoked from anywhere but unconditionally sent the current buffer as conversation context. When you trigger it from dired, `*scratch*`, or the chat buffer itself, that context is just noise.

This attaches the originating buffer only when it's visiting a file - a reliable signal that it's real source context. The reporter suggested gating on `copilot-mode`; I went with `buffer-file-name` instead so chat context doesn't depend on the completion minor mode being enabled.

Fixes #470