### PR TITLE
Shadow copilot-mode completions while a NES suggestion is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Hide regular `copilot-mode` completions while a NES suggestion is pending, so the two no longer overlap on screen. ([#477](https://github.com/copilot-emacs/copilot.el/issues/477))
 - Add experimental Agent mode for Copilot Chat (`copilot-chat-use-agent-mode`). When enabled, Copilot can run client-side tools (`run_in_terminal`, `create_file`, `get_errors`, `fetch_web_page`); each invocation prompts for confirmation unless listed in `copilot-chat-auto-approve-tools`. ([#441](https://github.com/copilot-emacs/copilot.el/issues/441))
 - Add native binary installation support. `copilot-install-server` now falls back to downloading precompiled binaries when npm is unavailable, removing the Node.js requirement on supported platforms. A new `copilot-install-server-native` command is also available for explicit native installation.
 

--- a/copilot-nes.el
+++ b/copilot-nes.el
@@ -166,6 +166,15 @@ Run `M-x copilot-reinstall-server' to upgrade."
   (setq copilot-nes--move-count 0)
   (setq copilot-nes--last-point nil))
 
+(defun copilot-nes--shadow-completion-p ()
+  "Return non-nil when a pending NES suggestion should hide completions.
+Registered in `copilot-disable-display-predicates' so that regular
+`copilot-mode' completions are suppressed while a NES suggestion is
+pending."
+  copilot-nes--edit)
+
+(add-to-list 'copilot-disable-display-predicates #'copilot-nes--shadow-completion-p)
+
 (defun copilot-nes--display (edit)
   "Display EDIT as overlays in the buffer."
   (copilot-nes--clear)
@@ -195,6 +204,10 @@ Run `M-x copilot-reinstall-server' to upgrade."
           (overlay-put ov 'copilot-nes t)
           (overlay-put ov 'priority 100)
           (push ov copilot-nes--overlays)))))
+  ;; Shadow any completion that is already on screen; the disable-display
+  ;; predicate keeps `copilot-mode' from re-showing one while the suggestion
+  ;; is pending.
+  (copilot-clear-overlay)
   ;; Record point so the post-command hook can detect actual movement
   (setq copilot-nes--last-point (point))
   ;; Notify server that we showed the suggestion

--- a/test/copilot-nes-test.el
+++ b/test/copilot-nes-test.el
@@ -136,6 +136,38 @@
           (expect copilot-nes--move-count :to-equal 0)))))
 
   ;;
+  ;; Shadowing copilot-mode completions
+  ;;
+
+  (describe "copilot-nes--shadow-completion-p"
+    (it "is non-nil while a suggestion is pending"
+      (let ((copilot-nes--edit '(:text "x")))
+        (expect (copilot-nes--shadow-completion-p) :to-be-truthy)))
+
+    (it "is nil when no suggestion is pending"
+      (let ((copilot-nes--edit nil))
+        (expect (copilot-nes--shadow-completion-p) :not :to-be-truthy)))
+
+    (it "is registered as a copilot disable-display predicate"
+      (expect (memq #'copilot-nes--shadow-completion-p
+                    copilot-disable-display-predicates)
+              :to-be-truthy)))
+
+  (describe "copilot-nes--display shadowing"
+    (it "clears a visible copilot completion"
+      (with-temp-buffer
+        (setq-local copilot--line-bias 1)
+        (insert "hello world\n")
+        (let ((edit (list :text "planet"
+                          :range (list :start (list :line 0 :character 6)
+                                       :end (list :line 0 :character 11))
+                          :command nil)))
+          (spy-on 'copilot--notify)
+          (spy-on 'copilot-clear-overlay)
+          (copilot-nes--display edit)
+          (expect 'copilot-clear-overlay :to-have-been-called)))))
+
+  ;;
   ;; Accept
   ;;
 


### PR DESCRIPTION
Follow-up to #478. When a regular `copilot-mode` completion and a NES suggestion want to show at the same time, they overlap on screen and accepting one can garble the other (see #477). This mirrors what the editor does in VSCode: prefer the Next Edit Suggestion and hide the inline completion while it's pending.

- New `copilot-nes--shadow-completion-p` disable-display predicate keeps `copilot-mode` from showing a completion while a NES edit is pending.
- Displaying a NES suggestion clears any completion already on screen.

Per the discussion in #477, there's no opt-out: offering two kinds of completion at once is overwhelming, and nobody has really run NES in production yet, so NES always wins when both would fire.

Refs #477