### PR TITLE
Add MCP server support for agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Add MCP (Model Context Protocol) server support for agent mode via the new `copilot-mcp-servers` option. Configured servers are forwarded to the language server and their tools become available in `copilot-chat`, each prompting for confirmation like the built-in tools.
 - Preview file changes in a temporary buffer before confirming an agent-mode edit tool (`create_file`, `insert_edit_into_file`, `replace_string_in_file`), so you can see what will be written before approving. Controlled by `copilot-chat-preview-tool-edits` (default on).
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -234,11 +234,28 @@ Key bindings in the `*copilot-chat*` buffer:
 
 Customization:
 - **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)
+- **`copilot-chat-use-agent-mode`** — let Copilot run tools (shell commands, file edits, reads, etc.) during a chat (default `nil`)
 - **`copilot-chat-preview-tool-edits`** — in agent mode, preview file changes in a temporary buffer before you confirm an edit tool (default `t`)
+- **`copilot-chat-auto-approve-tools`** — tool names that skip the confirmation prompt (default `'("get_errors")`)
 
 > [!TIP]
 >
 > Install [`markdown-mode`](https://github.com/jrblevin/markdown-mode) for rich markdown rendering (headings, code blocks, emphasis, etc.) in the chat buffer. Without it, only basic highlighting is used.
+
+#### MCP servers
+
+When agent mode is enabled, you can extend Copilot with [Model Context Protocol](https://modelcontextprotocol.io) servers. Set `copilot-mcp-servers` to a map of server name to definition and copilot.el forwards it to the language server, whose tools then become available in the chat. Each invocation still prompts for confirmation unless listed in `copilot-chat-auto-approve-tools`.
+
+```elisp
+(setopt copilot-mcp-servers
+        '(:fetch (:command "uvx" :args ["mcp-server-fetch"])
+          :memory (:command "npx"
+                   :args ["-y" "@modelcontextprotocol/server-memory"])
+          :remote (:type "http" :url "https://example.com/mcp/"
+                   :headers (:Authorization "Bearer TOKEN"))))
+```
+
+A server with a `:command` is launched locally over stdio; one with a `:type` of `"http"` or `"sse"` is reached at its `:url`. The value is serialized to JSON, so list-valued fields like `:args` must be vectors. Use `setopt` (or `customize`) so a running server picks up the change.
 
 For a more feature-rich chat experience, take a look at [copilot-chat.el](https://github.com/chep/copilot-chat.el).
 

--- a/copilot.el
+++ b/copilot.el
@@ -234,6 +234,33 @@ from available models."
   :group 'copilot
   :package-version '(copilot . "0.4"))
 
+(defcustom copilot-mcp-servers nil
+  "Model Context Protocol servers to expose to Copilot agent mode.
+The value is a map from server name to its definition, sent to the
+language server so its tools become available in `copilot-chat' agent
+mode (see `copilot-chat-use-agent-mode').  Each tool invocation still
+prompts for confirmation unless auto-approved.
+
+The map is most naturally written as a plist keyed by server name.  A
+stdio server is launched from a command; an HTTP or SSE server is
+reached at a URL:
+
+  \\='(:fetch (:command \"uvx\" :args [\"mcp-server-fetch\"])
+    :memory (:command \"npx\"
+             :args [\"-y\" \"@modelcontextprotocol/server-memory\"]
+             :env (:MEMORY_FILE_PATH \"/tmp/memory.json\"))
+    :remote (:type \"http\" :url \"https://example.com/mcp/\"
+             :headers (:Authorization \"Bearer TOKEN\")))
+
+The value is serialized to JSON, so list-valued fields such as `:args'
+must be vectors.  As with `copilot-lsp-settings', change this through
+the customization framework (`setopt' or `customize') so the running
+server is updated; a plain `setq' takes effect only on restart."
+  :set #'copilot--lsp-settings-changed
+  :type 'sexp
+  :group 'copilot
+  :package-version '(copilot . "0.7"))
+
 (defvar-local copilot--overlay nil
   "Overlay for Copilot completion.")
 
@@ -691,8 +718,23 @@ hanging.  See `copilot--shutdown-server'."
        ;; handle older jsonrpc versions
        (funcall make-fn :events-buffer-scrollback-size copilot-log-max)))))
 
+(defun copilot--mcp-settings-json ()
+  "Return `copilot-mcp-servers' encoded as the server's MCP config string.
+Return nil when no servers are configured or encoding fails."
+  (when copilot-mcp-servers
+    (condition-case err
+        (json-serialize copilot-mcp-servers)
+      (error
+       ;; A surfaced warning, not just a log line: the most likely cause
+       ;; is a list where a vector is required (e.g. :args), and silently
+       ;; dropping every server would be very hard to diagnose.
+       (lwarn 'copilot :error
+              "Invalid `copilot-mcp-servers' (list-valued fields like :args must be vectors): %S"
+              err)
+       nil))))
+
 (defun copilot--effective-lsp-settings ()
-  "Return the effective LSP settings, including completion model."
+  "Return the effective LSP settings, including completion model and MCP."
   (let ((settings (copy-sequence copilot-lsp-settings)))
     (when copilot-completion-model
       (let* ((github (or (plist-get settings :github) '()))
@@ -700,6 +742,11 @@ hanging.  See `copilot--shutdown-server'."
         (setq copilot-section (plist-put copilot-section :selectedCompletionModel copilot-completion-model))
         (setq github (plist-put github :copilot copilot-section))
         (setq settings (plist-put settings :github github))))
+    ;; The server reads :mcp as a JSON *string* (it checks the type and
+    ;; JSON-parses it), so this must stay a serialized string rather than
+    ;; a nested object like the other settings keys.
+    (when-let* ((mcp (copilot--mcp-settings-json)))
+      (setq settings (plist-put settings :mcp mcp)))
     settings))
 
 (defun copilot--start-server ()

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -497,7 +497,43 @@
                   :to-equal "gpt-4o")
           (expect (plist-get (plist-get (plist-get result :github) :copilot)
                              :other)
-                  :to-equal "value")))))
+                  :to-equal "value"))))
+
+    (it "omits :mcp when no servers are configured"
+      (let ((copilot-completion-model nil)
+            (copilot-mcp-servers nil)
+            (copilot-lsp-settings '(:foo "bar")))
+        (expect (plist-member (copilot--effective-lsp-settings) :mcp)
+                :to-be nil)))
+
+    (it "encodes configured MCP servers as a JSON string"
+      (let ((copilot-completion-model nil)
+            (copilot-mcp-servers '(:fetch (:command "uvx"
+                                           :args ["mcp-server-fetch"])))
+            (copilot-lsp-settings nil))
+        (let* ((result (copilot--effective-lsp-settings))
+               (mcp (plist-get result :mcp)))
+          (expect (stringp mcp) :to-be-truthy)
+          (expect (json-parse-string mcp :object-type 'plist)
+                  :to-equal '(:fetch (:command "uvx"
+                                      :args ["mcp-server-fetch"])))))))
+
+  (describe "copilot--mcp-settings-json"
+    (it "returns nil when no servers are configured"
+      (let ((copilot-mcp-servers nil))
+        (expect (copilot--mcp-settings-json) :to-be nil)))
+
+    (it "serializes a stdio and an http server"
+      (let ((copilot-mcp-servers
+             '(:local (:command "npx" :args ["-y" "srv"])
+               :remote (:type "http" :url "https://x/mcp/"))))
+        (expect (json-parse-string (copilot--mcp-settings-json)
+                                   :object-type 'plist)
+                :to-equal copilot-mcp-servers)))
+
+    (it "returns nil and logs when the value cannot be encoded"
+      (let ((copilot-mcp-servers '(:bad (:args (1 . 2)))))
+        (expect (copilot--mcp-settings-json) :to-be nil))))
 
   ;;
   ;; LSP position


### PR DESCRIPTION
Lets you expose [MCP](https://modelcontextprotocol.io) servers to Copilot agent mode. Set `copilot-mcp-servers` to a map of server name to definition (stdio command or http/sse url) and copilot.el forwards it to the language server through the existing settings channel, so the server's tools show up in `copilot-chat`. Their invocations already flow through the same confirmation path as the built-in tools (added in #485), so nothing extra was needed there.

The `:mcp` setting is intentionally sent as a JSON string: the language server checks the value's type and parses it itself, ignoring a nested object. Malformed configs (a common one being a list where a vector is required) now surface a warning instead of silently dropping the servers.
