### PR TITLE
Add an 'always' choice to agent-mode tool confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Run the agent-mode `run_in_terminal` tool asynchronously instead of blocking Emacs for the whole command. The editor stays responsive, the language-server connection keeps flowing, `C-g` aborts a running command, and `copilot-chat-terminal-timeout` (default 30s) kills runaways. The command's exit status is now reported back to the model.
 - Show a status line in the chat buffer when Copilot runs one of its own built-in or MCP tools that asks for confirmation (`read_file`, the edit tools, etc.), so those tool calls leave a trace, not just the ones copilot.el executes locally.
+- Offer an `always` choice at agent-mode tool confirmation prompts, alongside yes and no, to approve a tool for the rest of the conversation instead of confirming each call. The choice is remembered until a new conversation starts.
 - Add MCP (Model Context Protocol) server support for agent mode via the new `copilot-mcp-servers` option. Configured servers are forwarded to the language server and their tools become available in `copilot-chat`, each prompting for confirmation like the built-in tools.
 - Preview file changes in a temporary buffer before confirming an agent-mode edit tool (`create_file`, `insert_edit_into_file`, `replace_string_in_file`), so you can see what will be written before approving. Controlled by `copilot-chat-preview-tool-edits` (default on).
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Customization:
 - **`copilot-chat-preview-tool-edits`** — in agent mode, preview file changes in a temporary buffer before you confirm an edit tool (default `t`)
 - **`copilot-chat-auto-approve-tools`** — tool names that skip the confirmation prompt (default `'("get_errors")`)
 
+At each tool confirmation prompt you can answer `yes`, `no`, or `always`; `always` approves that tool for the rest of the conversation so it stops asking.
+
 > [!TIP]
 >
 > Install [`markdown-mode`](https://github.com/jrblevin/markdown-mode) for rich markdown rendering (headings, code blocks, emphasis, etc.) in the chat buffer. Without it, only basic highlighting is used.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -405,14 +405,27 @@ still tell what they are approving."
      (t
       "Copilot wants to run a tool.  Allow? "))))
 
+(defvar copilot-chat--session-approved-tools nil
+  "Tool base names approved for the rest of the conversation.
+Populated by choosing `always' at a confirmation prompt, and reset when
+a new conversation starts.  Unlike `copilot-chat-auto-approve-tools',
+this is a live, per-session choice, so it matches on the base name.
+
+This is a global, not a buffer-local, variable: the confirmation request
+is handled in the JSON-RPC dispatcher rather than in the chat buffer, so
+buffer-local state would not be reachable from there.")
+
 (defun copilot-chat--tool-auto-approved-p (name)
-  "Return non-nil when tool NAME is listed in `copilot-chat-auto-approve-tools'.
-Matching is exact.  Auto-approval bypasses confirmation entirely
-\(including the server's own prompts for sensitive files), so a tool is
-auto-approved only when its full reported name is listed, never a
-namespace-stripped variant."
+  "Return non-nil when tool NAME should skip the confirmation prompt.
+A tool is auto-approved when its full reported name is in
+`copilot-chat-auto-approve-tools' (matched exactly, since auto-approval
+bypasses confirmation entirely, including the server's own prompts for
+sensitive files), or when its base name was approved for this session
+via the `always' choice."
   (and (stringp name)
-       (member name copilot-chat-auto-approve-tools)
+       (or (member name copilot-chat-auto-approve-tools)
+           (member (copilot-chat--tool-base-name name)
+                   copilot-chat--session-approved-tools))
        t))
 
 (defconst copilot-chat--tool-preview-buffer-name "*copilot-chat-tool-preview*"
@@ -460,10 +473,24 @@ Return nil for tools that do not write files."
                   new "+" 'copilot-chat-diff-added-face)))))
     (_ nil)))
 
+(defun copilot-chat--ask-tool (msg)
+  "Prompt to approve the tool described by MSG.
+Return `allow' (run it once), `always' (run it and skip future prompts
+for this tool this session), or `deny'."
+  (pcase (car (read-multiple-choice
+               (copilot-chat--confirmation-prompt msg)
+               '((?y "yes" "Allow this tool call")
+                 (?n "no" "Decline this tool call")
+                 (?a "always"
+                     "Allow this and future calls to this tool this session"))))
+    (?y 'allow)
+    (?a 'always)
+    (_ 'deny)))
+
 (defun copilot-chat--confirm-with-preview (msg preview)
   "Show PREVIEW in a temporary window, then prompt to confirm MSG.
-Return non-nil when the user approves.  The preview buffer is removed
-afterwards."
+Return the approval decision (see `copilot-chat--ask-tool').  The preview
+buffer is removed afterwards."
   ;; A fresh buffer per call, so an overlapping confirmation can't erase
   ;; or kill the preview out from under this prompt.
   (let ((buf (generate-new-buffer copilot-chat--tool-preview-buffer-name)))
@@ -476,7 +503,7 @@ afterwards."
           (display-buffer buf '((display-buffer-pop-up-window
                                  display-buffer-use-some-window)
                                 (window-height . fit-window-to-buffer)))
-          (yes-or-no-p (copilot-chat--confirmation-prompt msg)))
+          (copilot-chat--ask-tool msg))
       (when-let* ((win (get-buffer-window buf)))
         (quit-window nil win))
       (kill-buffer buf))))
@@ -484,13 +511,14 @@ afterwards."
 (defun copilot-chat--confirm-tool (msg)
   "Ask the user whether to allow the tool described by MSG.
 Show a preview of the change first when `copilot-chat-preview-tool-edits'
-is enabled and the tool writes files.  Return non-nil on approval."
+is enabled and the tool writes files.  Return the approval decision (see
+`copilot-chat--ask-tool')."
   (let ((preview (and copilot-chat-preview-tool-edits
                       (copilot-chat--tool-preview (plist-get msg :name)
                                                   (plist-get msg :input)))))
     (if preview
         (copilot-chat--confirm-with-preview msg preview)
-      (yes-or-no-p (copilot-chat--confirmation-prompt msg)))))
+      (copilot-chat--ask-tool msg))))
 
 (defun copilot-chat--client-tool-names ()
   "Return the names of copilot.el's own client tools.
@@ -517,14 +545,25 @@ their own progress."
 (defun copilot-chat--handle-tool-confirmation (msg)
   "Handle `conversation/invokeClientToolConfirmation' request MSG.
 Return a result plist the server accepts: (:result \"accept\") to allow
-the tool call or (:result \"dismiss\") to decline it."
-  (if (or (copilot-chat--tool-auto-approved-p (plist-get msg :name))
-          (copilot-chat--confirm-tool msg))
-      (progn
-        ;; Logging must never derail the acceptance reply.
-        (ignore-errors (copilot-chat--log-server-tool msg))
-        (list :result "accept"))
-    (list :result "dismiss")))
+the tool call or (:result \"dismiss\") to decline it.  Choosing `always'
+at the prompt remembers the tool for the rest of the conversation."
+  (let ((name (plist-get msg :name)))
+    (if (copilot-chat--tool-auto-approved-p name)
+        (copilot-chat--accept-tool msg)
+      (pcase (copilot-chat--confirm-tool msg)
+        ('deny (list :result "dismiss"))
+        (decision
+         (when (eq decision 'always)
+           (cl-pushnew (copilot-chat--tool-base-name name)
+                       copilot-chat--session-approved-tools
+                       :test #'equal))
+         (copilot-chat--accept-tool msg))))))
+
+(defun copilot-chat--accept-tool (msg)
+  "Return an acceptance result for MSG, logging the tool activity."
+  ;; Logging must never derail the acceptance reply.
+  (ignore-errors (copilot-chat--log-server-tool msg))
+  (list :result "accept"))
 
 (copilot-on-request 'conversation/invokeClientToolConfirmation
                     #'copilot-chat--handle-tool-confirmation)
@@ -791,6 +830,8 @@ Dispatch to the appropriate tool and return a LanguageModelToolResult."
   "Create a new conversation with MESSAGE.
 CALLBACK is called with the response containing conversationId and turnId."
   (let ((token (format "copilot-chat-%s" (float-time))))
+    ;; A fresh conversation starts with a clean slate of session approvals.
+    (setq copilot-chat--session-approved-tools nil)
     (with-current-buffer (get-buffer copilot-chat--buffer-name)
       (setq copilot-chat--work-done-token token)
       (push (cons token (current-buffer)) copilot-chat--active-buffers))

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -15,7 +15,8 @@
   ;; Specs that exercise resolution override this spy.
   (before-each
     (setq copilot-chat--resolved-model nil
-          copilot-chat--model-resolved nil)
+          copilot-chat--model-resolved nil
+          copilot-chat--session-approved-tools nil)
     (spy-on 'jsonrpc-request :and-return-value nil))
 
   (describe "loading"
@@ -508,6 +509,21 @@
                         (cons nil nil)))
               (copilot-chat--create "hello" #'ignore)
               (expect (plist-member captured-params :model) :not :to-be-truthy))
+          (kill-buffer buf))))
+
+    (it "clears session tool approvals for a new conversation"
+      (let ((copilot-chat--session-approved-tools '("read_file"))
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot-chat--default-model :and-return-value nil)
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-return-value (cons nil nil))
+              (copilot-chat--create "hello" #'ignore)
+              (expect copilot-chat--session-approved-tools :to-be nil))
           (kill-buffer buf)))))
 
   ;;
@@ -639,30 +655,20 @@
 
     (it "prompts for tools not in auto-approve list"
       (let ((copilot-chat-auto-approve-tools '("get_errors")))
-        (spy-on 'yes-or-no-p :and-return-value t)
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'allow)
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "run_in_terminal"
                        :input (list :command "ls")))
                 :to-equal '(:result "accept"))
-        (expect 'yes-or-no-p :to-have-been-called)))
+        (expect 'copilot-chat--ask-tool :to-have-been-called)))
 
     (it "dismisses when user declines"
       (let ((copilot-chat-auto-approve-tools nil))
-        (spy-on 'yes-or-no-p :and-return-value nil)
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'deny)
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "run_in_terminal"
                        :input (list :command "rm -rf /")))
                 :to-equal '(:result "dismiss"))))
-
-    (it "summarizes the tool in the confirmation prompt"
-      (let ((copilot-chat-auto-approve-tools nil)
-            (prompt nil))
-        (spy-on 'yes-or-no-p :and-call-fake
-                (lambda (msg) (setq prompt msg) nil))
-        (copilot-chat--handle-tool-confirmation
-         (list :name "run_in_terminal" :input (list :command "make test")))
-        ;; The raw command shows, not a plist dump.
-        (expect prompt :to-match "run shell command: make test")))
 
     (it "auto-approves a server tool listed by its full name"
       (let ((copilot-chat-auto-approve-tools '("copilot.read_file")))
@@ -673,46 +679,64 @@
 
     (it "does not auto-approve a namespaced tool by its base name alone"
       (let ((copilot-chat-auto-approve-tools '("read_file")))
-        (spy-on 'yes-or-no-p :and-return-value nil)
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'deny)
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "copilot.read_file"
                        :input (list :filePath "/tmp/x.el")))
                 :to-equal '(:result "dismiss"))
-        (expect 'yes-or-no-p :to-have-been-called)))
+        (expect 'copilot-chat--ask-tool :to-have-been-called)))
 
-    (it "falls back to the server message for unknown tools"
+    (it "remembers a tool approved with `always' for the session"
       (let ((copilot-chat-auto-approve-tools nil)
-            (prompt nil))
-        (spy-on 'yes-or-no-p :and-call-fake
-                (lambda (msg) (setq prompt msg) nil))
-        (copilot-chat--handle-tool-confirmation
-         (list :name "copilot.some_new_tool"
-               :input (list :foo "bar")
-               :message "Allow the new tool to run?"))
-        ;; No plist dump: the server-provided message is shown verbatim.
-        (expect prompt :to-match "Allow the new tool to run?")
-        (expect prompt :not :to-match ":foo")))
+            (copilot-chat--session-approved-tools nil))
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'always)
+        ;; First call prompts and is approved...
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "copilot.read_file"
+                       :input (list :filePath "/tmp/x.el")))
+                :to-equal '(:result "accept"))
+        (expect copilot-chat--session-approved-tools :to-contain "read_file")
+        ;; ...the next call to the same tool is auto-approved without asking.
+        (spy-calls-reset 'copilot-chat--ask-tool)
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "copilot.read_file"
+                       :input (list :filePath "/tmp/y.el")))
+                :to-equal '(:result "accept"))
+        (expect 'copilot-chat--ask-tool :not :to-have-been-called)))
 
-    (it "shows the raw input when no summary or server message exists"
-      (let ((copilot-chat-auto-approve-tools nil)
-            (prompt nil))
-        (spy-on 'yes-or-no-p :and-call-fake
-                (lambda (msg) (setq prompt msg) nil))
-        (copilot-chat--handle-tool-confirmation
-         (list :name "copilot.mystery_tool"
-               :input (list :command "rm -rf /")))
-        ;; The user can still see what is being approved.
-        (expect prompt :to-match "mystery_tool")
-        (expect prompt :to-match "rm -rf /")))
+    (describe "confirmation prompt"
+      (it "summarizes the tool"
+        (expect (copilot-chat--confirmation-prompt
+                 (list :name "run_in_terminal" :input (list :command "make test")))
+                :to-match "run shell command: make test"))
 
-    (it "prompts sensibly when the request has no tool name"
-      (let ((copilot-chat-auto-approve-tools nil)
-            (prompt nil))
-        (spy-on 'yes-or-no-p :and-call-fake
-                (lambda (msg) (setq prompt msg) nil))
-        (copilot-chat--handle-tool-confirmation (list :input nil))
-        ;; No stray "nil" leaks into the prompt.
-        (expect prompt :not :to-match "run nil"))))
+      (it "falls back to the server message for unknown tools"
+        (let ((prompt (copilot-chat--confirmation-prompt
+                       (list :name "copilot.some_new_tool"
+                             :input (list :foo "bar")
+                             :message "Allow the new tool to run?"))))
+          (expect prompt :to-match "Allow the new tool to run?")
+          (expect prompt :not :to-match ":foo")))
+
+      (it "shows the raw input when no summary or server message exists"
+        (let ((prompt (copilot-chat--confirmation-prompt
+                       (list :name "copilot.mystery_tool"
+                             :input (list :command "rm -rf /")))))
+          (expect prompt :to-match "mystery_tool")
+          (expect prompt :to-match "rm -rf /")))
+
+      (it "stays sensible when the request has no tool name"
+        (expect (copilot-chat--confirmation-prompt (list :input nil))
+                :not :to-match "run nil"))))
+
+  (describe "copilot-chat--ask-tool"
+    (it "maps the yes/no/always choices to decisions"
+      (spy-on 'read-multiple-choice :and-return-value '(?y "yes" ""))
+      (expect (copilot-chat--ask-tool (list :name "x")) :to-equal 'allow)
+      (spy-on 'read-multiple-choice :and-return-value '(?n "no" ""))
+      (expect (copilot-chat--ask-tool (list :name "x")) :to-equal 'deny)
+      (spy-on 'read-multiple-choice :and-return-value '(?a "always" ""))
+      (expect (copilot-chat--ask-tool (list :name "x")) :to-equal 'always)))
 
   (describe "server-side tool activity logging"
     (it "logs a status line for an approved server tool"
@@ -726,14 +750,14 @@
     (it "does not log a client tool at confirmation time"
       ;; Client tools (run_in_terminal etc.) log their own progress while
       ;; executing, so they must not also log here.
-      (spy-on 'yes-or-no-p :and-return-value t)
+      (spy-on 'copilot-chat--ask-tool :and-return-value 'allow)
       (spy-on 'copilot-chat--insert-tool-status)
       (copilot-chat--handle-tool-confirmation
        (list :name "run_in_terminal" :input (list :command "ls")))
       (expect 'copilot-chat--insert-tool-status :not :to-have-been-called))
 
     (it "does not log a dismissed tool"
-      (spy-on 'yes-or-no-p :and-return-value nil)
+      (spy-on 'copilot-chat--ask-tool :and-return-value 'deny)
       (spy-on 'copilot-chat--insert-tool-status)
       (copilot-chat--handle-tool-confirmation
        (list :name "copilot.read_file" :input (list :filePath "/tmp/x.el")))
@@ -838,10 +862,10 @@
     (it "shows a preview buffer when approving an edit tool"
       (let ((copilot-chat-preview-tool-edits t)
             (shown nil))
-        (spy-on 'yes-or-no-p :and-call-fake
+        (spy-on 'read-multiple-choice :and-call-fake
                 (lambda (&rest _)
                   (setq shown (get-buffer "*copilot-chat-tool-preview*"))
-                  t))
+                  '(?y "yes" "")))
         (expect (copilot-chat--handle-tool-confirmation
                  (list :name "create_file"
                        :input (list :filePath "/tmp/x.el" :content "hi")))
@@ -853,7 +877,7 @@
 
     (it "skips the preview when copilot-chat-preview-tool-edits is nil"
       (let ((copilot-chat-preview-tool-edits nil))
-        (spy-on 'yes-or-no-p :and-return-value t)
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'allow)
         (copilot-chat--handle-tool-confirmation
          (list :name "create_file"
                :input (list :filePath "/tmp/x.el" :content "hi")))
@@ -861,7 +885,7 @@
 
     (it "does not preview non-editing tools"
       (let ((copilot-chat-preview-tool-edits t))
-        (spy-on 'yes-or-no-p :and-return-value nil)
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'deny)
         (copilot-chat--handle-tool-confirmation
          (list :name "run_in_terminal" :input (list :command "ls")))
         (expect (get-buffer "*copilot-chat-tool-preview*") :to-be nil))))


### PR DESCRIPTION
The agent-mode confirmation prompt was a binary yes/no, so a safe tool had to be re-approved on every call. It now offers a third choice - `always` - that approves the tool for the rest of the conversation. Approvals live in a session-scoped set (matched by base name) that's cleared when a new conversation begins; the persistent `copilot-chat-auto-approve-tools` list keeps its exact-match semantics.
