### PR TITLE
Show server-side tool activity in the chat buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - Run the agent-mode `run_in_terminal` tool asynchronously instead of blocking Emacs for the whole command. The editor stays responsive, the language-server connection keeps flowing, `C-g` aborts a running command, and `copilot-chat-terminal-timeout` (default 30s) kills runaways. The command's exit status is now reported back to the model.
+- Show a status line in the chat buffer when Copilot runs one of its own built-in or MCP tools that asks for confirmation (`read_file`, the edit tools, etc.), so those tool calls leave a trace, not just the ones copilot.el executes locally.
 - Add MCP (Model Context Protocol) server support for agent mode via the new `copilot-mcp-servers` option. Configured servers are forwarded to the language server and their tools become available in `copilot-chat`, each prompting for confirmation like the built-in tools.
 - Preview file changes in a temporary buffer before confirming an agent-mode edit tool (`create_file`, `insert_edit_into_file`, `replace_string_in_file`), so you can see what will be written before approving. Controlled by `copilot-chat-preview-tool-edits` (default on).
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -492,13 +492,38 @@ is enabled and the tool writes files.  Return non-nil on approval."
         (copilot-chat--confirm-with-preview msg preview)
       (yes-or-no-p (copilot-chat--confirmation-prompt msg)))))
 
+(defun copilot-chat--client-tool-names ()
+  "Return the names of copilot.el's own client tools.
+These are the tools copilot.el registers and runs itself; they log their
+own progress while running, so they need no separate status line at
+confirmation time."
+  (mapcar (lambda (def) (plist-get def :name))
+          (copilot-chat--tool-definitions)))
+
+(defun copilot-chat--log-server-tool (msg)
+  "Insert a status line for a server-executed tool approved via MSG.
+The server runs its own built-in and MCP tools internally, so for the
+ones it asks us to confirm this is the only trace they leave in the chat
+buffer.  Tools copilot.el executes itself are skipped, since they log
+their own progress."
+  (let* ((name (plist-get msg :name))
+         (base (copilot-chat--tool-base-name name)))
+    (unless (member base (copilot-chat--client-tool-names))
+      (copilot-chat--insert-tool-status
+       base
+       (or (copilot-chat--tool-summary name (plist-get msg :input))
+           "running")))))
+
 (defun copilot-chat--handle-tool-confirmation (msg)
   "Handle `conversation/invokeClientToolConfirmation' request MSG.
 Return a result plist the server accepts: (:result \"accept\") to allow
 the tool call or (:result \"dismiss\") to decline it."
   (if (or (copilot-chat--tool-auto-approved-p (plist-get msg :name))
           (copilot-chat--confirm-tool msg))
-      (list :result "accept")
+      (progn
+        ;; Logging must never derail the acceptance reply.
+        (ignore-errors (copilot-chat--log-server-tool msg))
+        (list :result "accept"))
     (list :result "dismiss")))
 
 (copilot-on-request 'conversation/invokeClientToolConfirmation

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -714,6 +714,31 @@
         ;; No stray "nil" leaks into the prompt.
         (expect prompt :not :to-match "run nil"))))
 
+  (describe "server-side tool activity logging"
+    (it "logs a status line for an approved server tool"
+      (let ((copilot-chat-auto-approve-tools '("copilot.read_file")))
+        (spy-on 'copilot-chat--insert-tool-status)
+        (copilot-chat--handle-tool-confirmation
+         (list :name "copilot.read_file" :input (list :filePath "/tmp/x.el")))
+        (expect 'copilot-chat--insert-tool-status
+                :to-have-been-called-with "read_file" "read file: /tmp/x.el")))
+
+    (it "does not log a client tool at confirmation time"
+      ;; Client tools (run_in_terminal etc.) log their own progress while
+      ;; executing, so they must not also log here.
+      (spy-on 'yes-or-no-p :and-return-value t)
+      (spy-on 'copilot-chat--insert-tool-status)
+      (copilot-chat--handle-tool-confirmation
+       (list :name "run_in_terminal" :input (list :command "ls")))
+      (expect 'copilot-chat--insert-tool-status :not :to-have-been-called))
+
+    (it "does not log a dismissed tool"
+      (spy-on 'yes-or-no-p :and-return-value nil)
+      (spy-on 'copilot-chat--insert-tool-status)
+      (copilot-chat--handle-tool-confirmation
+       (list :name "copilot.read_file" :input (list :filePath "/tmp/x.el")))
+      (expect 'copilot-chat--insert-tool-status :not :to-have-been-called)))
+
   ;;
   ;; Tool summary
   ;;


### PR DESCRIPTION
The server runs its own built-in and MCP tools internally, so until now they left no trace in `*copilot-chat*` - only the four tools copilot.el executes locally logged a status line. This logs one when such a tool is approved (the single client-visible choke point for every tool call that needs confirmation), skipping the client tools that already log their own progress. The logging is guarded so it can never derail the acceptance reply.
