### PR TITLE
Detect NES-triggering edits via track-changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changes
 
+- NES now detects buffer edits via `track-changes` instead of a hardcoded list of editing commands, so it reacts to edits from any command (including `evil` and other non-listed commands). ([#477](https://github.com/copilot-emacs/copilot.el/issues/477))
 - `copilot-chat` now only attaches the originating buffer as context when it is a file-visiting buffer, so invoking chat from an unrelated buffer (dired, `*scratch*`, etc.) no longer sends it as context. ([#470](https://github.com/copilot-emacs/copilot.el/issues/470))
 
 ### Bug Fixes

--- a/copilot-nes.el
+++ b/copilot-nes.el
@@ -48,6 +48,7 @@
 ;;; Code:
 
 (require 'copilot)
+(require 'track-changes)
 
 (defconst copilot-nes--min-server-version "1.434.0"
   "Minimum copilot-language-server version required for NES support.")
@@ -287,42 +288,36 @@ invocation (or when already at the edit), apply the edit."
 ;; Auto-triggering
 ;;
 
-(defvar copilot-nes--text-changing-commands
-  '(self-insert-command delete-char delete-backward-char
-                        kill-word backward-kill-word kill-line kill-region
-                        yank yank-pop newline newline-and-indent open-line
-                        delete-forward-char delete-indentation join-line
-                        indent-for-tab-command c-electric-brace c-electric-slash
-                        c-electric-semicolon c-electric-paren
-                        ;; Accepting a `copilot-mode' completion edits the
-                        ;; buffer too, which invalidates a pending NES overlay.
-                        copilot-accept-completion
-                        copilot-accept-completion-by-word
-                        copilot-accept-completion-by-line
-                        copilot-accept-completion-by-sentence
-                        copilot-accept-completion-by-paragraph
-                        copilot-accept-completion-up-to-char
-                        copilot-accept-completion-to-char)
-  "Commands considered text-modifying for NES triggering.")
+(defvar-local copilot-nes--track-changes-id nil
+  "Tracker id from `track-changes-register' for this buffer.")
+
+(defun copilot-nes--on-change (id &optional _distance)
+  "Handle a `track-changes' signal for tracker ID.
+Any buffer edit shifts the positions a pending suggestion was drawn at,
+so drop it (e.g. after accepting a `copilot-mode' completion) and
+schedule a fresh request.  This catches every text modification, no
+matter which command produced it."
+  (condition-case err
+      (progn
+        ;; We don't need the change details, but must fetch to re-arm the tracker.
+        (track-changes-fetch id #'ignore)
+        (when copilot-nes--edit
+          (copilot-nes--clear))
+        (copilot-nes--schedule-request))
+    (error
+     (copilot--log 'error "NES change fetch failed: %s"
+                   (error-message-string err)))))
 
 (defun copilot-nes--post-command ()
-  "Hook run after each command in `copilot-nes-mode'."
-  (cond
-   ;; After a text-modifying command, schedule a new request
-   ((memq this-command copilot-nes--text-changing-commands)
-    ;; Any edit shifts the positions a pending suggestion was drawn at, so
-    ;; drop it immediately (e.g. after accepting a `copilot-mode' completion)
-    ;; before requesting a fresh one.
-    (when copilot-nes--edit
-      (copilot-nes--clear))
-    (copilot-nes--schedule-request))
-   ;; When a suggestion is pending and point actually moved, track it
-   (copilot-nes--edit
+  "Auto-dismiss a pending suggestion once point wanders away from it.
+Text edits are handled separately via `track-changes'; this only tracks
+cursor movement, which does not modify the buffer."
+  (when copilot-nes--edit
     (when (and copilot-nes--last-point (/= (point) copilot-nes--last-point))
       (cl-incf copilot-nes--move-count)
       (when (or (>= copilot-nes--move-count copilot-nes-auto-dismiss-move-count)
                 (copilot-nes--too-far-p))
-        (copilot-nes--clear)))))
+        (copilot-nes--clear))))
   (setq copilot-nes--last-point (point)))
 
 (defun copilot-nes--too-far-p ()
@@ -408,9 +403,15 @@ otherwise `copilot-nes-mode' produces no suggestions.
         (run-with-idle-timer 0 nil
                              #'copilot-nes--warn-without-copilot-mode
                              (current-buffer))
+        (unless copilot-nes--track-changes-id
+          (setq copilot-nes--track-changes-id
+                (track-changes-register #'copilot-nes--on-change :nobefore t)))
         (add-hook 'post-command-hook #'copilot-nes--post-command nil t))
     (copilot-nes--cancel-timer)
     (copilot-nes--clear)
+    (when copilot-nes--track-changes-id
+      (track-changes-unregister copilot-nes--track-changes-id)
+      (setq copilot-nes--track-changes-id nil))
     (remove-hook 'post-command-hook #'copilot-nes--post-command t)))
 
 (provide 'copilot-nes)

--- a/test/copilot-nes-test.el
+++ b/test/copilot-nes-test.el
@@ -299,14 +299,25 @@
             (copilot-nes--post-command))
           (expect copilot-nes--edit :to-equal nil))))
 
-    (it "schedules a request after text-modifying commands"
+    (it "does not schedule a request on plain cursor movement"
       (with-temp-buffer
+        (insert "hello\nworld\n")
+        (goto-char (point-min))
         (spy-on 'copilot-nes--schedule-request)
-        (let ((this-command 'self-insert-command))
+        (let ((this-command 'next-line))
+          (forward-line 1)
           (copilot-nes--post-command))
+        (expect 'copilot-nes--schedule-request :not :to-have-been-called))))
+
+  (describe "copilot-nes--on-change"
+    (it "schedules a request after a buffer change"
+      (with-temp-buffer
+        (spy-on 'track-changes-fetch)
+        (spy-on 'copilot-nes--schedule-request)
+        (copilot-nes--on-change 'id)
         (expect 'copilot-nes--schedule-request :to-have-been-called)))
 
-    (it "dismisses a stale suggestion after accepting a copilot completion"
+    (it "clears a stale suggestion before scheduling a fresh request"
       (with-temp-buffer
         (setq-local copilot--line-bias 1)
         (insert "hello\nworld\n")
@@ -316,13 +327,13 @@
                                        :end (list :line 0 :character 1))
                           :command nil)))
           (spy-on 'copilot--notify)
+          (spy-on 'track-changes-fetch)
           (spy-on 'copilot-nes--schedule-request)
           (copilot-nes--display edit)
           (expect copilot-nes--edit :to-be-truthy)
-          ;; Accepting an inline completion edits the buffer and should clear
-          ;; the now-misplaced NES overlay right away.
-          (let ((this-command 'copilot-accept-completion))
-            (copilot-nes--post-command))
+          ;; Any edit (e.g. accepting an inline completion) shifts the overlay
+          ;; out of place, so it should be dropped and a fresh request made.
+          (copilot-nes--on-change 'id)
           (expect copilot-nes--edit :to-equal nil)
           (expect copilot-nes--overlays :to-equal nil)
           (expect 'copilot-nes--schedule-request :to-have-been-called)))))
@@ -371,6 +382,18 @@
         (copilot-nes-mode -1)
         (expect (memq #'copilot-nes--post-command post-command-hook)
                 :not :to-be-truthy)))
+
+    (it "registers a track-changes tracker when enabled"
+      (with-temp-buffer
+        (copilot-nes-mode 1)
+        (expect copilot-nes--track-changes-id :to-be-truthy)
+        (copilot-nes-mode -1)))
+
+    (it "unregisters the track-changes tracker when disabled"
+      (with-temp-buffer
+        (copilot-nes-mode 1)
+        (copilot-nes-mode -1)
+        (expect copilot-nes--track-changes-id :to-equal nil)))
 
     (it "clears state when disabled"
       (with-temp-buffer


### PR DESCRIPTION
`copilot-nes-mode` decided when to refresh a suggestion by matching `this-command` against a hand-maintained `copilot-nes--text-changing-commands` list. That list inevitably missed editing commands it didn't know about (evil's operators, custom commands, anything from other packages), so those edits left a stale suggestion on screen and never triggered a fresh request. This is the root cause raised in #477.

Register a `track-changes` tracker instead, the same mechanism `copilot-mode` already uses for `textDocument/didChange`. Any buffer edit now drops the pending suggestion and schedules a new request, no matter which command produced it. `post-command-hook` is left to do only the cursor-movement auto-dismiss, since motion doesn't modify the buffer.

One intended side effect: accepting a suggestion now schedules the next one (applying the edit is itself a buffer change), which matches the editor's chained-edit behaviour.

Refs #477