### PR TITLE
Preview file changes before confirming agent edit tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### New Features
+
+- Preview file changes in a temporary buffer before confirming an agent-mode edit tool (`create_file`, `insert_edit_into_file`, `replace_string_in_file`), so you can see what will be written before approving. Controlled by `copilot-chat-preview-tool-edits` (default on).
+
 ### Bug Fixes
 
 - Resolve a concrete default chat model from the server when `copilot-chat-model` is nil (preferring the server's designated chat default, then an `auto` model) instead of leaving the model unset, which some servers answer with an empty reply. The lookup runs once per session, only against an already-running server. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Key bindings in the `*copilot-chat*` buffer:
 
 Customization:
 - **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)
+- **`copilot-chat-preview-tool-edits`** — in agent mode, preview file changes in a temporary buffer before you confirm an edit tool (default `t`)
 
 > [!TIP]
 >

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -83,6 +83,16 @@ match."
   :group 'copilot-chat
   :package-version '(copilot . "0.6"))
 
+(defcustom copilot-chat-preview-tool-edits t
+  "When non-nil, preview file changes before confirming an edit tool.
+For the tools that create or edit files (`create_file',
+`insert_edit_into_file', `replace_string_in_file') the proposed change
+is shown in a temporary buffer while you are asked to approve it, so
+you can see what will be written before answering."
+  :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.7"))
+
 (defface copilot-chat-error-face
   '((t :inherit error))
   "Face for error messages in the chat buffer."
@@ -96,6 +106,16 @@ match."
 (defface copilot-chat-tool-face
   '((t :inherit font-lock-preprocessor-face))
   "Face for tool invocation lines in the chat buffer."
+  :group 'copilot-chat)
+
+(defface copilot-chat-diff-added-face
+  '((t :inherit diff-added))
+  "Face for added lines in a tool edit preview."
+  :group 'copilot-chat)
+
+(defface copilot-chat-diff-removed-face
+  '((t :inherit diff-removed))
+  "Face for removed lines in a tool edit preview."
   :group 'copilot-chat)
 
 ;;
@@ -382,12 +402,89 @@ namespace-stripped variant."
        (member name copilot-chat-auto-approve-tools)
        t))
 
+(defconst copilot-chat--tool-preview-buffer-name "*copilot-chat-tool-preview*"
+  "Name of the buffer used to preview a pending tool edit.")
+
+(defun copilot-chat--diff-lines (text prefix face)
+  "Prefix each line of TEXT with PREFIX and propertize it with FACE."
+  (mapconcat (lambda (line)
+               (propertize (concat prefix line) 'face face))
+             (split-string (or text "") "\n")
+             "\n"))
+
+(defun copilot-chat--tool-preview (name input)
+  "Return a textual preview of the change NAME with INPUT will make.
+Return nil for tools that do not write files."
+  (pcase (copilot-chat--tool-base-name name)
+    ("create_file"
+     (format "Create %s:\n\n%s"
+             (plist-get input :filePath)
+             (copilot-chat--diff-lines (plist-get input :content)
+                                       "+" 'copilot-chat-diff-added-face)))
+    ("insert_edit_into_file"
+     ;; The :code here is the model's edit snippet, not the resulting
+     ;; file: it uses "...existing code..." markers for the regions it
+     ;; leaves untouched.  Frame it as such rather than implying it is
+     ;; the literal content that will be written.
+     (let ((explanation (plist-get input :explanation)))
+       (concat (format "Edit %s" (plist-get input :filePath))
+               (when (and (stringp explanation) (not (string-empty-p explanation)))
+                 (format "\n%s" explanation))
+               "\n\nProposed edit (\"...existing code...\" marks unchanged regions):\n\n"
+               (or (plist-get input :code) ""))))
+    ("replace_string_in_file"
+     (let ((old (plist-get input :oldString))
+           (new (plist-get input :newString)))
+       (concat (format "Edit %s\n\n" (plist-get input :filePath))
+               ;; Omit an empty side so a pure insertion or deletion does
+               ;; not render a misleading bare "-"/"+" line.
+               (when (and (stringp old) (not (string-empty-p old)))
+                 (concat (copilot-chat--diff-lines
+                          old "-" 'copilot-chat-diff-removed-face)
+                         "\n"))
+               (when (and (stringp new) (not (string-empty-p new)))
+                 (copilot-chat--diff-lines
+                  new "+" 'copilot-chat-diff-added-face)))))
+    (_ nil)))
+
+(defun copilot-chat--confirm-with-preview (msg preview)
+  "Show PREVIEW in a temporary window, then prompt to confirm MSG.
+Return non-nil when the user approves.  The preview buffer is removed
+afterwards."
+  ;; A fresh buffer per call, so an overlapping confirmation can't erase
+  ;; or kill the preview out from under this prompt.
+  (let ((buf (generate-new-buffer copilot-chat--tool-preview-buffer-name)))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (insert preview)
+            (goto-char (point-min))
+            (setq buffer-read-only t))
+          (display-buffer buf '((display-buffer-pop-up-window
+                                 display-buffer-use-some-window)
+                                (window-height . fit-window-to-buffer)))
+          (yes-or-no-p (copilot-chat--confirmation-prompt msg)))
+      (when-let* ((win (get-buffer-window buf)))
+        (quit-window nil win))
+      (kill-buffer buf))))
+
+(defun copilot-chat--confirm-tool (msg)
+  "Ask the user whether to allow the tool described by MSG.
+Show a preview of the change first when `copilot-chat-preview-tool-edits'
+is enabled and the tool writes files.  Return non-nil on approval."
+  (let ((preview (and copilot-chat-preview-tool-edits
+                      (copilot-chat--tool-preview (plist-get msg :name)
+                                                  (plist-get msg :input)))))
+    (if preview
+        (copilot-chat--confirm-with-preview msg preview)
+      (yes-or-no-p (copilot-chat--confirmation-prompt msg)))))
+
 (defun copilot-chat--handle-tool-confirmation (msg)
   "Handle `conversation/invokeClientToolConfirmation' request MSG.
 Return a result plist the server accepts: (:result \"accept\") to allow
 the tool call or (:result \"dismiss\") to decline it."
   (if (or (copilot-chat--tool-auto-approved-p (plist-get msg :name))
-          (yes-or-no-p (copilot-chat--confirmation-prompt msg)))
+          (copilot-chat--confirm-tool msg))
       (list :result "accept")
     (list :result "dismiss")))
 

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -762,6 +762,86 @@
               :to-be nil)))
 
   ;;
+  ;; Tool edit preview
+  ;;
+
+  (describe "copilot-chat--tool-preview"
+    (it "previews a file creation with its content"
+      (let ((preview (copilot-chat--tool-preview
+                      "create_file"
+                      (list :filePath "/tmp/x.el" :content "line1\nline2"))))
+        (expect preview :to-match "Create /tmp/x.el")
+        (expect preview :to-match "\\+line1")
+        (expect preview :to-match "\\+line2")))
+
+    (it "previews an edit with explanation and code"
+      (let ((preview (copilot-chat--tool-preview
+                      "copilot.insert_edit_into_file"
+                      (list :filePath "/tmp/x.el"
+                            :explanation "add guard"
+                            :code "(when x y)"))))
+        (expect preview :to-match "Edit /tmp/x.el")
+        (expect preview :to-match "add guard")
+        (expect preview :to-match "(when x y)")))
+
+    (it "previews a string replacement as a diff"
+      (let ((preview (copilot-chat--tool-preview
+                      "replace_string_in_file"
+                      (list :filePath "/tmp/x.el"
+                            :oldString "old" :newString "new"))))
+        (expect preview :to-match "-old")
+        (expect preview :to-match "\\+new")))
+
+    (it "omits the removed side for a pure insertion"
+      (let ((preview (copilot-chat--tool-preview
+                      "replace_string_in_file"
+                      (list :filePath "/tmp/x.el"
+                            :oldString "" :newString "added"))))
+        (expect preview :to-match "\\+added")
+        ;; No misleading lone "-" line for an empty old string.
+        (expect preview :not :to-match "^-")))
+
+    (it "returns nil for read-only and unknown tools"
+      (expect (copilot-chat--tool-preview
+               "copilot.read_file" (list :filePath "/tmp/x.el"))
+              :to-be nil)
+      (expect (copilot-chat--tool-preview
+               "run_in_terminal" (list :command "ls"))
+              :to-be nil)))
+
+  (describe "tool confirmation preview"
+    (it "shows a preview buffer when approving an edit tool"
+      (let ((copilot-chat-preview-tool-edits t)
+            (shown nil))
+        (spy-on 'yes-or-no-p :and-call-fake
+                (lambda (&rest _)
+                  (setq shown (get-buffer "*copilot-chat-tool-preview*"))
+                  t))
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "create_file"
+                       :input (list :filePath "/tmp/x.el" :content "hi")))
+                :to-equal '(:result "accept"))
+        ;; The preview buffer existed during the prompt...
+        (expect shown :to-be-truthy)
+        ;; ...and is cleaned up afterwards.
+        (expect (get-buffer "*copilot-chat-tool-preview*") :to-be nil)))
+
+    (it "skips the preview when copilot-chat-preview-tool-edits is nil"
+      (let ((copilot-chat-preview-tool-edits nil))
+        (spy-on 'yes-or-no-p :and-return-value t)
+        (copilot-chat--handle-tool-confirmation
+         (list :name "create_file"
+               :input (list :filePath "/tmp/x.el" :content "hi")))
+        (expect (get-buffer "*copilot-chat-tool-preview*") :to-be nil)))
+
+    (it "does not preview non-editing tools"
+      (let ((copilot-chat-preview-tool-edits t))
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (copilot-chat--handle-tool-confirmation
+         (list :name "run_in_terminal" :input (list :command "ls")))
+        (expect (get-buffer "*copilot-chat-tool-preview*") :to-be nil))))
+
+  ;;
   ;; Tool invocation dispatch
   ;;
 


### PR DESCRIPTION
Now that agent-mode confirmations are readable (#485), this adds a preview so you can see what a file-writing tool will do before approving it. When `create_file`, `insert_edit_into_file`, or `replace_string_in_file` asks for confirmation, the proposed change pops up in a temporary buffer alongside the prompt. String replacements render as a colorized diff; the `insert_edit_into_file` snippet is clearly framed since it uses `...existing code...` markers rather than literal file content.

Controlled by `copilot-chat-preview-tool-edits` (on by default). Other tools (terminal, reads, web fetches) keep the plain prompt.
