### PR TITLE
Fix agent-mode tool confirmations rejected by the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug Fixes
+
+- Fix agent-mode tool confirmations always failing (so Copilot Chat couldn't read files, edit, etc.) by returning the `(:result "accept")`/`(:result "dismiss")` shape the server expects instead of a bare string. ([#483](https://github.com/copilot-emacs/copilot.el/issues/483))
+
 ## 0.6.0 (2026-06-22)
 
 ### New Features

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -262,15 +262,15 @@ approving without seeing a raw plist dump."
 
 (defun copilot-chat--handle-tool-confirmation (msg)
   "Handle `conversation/invokeClientToolConfirmation' request MSG.
-Return \"Accept\" or \"Dismiss\" based on user confirmation."
+Return a result plist the server accepts: (:result \"accept\") to allow
+the tool call or (:result \"dismiss\") to decline it."
   (let ((name (plist-get msg :name))
         (input (plist-get msg :input)))
-    (if (member name copilot-chat-auto-approve-tools)
-        "Accept"
-      (if (yes-or-no-p (format "Copilot wants to %s.  Allow? "
-                               (copilot-chat--tool-summary name input)))
-          "Accept"
-        "Dismiss"))))
+    (if (or (member name copilot-chat-auto-approve-tools)
+            (yes-or-no-p (format "Copilot wants to %s.  Allow? "
+                                 (copilot-chat--tool-summary name input))))
+        (list :result "accept")
+      (list :result "dismiss"))))
 
 (copilot-on-request 'conversation/invokeClientToolConfirmation
                     #'copilot-chat--handle-tool-confirmation)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -563,7 +563,7 @@
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "get_errors"
                        :input (list :filePaths ["foo.el"])))
-                :to-equal "Accept")))
+                :to-equal '(:result "accept"))))
 
     (it "prompts for tools not in auto-approve list"
       (let ((copilot-chat-auto-approve-tools '("get_errors")))
@@ -571,16 +571,16 @@
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "run_in_terminal"
                        :input (list :command "ls")))
-                :to-equal "Accept")
+                :to-equal '(:result "accept"))
         (expect 'yes-or-no-p :to-have-been-called)))
 
-    (it "returns Dismiss when user declines"
+    (it "dismisses when user declines"
       (let ((copilot-chat-auto-approve-tools nil))
         (spy-on 'yes-or-no-p :and-return-value nil)
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "run_in_terminal"
                        :input (list :command "rm -rf /")))
-                :to-equal "Dismiss")))
+                :to-equal '(:result "dismiss"))))
 
     (it "summarizes the tool in the confirmation prompt"
       (let ((copilot-chat-auto-approve-tools nil)


### PR DESCRIPTION
Agent-mode chat could never read files, edit, or run any server-side tool that needs confirmation. After answering "yes" the model would report something like "It looks like you've skipped the file read."

The confirmation handler returned a bare string (`"Accept"`/`"Dismiss"`), but the language server validates the response against an object schema `{result: "accept"|"dismiss"}`. The bare string failed validation, the server logged a `ResponseError` (`-32001`), and treated every confirmation as a non-acceptance. We now return the `(:result "accept")`/`(:result "dismiss")` plist the server expects.

The existing tests passed only because they asserted the wrong contract, so they're updated here too.

Fixes #483
