### PR TITLE
Surface MCP server and tool status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Show a status line in the chat buffer when Copilot runs one of its own built-in or MCP tools that asks for confirmation (`read_file`, the edit tools, etc.), so those tool calls leave a trace, not just the ones copilot.el executes locally.
 - Offer an `always` choice at agent-mode tool confirmation prompts, alongside yes and no, to approve a tool for the rest of the conversation instead of confirming each call. The choice is remembered until a new conversation starts.
 - Add MCP (Model Context Protocol) server support for agent mode via the new `copilot-mcp-servers` option. Configured servers are forwarded to the language server and their tools become available in `copilot-chat`, each prompting for confirmation like the built-in tools.
+- Add `copilot-chat-list-mcp-tools` to see the connected MCP servers, their status, and their tools, and warn when an MCP server fails to start (previously silent).
 - Preview file changes in a temporary buffer before confirming an agent-mode edit tool (`create_file`, `insert_edit_into_file`, `replace_string_in_file`), so you can see what will be written before approving. Controlled by `copilot-chat-preview-tool-edits` (default on).
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ When agent mode is enabled, you can extend Copilot with [Model Context Protocol]
 
 A server with a `:command` is launched locally over stdio; one with a `:type` of `"http"` or `"sse"` is reached at its `:url`. The value is serialized to JSON, so list-valued fields like `:args` must be vectors. Use `setopt` (or `customize`) so a running server picks up the change.
 
+Run `M-x copilot-chat-list-mcp-tools` to see the connected servers, their status, and the tools they expose. A server that fails to start is reported as a warning.
+
 For a more feature-rich chat experience, take a look at [copilot-chat.el](https://github.com/chep/copilot-chat.el).
 
 > [!WARNING]

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -758,6 +758,82 @@ Dispatch to the appropriate tool and return a LanguageModelToolResult."
                     #'copilot-chat--handle-tool-invocation)
 
 ;;
+;; MCP server status
+;;
+
+(defconst copilot-chat--mcp-buffer-name "*copilot-mcp-tools*"
+  "Name of the buffer listing MCP servers and their tools.")
+
+(defvar copilot-chat--mcp-servers nil
+  "Latest MCP server snapshots reported by the language server.
+A list of plists with keys such as :name, :status, :tools, and :error,
+refreshed from `copilot/mcpTools' notifications.")
+
+(defvar copilot-chat--mcp-warned-errors nil
+  "Alist of MCP server name to the last error string warned about.
+Kept across notifications so a server that flaps in and out of the
+reported set is not warned about repeatedly for the same failure.")
+
+(defun copilot-chat--handle-mcp-tools (msg)
+  "Handle a `copilot/mcpTools' notification MSG.
+Cache the server snapshots and warn once about any newly failed server,
+which the language server otherwise reports only silently."
+  (setq copilot-chat--mcp-servers (append (plist-get msg :servers) nil))
+  (dolist (server copilot-chat--mcp-servers)
+    (let ((name (plist-get server :name))
+          (err (plist-get server :error)))
+      (when (and (stringp err) (not (string-empty-p err))
+                 (not (equal err (alist-get name copilot-chat--mcp-warned-errors
+                                            nil nil #'equal))))
+        (copilot--log 'warning "MCP server %s failed: %s" name err)
+        (setf (alist-get name copilot-chat--mcp-warned-errors nil nil #'equal)
+              err)))))
+
+(copilot-on-notification 'copilot/mcpTools #'copilot-chat--handle-mcp-tools)
+
+(defun copilot-chat--insert-mcp-server (server)
+  "Insert a description of MCP SERVER into the current buffer."
+  (insert (propertize (or (plist-get server :name) "(unnamed)") 'face 'bold)
+          (format " [%s]\n" (or (plist-get server :status) "unknown")))
+  (let ((err (plist-get server :error)))
+    (when (and (stringp err) (not (string-empty-p err)))
+      (insert (propertize (format "  error: %s\n" err)
+                          'face 'copilot-chat-error-face))))
+  (let ((tools (append (plist-get server :tools) nil)))
+    (if tools
+        (dolist (tool tools)
+          (insert (format "  - %s" (or (plist-get tool :name) "(unnamed)")))
+          (let ((desc (plist-get tool :description)))
+            (when (stringp desc)
+              (insert (format ": %s" (car (split-string desc "\n"))))))
+          (insert "\n"))
+      (insert "  (no tools)\n")))
+  (insert "\n"))
+
+(defun copilot-chat-list-mcp-tools ()
+  "Display the MCP servers and tools currently available to Copilot.
+Servers are configured via `copilot-mcp-servers'."
+  (interactive)
+  (let ((buf (get-buffer-create copilot-chat--mcp-buffer-name)))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (cond
+         (copilot-chat--mcp-servers
+          (mapc #'copilot-chat--insert-mcp-server copilot-chat--mcp-servers))
+         (copilot-mcp-servers
+          (insert "No MCP servers reported yet.\n\n"
+                  "They appear once the language server connects them in "
+                  "agent mode.\n"))
+         (t
+          (insert "No MCP servers configured.\n\n"
+                  "Set `copilot-mcp-servers' and enable "
+                  "`copilot-chat-use-agent-mode'.\n")))
+        (goto-char (point-min)))
+      (special-mode))
+    (display-buffer buf)))
+
+;;
 ;; Context doc generation
 ;;
 

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1181,6 +1181,85 @@
                   "GPT-4o (gpt-4o)"))
         (copilot-chat-select-model)
         (expect (length captured-choices) :to-equal 1)
-        (expect (cdar captured-choices) :to-equal "gpt-4o")))))
+        (expect (cdar captured-choices) :to-equal "gpt-4o"))))
+
+  (describe "copilot-chat--handle-mcp-tools"
+    (before-each (setq copilot-chat--mcp-servers nil
+                       copilot-chat--mcp-warned-errors nil))
+    (after-each (setq copilot-chat--mcp-servers nil
+                      copilot-chat--mcp-warned-errors nil))
+
+    (it "caches the reported servers"
+      (copilot-chat--handle-mcp-tools
+       (list :servers (vector (list :name "fetch" :status "running"
+                                    :tools (vector (list :name "get"))))))
+      (expect (length copilot-chat--mcp-servers) :to-equal 1)
+      (expect (plist-get (car copilot-chat--mcp-servers) :name)
+              :to-equal "fetch"))
+
+    (it "warns once about a newly failed server"
+      (spy-on 'copilot--log)
+      (let ((msg (list :servers
+                       (vector (list :name "bad" :status "error"
+                                     :error "spawn failed")))))
+        (copilot-chat--handle-mcp-tools msg)
+        ;; A repeat notification with the same error does not warn again.
+        (copilot-chat--handle-mcp-tools msg))
+      (expect 'copilot--log :to-have-been-called-times 1))
+
+    (it "does not warn about a healthy server"
+      (spy-on 'copilot--log)
+      (copilot-chat--handle-mcp-tools
+       (list :servers (vector (list :name "ok" :status "running"))))
+      (expect 'copilot--log :not :to-have-been-called))
+
+    (it "does not warn about an empty error string"
+      (spy-on 'copilot--log)
+      (copilot-chat--handle-mcp-tools
+       (list :servers (vector (list :name "ok" :status "stopped" :error ""))))
+      (expect 'copilot--log :not :to-have-been-called)))
+
+  (describe "copilot-chat-list-mcp-tools"
+    (after-each
+      (setq copilot-chat--mcp-servers nil)
+      (when (get-buffer "*copilot-mcp-tools*")
+        (kill-buffer "*copilot-mcp-tools*")))
+
+    (it "lists servers, status, and tools"
+      (let ((copilot-chat--mcp-servers
+             (list (list :name "fetch" :status "running"
+                         :tools (vector (list :name "get_url"
+                                              :description "Fetch a URL"))))))
+        (spy-on 'display-buffer)
+        (copilot-chat-list-mcp-tools)
+        (with-current-buffer "*copilot-mcp-tools*"
+          (let ((text (buffer-string)))
+            (expect text :to-match "fetch")
+            (expect text :to-match "running")
+            (expect text :to-match "get_url")
+            (expect text :to-match "Fetch a URL")))))
+
+    (it "renders tools with a missing name or non-string description"
+      (let ((copilot-chat--mcp-servers
+             (list (list :name "weird" :status "running"
+                         :tools (vector (list :description 42))))))
+        (spy-on 'display-buffer)
+        ;; Must not raise on the non-string description.
+        (copilot-chat-list-mcp-tools)
+        (with-current-buffer "*copilot-mcp-tools*"
+          (expect (buffer-string) :to-match "(unnamed)"))))
+
+    (it "distinguishes unconfigured from not-yet-reported"
+      (spy-on 'display-buffer)
+      (let ((copilot-chat--mcp-servers nil)
+            (copilot-mcp-servers nil))
+        (copilot-chat-list-mcp-tools)
+        (with-current-buffer "*copilot-mcp-tools*"
+          (expect (buffer-string) :to-match "No MCP servers configured")))
+      (let ((copilot-chat--mcp-servers nil)
+            (copilot-mcp-servers '(:fetch (:command "uvx"))))
+        (copilot-chat-list-mcp-tools)
+        (with-current-buffer "*copilot-mcp-tools*"
+          (expect (buffer-string) :to-match "reported yet"))))))
 
 ;;; copilot-chat-test.el ends here


### PR DESCRIPTION
MCP servers were configured but invisible: no way to see which connected or what tools they exposed, and a server that failed to start did so silently. This handles the `copilot/mcpTools` notification to cache the server snapshots, warns once when a server newly fails, and adds `M-x copilot-chat-list-mcp-tools` to list servers, their status, and their tools.
