### PR TITLE
Resolve a default chat model when none is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug Fixes
+
+- Resolve a concrete default chat model from the server when `copilot-chat-model` is nil (preferring the server's designated chat default, then an `auto` model) instead of leaving the model unset, which some servers answer with an empty reply. The lookup runs once per session, only against an already-running server. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))
+
 ### Changes
 
 - Show readable agent-mode confirmation prompts for the server's own tools (`read_file`, `insert_edit_into_file`, `replace_string_in_file`, etc.) instead of a raw plist dump, falling back to the server-provided message, then the raw input, for any tool we don't recognize. `copilot-chat-auto-approve-tools` is matched exactly so it never auto-approves a same-named tool from a different namespace.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Key bindings in the `*copilot-chat*` buffer:
 - **q** — quit the chat window
 
 Customization:
-- **`copilot-chat-model`** — model to use for chat (default `nil`, meaning server default)
+- **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)
 
 > [!TIP]
 >
@@ -590,7 +590,10 @@ GitHub only offers a single completion model (`gpt-41-copilot`).
 
 To select a chat model, run `M-x copilot-chat-select-model`. Many more models
 are available for chat (Claude, Gemini, GPT-4o, etc.). The selection is saved
-in `copilot-chat-model`.
+in `copilot-chat-model`. When that is left at `nil`, copilot.el resolves a
+default from the server (its designated chat default, or an `auto` model)
+rather than leaving the model unset, which some servers answer with an empty
+reply.
 
 ## Reporting Bugs
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -50,7 +50,9 @@
 
 (defcustom copilot-chat-model nil
   "The model to use for Copilot Chat.
-When nil, the server picks the default model."
+When nil, a default chat model is resolved from the server (preferring
+its designated chat default, then an `auto' model).  Use
+`copilot-chat-select-model' to choose one interactively."
   :type '(choice (const :tag "Default" nil)
                  (string :tag "Model ID"))
   :group 'copilot-chat
@@ -136,6 +138,63 @@ which may be slightly after `copilot-chat--request-id' is set.")
 
 (defconst copilot-chat--buffer-name "*copilot-chat*"
   "Name of the Copilot Chat buffer.")
+
+;;
+;; Model selection
+;;
+
+(defvar copilot-chat--resolved-model nil
+  "Cached default chat model id resolved from the server, or nil.
+Only meaningful once `copilot-chat--model-resolved' is non-nil.")
+
+(defvar copilot-chat--model-resolved nil
+  "Non-nil once a default chat model has been resolved this session.
+Tracked separately from `copilot-chat--resolved-model' so that a nil
+result (no usable default) is cached too and not re-queried on every
+message.")
+
+(defun copilot-chat--chat-models ()
+  "Return the models the server scopes for the chat panel."
+  (seq-filter (lambda (m)
+                (seq-contains-p (plist-get m :scopes) "chat-panel"))
+              (copilot--request 'copilot/models nil :timeout 5)))
+
+(defun copilot-chat--resolve-default-model ()
+  "Query the server for a default chat model id, or nil.
+Prefer the model the server marks as the chat default, then an `auto'
+model, then the first available chat model."
+  (condition-case err
+      (let ((models (copilot-chat--chat-models)))
+        (or (plist-get (seq-find (lambda (m)
+                                   (eq (plist-get m :isChatDefault) t))
+                                 models)
+                       :id)
+            ;; "auto" is the server's catch-all router model; it has no
+            ;; dedicated flag, so match it by its stable id.
+            (plist-get (seq-find (lambda (m)
+                                   (equal (plist-get m :id) "auto"))
+                                 models)
+                       :id)
+            (plist-get (car models) :id)))
+    (error
+     (copilot--log 'warn "Could not resolve a default chat model: %S" err)
+     nil)))
+
+(defun copilot-chat--default-model ()
+  "Return a server-resolved default chat model id, or nil.
+The server is queried at most once per session, and only when the
+connection is already up so chat never blocks on starting it.  The
+result, including nil, is cached."
+  (when (and (not copilot-chat--model-resolved)
+             (copilot--connection-alivep))
+    (setq copilot-chat--resolved-model (copilot-chat--resolve-default-model)
+          copilot-chat--model-resolved t))
+  copilot-chat--resolved-model)
+
+(defun copilot-chat--model ()
+  "Return the chat model id to send to the server.
+Use `copilot-chat-model' when set, otherwise a server-resolved default."
+  (or copilot-chat-model (copilot-chat--default-model)))
 
 ;;
 ;; Internal helpers
@@ -521,8 +580,8 @@ CALLBACK is called with the response containing conversationId and turnId."
                    :capabilities (list :skills (vector "current-editor")
                                        :allSkills t)
                    :source "panel")
-             (when copilot-chat-model
-               (list :model copilot-chat-model))
+             (when-let* ((model (copilot-chat--model)))
+               (list :model model))
              (list :workspaceFolders
                    (vconcat
                     (when-let* ((root (copilot--workspace-root)))
@@ -766,18 +825,16 @@ If not currently streaming, reset the conversation instead."
 (defun copilot-chat-select-model ()
   "Interactively select a Copilot Chat model."
   (interactive)
-  (let* ((models (copilot--request 'copilot/models nil))
-         (chat-models
-          (seq-filter (lambda (m)
-                        (seq-contains-p (plist-get m :scopes) "chat-panel"))
-                      models))
-         (choices (mapcar (lambda (m)
+  (let* ((choices (mapcar (lambda (m)
                             (cons (format "%s (%s)" (plist-get m :modelName) (plist-get m :id))
                                   (plist-get m :id)))
-                          chat-models))
+                          (copilot-chat--chat-models)))
          (choice (completing-read "Chat model: " choices nil t))
          (model-id (cdr (assoc choice choices))))
-    (setq copilot-chat-model model-id)
+    (setq copilot-chat-model model-id
+          ;; Forget any cached default so clearing the model later
+          ;; re-resolves from the server.
+          copilot-chat--model-resolved nil)
     (message "Chat model set to %s" model-id)))
 
 (provide 'copilot-chat)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -10,6 +10,14 @@
 (require 'copilot-chat)
 
 (describe "copilot-chat"
+  ;; Resolving a default model issues a synchronous request; keep it from
+  ;; reaching the (absent) server during specs that don't care about it.
+  ;; Specs that exercise resolution override this spy.
+  (before-each
+    (setq copilot-chat--resolved-model nil
+          copilot-chat--model-resolved nil)
+    (spy-on 'jsonrpc-request :and-return-value nil))
+
   (describe "loading"
     (it "provides the copilot-chat feature"
       (expect (featurep 'copilot-chat) :to-be-truthy)))
@@ -464,7 +472,7 @@
               (expect (plist-get captured-params :model) :to-equal "gpt-4o"))
           (kill-buffer buf))))
 
-    (it "omits model when copilot-chat-model is nil"
+    (it "sends a server-resolved default when copilot-chat-model is nil"
       (let ((captured-params nil)
             (copilot-chat-model nil)
             (buf (get-buffer-create copilot-chat--buffer-name)))
@@ -472,6 +480,26 @@
             (progn
               (with-current-buffer buf
                 (copilot-chat-mode))
+              (spy-on 'copilot-chat--default-model :and-return-value "auto")
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-get captured-params :model) :to-equal "auto"))
+          (kill-buffer buf))))
+
+    (it "omits model when no default can be resolved"
+      (let ((captured-params nil)
+            (copilot-chat-model nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot-chat--default-model :and-return-value nil)
               (spy-on 'copilot--connection-alivep :and-return-value t)
               (spy-on 'jsonrpc--async-request-1
                       :and-call-fake
@@ -481,6 +509,50 @@
               (copilot-chat--create "hello" #'ignore)
               (expect (plist-member captured-params :model) :not :to-be-truthy))
           (kill-buffer buf)))))
+
+  ;;
+  ;; Default model resolution
+  ;;
+
+  (describe "copilot-chat--default-model"
+    (before-each
+      (setq copilot-chat--resolved-model nil
+            copilot-chat--model-resolved nil)
+      (spy-on 'copilot--connection-alivep :and-return-value t))
+
+    (it "prefers the server-designated chat default"
+      (spy-on 'copilot-chat--chat-models :and-return-value
+              (list (list :id "gpt-4o" :isChatDefault :json-false)
+                    (list :id "claude" :isChatDefault t)
+                    (list :id "auto")))
+      (expect (copilot-chat--default-model) :to-equal "claude"))
+
+    (it "falls back to the auto model when no chat default is marked"
+      (spy-on 'copilot-chat--chat-models :and-return-value
+              (list (list :id "gpt-4o" :isChatDefault :json-false)
+                    (list :id "auto" :isChatDefault :json-false)))
+      (expect (copilot-chat--default-model) :to-equal "auto"))
+
+    (it "falls back to the first chat model otherwise"
+      (spy-on 'copilot-chat--chat-models :and-return-value
+              (list (list :id "gpt-4o") (list :id "gemini")))
+      (expect (copilot-chat--default-model) :to-equal "gpt-4o"))
+
+    (it "returns nil when the model list is unavailable"
+      (spy-on 'copilot-chat--chat-models :and-throw-error 'error)
+      (expect (copilot-chat--default-model) :to-be nil))
+
+    (it "does not query the server when the connection is down"
+      (spy-on 'copilot--connection-alivep :and-return-value nil)
+      (spy-on 'copilot-chat--chat-models)
+      (expect (copilot-chat--default-model) :to-be nil)
+      (expect 'copilot-chat--chat-models :not :to-have-been-called))
+
+    (it "caches the result, including nil, and queries the server once"
+      (spy-on 'copilot-chat--chat-models :and-return-value nil)
+      (copilot-chat--default-model)
+      (copilot-chat--default-model)
+      (expect 'copilot-chat--chat-models :to-have-been-called-times 1)))
 
   ;;
   ;; Streaming cancellation


### PR DESCRIPTION
Addresses the main complaint in #473: with `copilot-chat-model` left at nil, copilot.el sent no model and relied on the server's implicit default, which some servers answer with an empty reply.

Now we resolve a concrete default from `copilot/models` (the server's designated chat default, then an `auto` model, then the first chat model). The lookup runs at most once per session, caches its result (nil included), only fires against an already-running server, and is bounded by a short timeout so chat never blocks on startup.

This handles the default-model part of #473; the indentation warning and the "no subsequent answers" report in that issue are separate and left open.
