### PR TITLE
Improve NES coexistence with copilot-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Bug Fixes
 
+- Dismiss a pending NES suggestion immediately when the buffer is edited (e.g. after accepting a `copilot-mode` completion), instead of leaving a misplaced overlay behind. ([#477](https://github.com/copilot-emacs/copilot.el/issues/477))
+- Clear NES overlays before applying an accepted suggestion so the ghost text no longer lingers over the edit until the next command. ([#477](https://github.com/copilot-emacs/copilot.el/issues/477))
+- Tell the user to enable `copilot-mode` when `copilot-nes-mode` is turned on without it, since NES relies on `copilot-mode` to start and sync the server. ([#477](https://github.com/copilot-emacs/copilot.el/issues/477))
 - Fix Emacs hanging on exit when shutting down the Copilot server (the blocking `jsonrpc-shutdown` is now skipped at `kill-emacs` time). ([#469](https://github.com/copilot-emacs/copilot.el/issues/469))
 - Fix NES insertion text never rendering because its zero-width overlay was marked `evaporate` and got deleted immediately. ([#451](https://github.com/copilot-emacs/copilot.el/issues/451))
 - Suppress "Request was canceled" error messages in the echo area. ([#464](https://github.com/copilot-emacs/copilot.el/pull/464))

--- a/README.md
+++ b/README.md
@@ -253,15 +253,20 @@ NES predicts the next edit you'll want to make anywhere in the file, based on yo
 >
 > NES requires `copilot-language-server` version 1.434.0 or newer. Run `M-x copilot-reinstall-server` to upgrade if needed.
 
-Enable `copilot-nes-mode` in a buffer to start receiving suggestions. It can coexist with `copilot-mode`:
+`copilot-nes-mode` works alongside `copilot-mode` and relies on it to start and sync the language server. Enable both in the buffer; on its own `copilot-nes-mode` does not produce any suggestions (it will tell you so when enabled without `copilot-mode`).
 
 ```elisp
+(add-hook 'prog-mode-hook #'copilot-mode)
 (add-hook 'prog-mode-hook #'copilot-nes-mode)
 ```
 
 When a suggestion is pending:
 - **TAB** — accept the suggestion (jumps to it first if far away, applies on second press)
 - **C-g** — dismiss the suggestion
+
+> [!NOTE]
+>
+> `copilot-nes-mode` predefines **TAB** and **C-g**, whereas `copilot-mode` ships no completion keybindings and leaves `copilot-completion-map` for you to populate. In both cases the bindings only take effect while a suggestion (or completion) is pending and otherwise fall through to their usual commands, so the predefined NES keys are safe to leave enabled.
 
 Customization variables:
 - **`copilot-nes-idle-delay`** — seconds of idle time before requesting a suggestion (default `0.5`)

--- a/copilot-nes.el
+++ b/copilot-nes.el
@@ -33,10 +33,12 @@
 ;; text at cursor), NES suggestions can appear anywhere in the file and can
 ;; replace or delete existing text.
 ;;
-;; Enable `copilot-nes-mode' in a buffer to start receiving suggestions.  It
-;; can coexist with `copilot-mode'.
+;; Enable `copilot-nes-mode' in a buffer to start receiving suggestions.  NES
+;; relies on `copilot-mode' to start and sync the language server, so enable
+;; `copilot-mode' in the same buffer.
 ;;
 ;; Usage:
+;;   (add-hook 'prog-mode-hook #'copilot-mode)
 ;;   (add-hook 'prog-mode-hook #'copilot-nes-mode)
 ;;
 ;; Key bindings (active when a suggestion is pending):
@@ -257,6 +259,11 @@ invocation (or when already at the edit), apply the edit."
       (if (not near-edit)
           ;; Jump to the edit location so the user can see what they're accepting
           (goto-char beg)
+        ;; Clear the overlays before touching the buffer so the suggestion's
+        ;; ghost text can't linger over the applied edit until the next
+        ;; command (notably under evil-mode).  The edit details are already
+        ;; captured above, so resetting state here is safe.
+        (copilot-nes--clear)
         ;; Apply the edit
         (delete-region beg end)
         (goto-char beg)
@@ -265,8 +272,7 @@ invocation (or when already at the edit), apply the edit."
         (when command
           (copilot--notify 'workspace/executeCommand
                            (list :command (plist-get command :command)
-                                 :arguments (plist-get command :arguments))))
-        (copilot-nes--clear)))))
+                                 :arguments (plist-get command :arguments))))))))
 
 ;;
 ;; Dismiss
@@ -287,7 +293,16 @@ invocation (or when already at the edit), apply the edit."
                         yank yank-pop newline newline-and-indent open-line
                         delete-forward-char delete-indentation join-line
                         indent-for-tab-command c-electric-brace c-electric-slash
-                        c-electric-semicolon c-electric-paren)
+                        c-electric-semicolon c-electric-paren
+                        ;; Accepting a `copilot-mode' completion edits the
+                        ;; buffer too, which invalidates a pending NES overlay.
+                        copilot-accept-completion
+                        copilot-accept-completion-by-word
+                        copilot-accept-completion-by-line
+                        copilot-accept-completion-by-sentence
+                        copilot-accept-completion-by-paragraph
+                        copilot-accept-completion-up-to-char
+                        copilot-accept-completion-to-char)
   "Commands considered text-modifying for NES triggering.")
 
 (defun copilot-nes--post-command ()
@@ -295,6 +310,11 @@ invocation (or when already at the edit), apply the edit."
   (cond
    ;; After a text-modifying command, schedule a new request
    ((memq this-command copilot-nes--text-changing-commands)
+    ;; Any edit shifts the positions a pending suggestion was drawn at, so
+    ;; drop it immediately (e.g. after accepting a `copilot-mode' completion)
+    ;; before requesting a fresh one.
+    (when copilot-nes--edit
+      (copilot-nes--clear))
     (copilot-nes--schedule-request))
    ;; When a suggestion is pending and point actually moved, track it
    (copilot-nes--edit
@@ -356,6 +376,15 @@ invocation (or when already at the edit), apply the edit."
   "Keymap for `copilot-nes-mode'.
 Bindings only activate when a NES suggestion is pending.")
 
+(defun copilot-nes--warn-without-copilot-mode (buffer)
+  "Warn if BUFFER has `copilot-nes-mode' enabled but not `copilot-mode'.
+NES does not start or sync the language server on its own; it relies on
+`copilot-mode' for that, so without it no suggestions ever appear."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (when (and copilot-nes-mode (not (bound-and-true-p copilot-mode)))
+        (message "copilot-nes-mode needs copilot-mode enabled in this buffer to receive suggestions")))))
+
 ;;;###autoload
 (define-minor-mode copilot-nes-mode
   "Minor mode for Copilot Next Edit Suggestions.
@@ -363,12 +392,22 @@ NES predicts edits you will want to make next, based on recent
 edit history.  Suggestions can appear anywhere in the file and
 can replace or delete existing text.
 
+NES does not start or sync the language server itself; it relies on
+`copilot-mode' to do that.  Enable `copilot-mode' in the same buffer,
+otherwise `copilot-nes-mode' produces no suggestions.
+
 \\{copilot-nes-mode-map}"
   :lighter " NES"
   :keymap copilot-nes-mode-map
   (if copilot-nes-mode
       (progn
         (copilot-nes--check-server-version)
+        ;; Warn when `copilot-mode' is missing, deferred to idle so that
+        ;; enabling both modes from the same hook (in either order) doesn't
+        ;; trigger a spurious warning.
+        (run-with-idle-timer 0 nil
+                             #'copilot-nes--warn-without-copilot-mode
+                             (current-buffer))
         (add-hook 'post-command-hook #'copilot-nes--post-command nil t))
     (copilot-nes--cancel-timer)
     (copilot-nes--clear)

--- a/test/copilot-nes-test.el
+++ b/test/copilot-nes-test.el
@@ -154,7 +154,9 @@
           (copilot-nes-accept)
           (expect (buffer-substring-no-properties (point-min) (point-max))
                   :to-equal "hello planet\n")
-          (expect copilot-nes--edit :to-equal nil))))
+          (expect copilot-nes--edit :to-equal nil)
+          ;; Overlays must be gone so no ghost text lingers over the edit.
+          (expect copilot-nes--overlays :to-equal nil))))
 
     (it "applies a pure insertion"
       (with-temp-buffer
@@ -302,7 +304,28 @@
         (spy-on 'copilot-nes--schedule-request)
         (let ((this-command 'self-insert-command))
           (copilot-nes--post-command))
-        (expect 'copilot-nes--schedule-request :to-have-been-called))))
+        (expect 'copilot-nes--schedule-request :to-have-been-called)))
+
+    (it "dismisses a stale suggestion after accepting a copilot completion"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello\nworld\n")
+        (goto-char (point-min))
+        (let ((edit (list :text "x"
+                          :range (list :start (list :line 0 :character 0)
+                                       :end (list :line 0 :character 1))
+                          :command nil)))
+          (spy-on 'copilot--notify)
+          (spy-on 'copilot-nes--schedule-request)
+          (copilot-nes--display edit)
+          (expect copilot-nes--edit :to-be-truthy)
+          ;; Accepting an inline completion edits the buffer and should clear
+          ;; the now-misplaced NES overlay right away.
+          (let ((this-command 'copilot-accept-completion))
+            (copilot-nes--post-command))
+          (expect copilot-nes--edit :to-equal nil)
+          (expect copilot-nes--overlays :to-equal nil)
+          (expect 'copilot-nes--schedule-request :to-have-been-called)))))
 
   ;;
   ;; Timer management
@@ -369,6 +392,33 @@
         (copilot-nes-mode 1)
         (expect 'copilot-nes--check-server-version :to-have-been-called)
         (copilot-nes-mode -1))))
+
+  ;;
+  ;; copilot-mode dependency warning
+  ;;
+
+  (describe "copilot-nes--warn-without-copilot-mode"
+    (it "warns when copilot-nes-mode is on but copilot-mode is off"
+      (with-temp-buffer
+        (setq-local copilot-nes-mode t)
+        (spy-on 'message)
+        (copilot-nes--warn-without-copilot-mode (current-buffer))
+        (expect 'message :to-have-been-called)))
+
+    (it "is silent when copilot-mode is also on"
+      (with-temp-buffer
+        (setq-local copilot-nes-mode t)
+        (setq-local copilot-mode t)
+        (spy-on 'message)
+        (copilot-nes--warn-without-copilot-mode (current-buffer))
+        (expect 'message :not :to-have-been-called)))
+
+    (it "is silent when the buffer is dead"
+      (let ((buf (generate-new-buffer "nes-dead")))
+        (kill-buffer buf)
+        (spy-on 'message)
+        (copilot-nes--warn-without-copilot-mode buf)
+        (expect 'message :not :to-have-been-called))))
 
   ;;
   ;; Distance check


### PR DESCRIPTION
NES relies on `copilot-mode` to start and sync the language server, but that wasn't enforced or documented, and the two modes stepped on each other's overlays. Addresses the points raised in #477 (and the keybinding question from the #451 thread).

- Dismiss a pending NES suggestion as soon as the buffer is edited (now including the `copilot-accept-completion*` commands), so accepting an inline completion no longer leaves a stale, misplaced NES overlay behind.
- Clear the NES overlays before applying an accepted suggestion, so the ghost text doesn't linger over the edit until the next command. Note: I couldn't reproduce the evil-mode redisplay glitch in Example 2 locally, so this is a best-effort fix for the most likely cause (the lingering after-string overlay) — worth confirming with the reporter.
- Warn when `copilot-nes-mode` is enabled without `copilot-mode`, and document the dependency in the docstring and README.
- Document why NES predefines TAB/C-g while `copilot-mode` leaves accept keys to `copilot-completion-map`.

I left true standalone NES (driving the doc lifecycle without `copilot-mode`) out of scope; this clarifies the current relationship instead.

Refs #477