### PR TITLE
Improve agent-mode tool confirmation prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Changes
+
+- Show readable agent-mode confirmation prompts for the server's own tools (`read_file`, `insert_edit_into_file`, `replace_string_in_file`, etc.) instead of a raw plist dump, falling back to the server-provided message, then the raw input, for any tool we don't recognize. `copilot-chat-auto-approve-tools` is matched exactly so it never auto-approves a same-named tool from a different namespace.
+
 ### Bug Fixes
 
 - Fix agent-mode tool confirmations always failing (so Copilot Chat couldn't read files, edit, etc.) by returning the `(:result "accept")`/`(:result "dismiss")` shape the server expects instead of a bare string. ([#483](https://github.com/copilot-emacs/copilot.el/issues/483))

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -69,7 +69,14 @@ and file edits."
 Only read-only, local tools should be auto-approved.  Tools that run
 shell commands, modify files, or reach the network (e.g.
 `fetch_web_page') are intentionally excluded so they always prompt
-for confirmation."
+for confirmation.
+
+Names are matched exactly, and auto-approval bypasses confirmation
+completely, including the server's own prompts for sensitive files, so
+add an entry only for a tool you fully trust.  The server's built-in
+tools are reported with a namespace prefix (e.g. \"copilot.read_file\"
+for the read-only file reader); an entry must include that prefix to
+match."
   :type '(repeat string)
   :group 'copilot-chat
   :package-version '(copilot . "0.6"))
@@ -243,34 +250,87 @@ Return editor context for the requested skill."
                               'face 'copilot-chat-tool-face))
           (copilot-chat--scroll-to-bottom))))))
 
+(defun copilot-chat--tool-base-name (name)
+  "Return tool NAME stripped of any server namespace prefix.
+The server's built-in tools may arrive qualified (e.g.
+\"copilot.read_file\"), while the client tools we register are
+unqualified.  Matching on the base name handles both forms."
+  (if (and (stringp name) (string-match "\\.\\([^.]+\\)\\'" name))
+      (match-string 1 name)
+    name))
+
 (defun copilot-chat--tool-summary (name input)
   "Return a concise, human-readable summary of tool NAME with INPUT.
-Used in confirmation prompts so the user can tell what they are
-approving without seeing a raw plist dump."
-  (pcase name
+Return nil for tools we have no tailored summary for, so callers can
+fall back to the server-provided confirmation message."
+  (pcase (copilot-chat--tool-base-name name)
     ("run_in_terminal"
      (format "run shell command: %s" (plist-get input :command)))
     ("create_file"
      (format "create file: %s" (plist-get input :filePath)))
+    ("read_file"
+     (format "read file: %s" (plist-get input :filePath)))
+    ("insert_edit_into_file"
+     (let ((path (plist-get input :filePath))
+           (explanation (plist-get input :explanation)))
+       (if (and (stringp explanation) (not (string-empty-p explanation)))
+           (format "edit file %s: %s" path explanation)
+         (format "edit file: %s" path))))
+    ("replace_string_in_file"
+     (format "edit file: %s" (plist-get input :filePath)))
     ("fetch_web_page"
      (format "fetch: %s"
              (string-join (append (plist-get input :urls) nil) ", ")))
     ("get_errors"
      (format "read diagnostics for: %s"
              (string-join (append (plist-get input :filePaths) nil) ", ")))
-    (_ (format "%s with input %S" name input))))
+    (_ nil)))
+
+(defun copilot-chat--confirmation-prompt (msg)
+  "Return the yes-or-no prompt string for confirmation request MSG.
+Prefer a tailored summary of the tool, then the server-provided message
+or title, and finally the tool name with its raw input so the user can
+still tell what they are approving."
+  (let* ((name (plist-get msg :name))
+         (input (plist-get msg :input))
+         (summary (copilot-chat--tool-summary name input))
+         (message (plist-get msg :message))
+         (title (plist-get msg :title))
+         (base (copilot-chat--tool-base-name name)))
+    (cond
+     (summary
+      (format "Copilot wants to %s.  Allow? " summary))
+     ((and (stringp message) (not (string-empty-p message)))
+      (format "%s  Allow? " message))
+     ((and (stringp title) (not (string-empty-p title)))
+      (format "%s  Allow? " title))
+     ((and (stringp base) (not (string-empty-p base)) input)
+      (format "Copilot wants to run %s with input %S.  Allow? " base input))
+     ((and (stringp base) (not (string-empty-p base)))
+      (format "Copilot wants to run %s.  Allow? " base))
+     (input
+      (format "Copilot wants to run a tool with input %S.  Allow? " input))
+     (t
+      "Copilot wants to run a tool.  Allow? "))))
+
+(defun copilot-chat--tool-auto-approved-p (name)
+  "Return non-nil when tool NAME is listed in `copilot-chat-auto-approve-tools'.
+Matching is exact.  Auto-approval bypasses confirmation entirely
+\(including the server's own prompts for sensitive files), so a tool is
+auto-approved only when its full reported name is listed, never a
+namespace-stripped variant."
+  (and (stringp name)
+       (member name copilot-chat-auto-approve-tools)
+       t))
 
 (defun copilot-chat--handle-tool-confirmation (msg)
   "Handle `conversation/invokeClientToolConfirmation' request MSG.
 Return a result plist the server accepts: (:result \"accept\") to allow
 the tool call or (:result \"dismiss\") to decline it."
-  (let ((name (plist-get msg :name))
-        (input (plist-get msg :input)))
-    (if (or (member name copilot-chat-auto-approve-tools)
-            (yes-or-no-p (format "Copilot wants to %s.  Allow? "
-                                 (copilot-chat--tool-summary name input))))
-        (list :result "accept")
-      (list :result "dismiss"))))
+  (if (or (copilot-chat--tool-auto-approved-p (plist-get msg :name))
+          (yes-or-no-p (copilot-chat--confirmation-prompt msg)))
+      (list :result "accept")
+    (list :result "dismiss")))
 
 (copilot-on-request 'conversation/invokeClientToolConfirmation
                     #'copilot-chat--handle-tool-confirmation)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -590,7 +590,57 @@
         (copilot-chat--handle-tool-confirmation
          (list :name "run_in_terminal" :input (list :command "make test")))
         ;; The raw command shows, not a plist dump.
-        (expect prompt :to-match "run shell command: make test"))))
+        (expect prompt :to-match "run shell command: make test")))
+
+    (it "auto-approves a server tool listed by its full name"
+      (let ((copilot-chat-auto-approve-tools '("copilot.read_file")))
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "copilot.read_file"
+                       :input (list :filePath "/tmp/x.el")))
+                :to-equal '(:result "accept"))))
+
+    (it "does not auto-approve a namespaced tool by its base name alone"
+      (let ((copilot-chat-auto-approve-tools '("read_file")))
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "copilot.read_file"
+                       :input (list :filePath "/tmp/x.el")))
+                :to-equal '(:result "dismiss"))
+        (expect 'yes-or-no-p :to-have-been-called)))
+
+    (it "falls back to the server message for unknown tools"
+      (let ((copilot-chat-auto-approve-tools nil)
+            (prompt nil))
+        (spy-on 'yes-or-no-p :and-call-fake
+                (lambda (msg) (setq prompt msg) nil))
+        (copilot-chat--handle-tool-confirmation
+         (list :name "copilot.some_new_tool"
+               :input (list :foo "bar")
+               :message "Allow the new tool to run?"))
+        ;; No plist dump: the server-provided message is shown verbatim.
+        (expect prompt :to-match "Allow the new tool to run?")
+        (expect prompt :not :to-match ":foo")))
+
+    (it "shows the raw input when no summary or server message exists"
+      (let ((copilot-chat-auto-approve-tools nil)
+            (prompt nil))
+        (spy-on 'yes-or-no-p :and-call-fake
+                (lambda (msg) (setq prompt msg) nil))
+        (copilot-chat--handle-tool-confirmation
+         (list :name "copilot.mystery_tool"
+               :input (list :command "rm -rf /")))
+        ;; The user can still see what is being approved.
+        (expect prompt :to-match "mystery_tool")
+        (expect prompt :to-match "rm -rf /")))
+
+    (it "prompts sensibly when the request has no tool name"
+      (let ((copilot-chat-auto-approve-tools nil)
+            (prompt nil))
+        (spy-on 'yes-or-no-p :and-call-fake
+                (lambda (msg) (setq prompt msg) nil))
+        (copilot-chat--handle-tool-confirmation (list :input nil))
+        ;; No stray "nil" leaks into the prompt.
+        (expect prompt :not :to-match "run nil"))))
 
   ;;
   ;; Tool summary
@@ -610,7 +660,34 @@
     (it "joins multiple fetch URLs"
       (expect (copilot-chat--tool-summary
                "fetch_web_page" (list :urls ["https://a.com" "https://b.com"]))
-              :to-equal "fetch: https://a.com, https://b.com")))
+              :to-equal "fetch: https://a.com, https://b.com"))
+
+    (it "describes reading a server file by path"
+      (expect (copilot-chat--tool-summary
+               "read_file" (list :filePath "/tmp/x.el" :offset 1 :limit 50))
+              :to-equal "read file: /tmp/x.el"))
+
+    (it "describes a namespaced server tool by its base name"
+      (expect (copilot-chat--tool-summary
+               "copilot.read_file" (list :filePath "/tmp/x.el"))
+              :to-equal "read file: /tmp/x.el"))
+
+    (it "includes the explanation when editing a file"
+      (expect (copilot-chat--tool-summary
+               "insert_edit_into_file"
+               (list :filePath "/tmp/x.el" :explanation "add error handling"))
+              :to-equal "edit file /tmp/x.el: add error handling"))
+
+    (it "describes a string replacement edit by path"
+      (expect (copilot-chat--tool-summary
+               "replace_string_in_file"
+               (list :filePath "/tmp/x.el" :oldString "a" :newString "b"))
+              :to-equal "edit file: /tmp/x.el"))
+
+    (it "returns nil for tools without a tailored summary"
+      (expect (copilot-chat--tool-summary
+               "copilot.some_new_tool" (list :foo "bar"))
+              :to-be nil)))
 
   ;;
   ;; Tool invocation dispatch


### PR DESCRIPTION
Follow-up to #483. Now that agent-mode confirmations actually work, the most common tools hitting them (`read_file`, `insert_edit_into_file`, `replace_string_in_file`) are server built-ins that fell through to a raw plist dump in the prompt.

This adds tailored summaries for them, and for anything we don't recognize falls back to the server's own message, then the tool name plus its raw input, so you can always see what you're approving. `copilot-chat-auto-approve-tools` is matched exactly on purpose: auto-approval skips even the server's sensitive-file prompts, so it must never approve a same-named tool from a different namespace.
