### PR TITLE
Surface turn errors and quiet the indent warning in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+- Surface a turn-level error reported by the server at the end of a chat turn, instead of leaving only an empty reply. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))
+- Stop the `copilot--infer-indentation-offset` warning from firing while generating chat context, so chatting from a buffer whose mode has no configured indentation offset no longer nags. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))
 - Resolve a concrete default chat model from the server when `copilot-chat-model` is nil (preferring the server's designated chat default, then an `auto` model) instead of leaving the model unset, which some servers answer with an empty reply. The lookup runs once per session, only against an already-running server. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))
 
 ### Changes

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -274,6 +274,19 @@ Returns a string or nil."
                      (plist-get last-round :reply)))))
     (and (stringp reply) reply)))
 
+(defun copilot-chat--error-text (err)
+  "Return a human-readable string for a server ERR value, or nil.
+ERR may be a string, a structured object with a `:message', or absent."
+  (cond ((null err) nil)
+        ((stringp err) err)
+        ((and (listp err) (stringp (plist-get err :message)))
+         (plist-get err :message))
+        (t (format "%S" err))))
+
+(defun copilot-chat--format-error (msg)
+  "Return MSG rendered as a styled chat error line."
+  (propertize (format "[Error: %s]\n\n" msg) 'face 'copilot-chat-error-face))
+
 (defun copilot-chat--handle-progress (msg)
   "Handle `$/progress' notification MSG for chat streaming."
   (copilot--dbind (token value) msg
@@ -294,18 +307,27 @@ Returns a string or nil."
                 (copilot-chat--scroll-to-bottom)))
              ((equal kind "end")
               (copilot-chat--end-streaming)
-              (when-let* ((result (plist-get value :result))
-                          ((listp result)))
-                (setq copilot-chat--follow-up (plist-get result :followUp)))
-              (let ((inhibit-read-only t))
-                (goto-char (point-max))
-                (insert "\n\n")
-                (when (and copilot-chat--follow-up
-                           (stringp copilot-chat--follow-up)
-                           (not (string-empty-p copilot-chat--follow-up)))
-                  (insert (propertize
-                           (format "Follow-up: %s\n\n" copilot-chat--follow-up)
-                           'face 'copilot-chat-follow-up-face))))
+              (let* ((result (plist-get value :result))
+                     ;; The server normally sends an object here, but
+                     ;; guard against any other shape.
+                     (result (and (listp result) result))
+                     (error-msg (copilot-chat--error-text
+                                 (plist-get result :error))))
+                ;; Reset the follow-up every turn so a stale one from a
+                ;; previous turn is never re-inserted.
+                (setq copilot-chat--follow-up (plist-get result :followUp))
+                (let ((inhibit-read-only t))
+                  (goto-char (point-max))
+                  (insert "\n\n")
+                  ;; Surface a turn-level error the server reports at the
+                  ;; end, which would otherwise leave only an empty reply.
+                  (when error-msg
+                    (insert (copilot-chat--format-error error-msg)))
+                  (when (and (stringp copilot-chat--follow-up)
+                             (not (string-empty-p copilot-chat--follow-up)))
+                    (insert (propertize
+                             (format "Follow-up: %s\n\n" copilot-chat--follow-up)
+                             'face 'copilot-chat-follow-up-face)))))
               (copilot-chat--scroll-to-bottom)
               (setq copilot-chat--active-buffers
                     (assoc-delete-all token copilot-chat--active-buffers))))))))))
@@ -842,7 +864,11 @@ Servers are configured via `copilot-mcp-servers'."
   (let ((buf copilot-chat--source-buffer))
     (when (and buf (buffer-live-p buf))
       (with-current-buffer buf
-        (let ((doc (copilot--generate-doc)))
+        ;; The indentation-offset warning is meant for completion
+        ;; debugging; suppress it here so merely chatting from a buffer
+        ;; whose mode has no configured offset doesn't nag the user.
+        (let* ((copilot-indent-offset-warning-disable t)
+               (doc (copilot--generate-doc)))
           (plist-put doc :source (copilot--get-source))
           doc)))))
 
@@ -852,8 +878,7 @@ Servers are configured via `copilot-mcp-servers'."
     (with-current-buffer buf
       (let ((inhibit-read-only t))
         (goto-char (point-max))
-        (insert (propertize (format "\n[Error: %s]\n\n" error-msg)
-                            'face 'copilot-chat-error-face))
+        (insert "\n" (copilot-chat--format-error error-msg))
         (copilot-chat--scroll-to-bottom)))))
 
 ;;

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -217,6 +217,94 @@
           (kill-buffer buf)))))
 
   ;;
+  ;; Turn-end error display
+  ;;
+
+  (describe "turn error display in progress handler"
+    (it "surfaces an error reported at the end of a turn"
+      (let ((buf (get-buffer-create "*copilot-chat-test-turn-error*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "end"
+                                    :result (list :error "model overloaded"))))
+                (with-current-buffer buf
+                  (expect (buffer-string) :to-match "Error: model overloaded"))))
+          (kill-buffer buf))))
+
+    (it "shows no error line for a clean turn"
+      (let ((buf (get-buffer-create "*copilot-chat-test-clean-turn*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "end"
+                                    :result (list :followUp "next"))))
+                (with-current-buffer buf
+                  (expect (buffer-string) :not :to-match "Error:"))))
+          (kill-buffer buf))))
+
+    (it "renders a structured error as its message"
+      (let ((buf (get-buffer-create "*copilot-chat-test-struct-error*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "end"
+                                    :result (list :error (list :code 500
+                                                               :message "overloaded")))))
+                (with-current-buffer buf
+                  (expect (buffer-string) :to-match "Error: overloaded")
+                  ;; Not the raw plist.
+                  (expect (buffer-string) :not :to-match ":code"))))
+          (kill-buffer buf))))
+
+    (it "clears a stale follow-up when the result is not an object"
+      (let ((buf (get-buffer-create "*copilot-chat-test-stale-fu*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t
+                      copilot-chat--follow-up "old suggestion"))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "end" :result "not-an-object")))
+                (with-current-buffer buf
+                  (expect (buffer-string) :not :to-match "old suggestion")
+                  (expect copilot-chat--follow-up :to-be nil))))
+          (kill-buffer buf)))))
+
+  (describe "copilot-chat--error-text"
+    (it "returns a bare string error unchanged"
+      (expect (copilot-chat--error-text "boom") :to-equal "boom"))
+
+    (it "extracts the message from a structured error"
+      (expect (copilot-chat--error-text '(:code 500 :message "overloaded"))
+              :to-equal "overloaded"))
+
+    (it "returns nil when there is no error"
+      (expect (copilot-chat--error-text nil) :to-be nil)))
+
+  ;;
   ;; Context handler
   ;;
 
@@ -272,7 +360,19 @@
             (let ((doc (copilot-chat--generate-context-doc)))
               (expect doc :to-be-truthy)
               (expect (plist-get doc :source) :to-match "hello")
-              (expect (plist-get doc :languageId) :to-equal "emacs-lisp")))))))
+              (expect (plist-get doc :languageId) :to-equal "emacs-lisp"))))))
+
+    (it "suppresses the indentation-offset warning while generating"
+      (with-temp-buffer
+        (let ((source-buf (current-buffer))
+              (captured 'unset))
+          (setq copilot-chat--source-buffer source-buf)
+          (spy-on 'copilot--generate-doc :and-call-fake
+                  (lambda () (setq captured copilot-indent-offset-warning-disable)
+                    '()))
+          (spy-on 'copilot--get-source :and-return-value "")
+          (copilot-chat--generate-context-doc)
+          (expect captured :to-be t)))))
 
   ;;
   ;; Inline error display


### PR DESCRIPTION
Two of the remaining complaints in #473. The server can report a turn-level error in the end progress result, but the handler only read the follow-up from there, so an errored turn showed nothing but an empty reply - now the error is surfaced (a structured error renders its message, not a raw plist). And generating chat context ran `copilot--infer-indentation-offset`, which warns when the source buffer's mode has no configured offset; that debugging aid is irrelevant to chat, so it's suppressed there.

Leaves the remaining #473 items (the multi-step indentation/model interplay) for separate follow-up, so the issue isn't auto-closed.
