### PR TITLE
Support Flycheck in the get_errors agent tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+- Report Flycheck diagnostics for the agent-mode `get_errors` tool, not just Flymake, so Flycheck users get real diagnostics instead of "no diagnostics available".
 - Surface a turn-level error reported by the server at the end of a chat turn, instead of leaving only an empty reply. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))
 - Stop the `copilot--infer-indentation-offset` warning from firing while generating chat context, so chatting from a buffer whose mode has no configured indentation offset no longer nags. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))
 - Resolve a concrete default chat model from the server when `copilot-chat-model` is nil (preferring the server's designated chat default, then an `auto` model) instead of leaving the model unset, which some servers answer with an empty reply. The lookup runs once per session, only against an already-running server. ([#473](https://github.com/copilot-emacs/copilot.el/issues/473))

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -38,6 +38,9 @@
 (declare-function flymake-diagnostics "flymake")
 (declare-function flymake-diagnostic-beg "flymake")
 (declare-function flymake-diagnostic-text "flymake")
+(declare-function flycheck-current-errors "flycheck")
+(declare-function flycheck-error-line "flycheck")
+(declare-function flycheck-error-message "flycheck")
 
 ;;
 ;; Customization
@@ -718,29 +721,44 @@ process exit code for `success'/`error', nil otherwise)."
       (error
        (copilot-chat--tool-result "error" (error-message-string err))))))
 
+(defun copilot-chat--buffer-diagnostics (path)
+  "Return diagnostic strings for the current buffer, labelled with PATH.
+Collect from Flymake and Flycheck whenever they are active (both, if
+both are on), and report when no backend is available at all."
+  (let ((backends 0)
+        (diagnostics '()))
+    (when (bound-and-true-p flymake-mode)
+      (setq backends (1+ backends))
+      (dolist (diag (flymake-diagnostics))
+        (push (format "%s:%d: %s" path
+                      (line-number-at-pos (flymake-diagnostic-beg diag))
+                      (flymake-diagnostic-text diag))
+              diagnostics)))
+    (when (bound-and-true-p flycheck-mode)
+      (setq backends (1+ backends))
+      (dolist (err (flycheck-current-errors))
+        (push (format "%s:%d: %s" path
+                      (or (flycheck-error-line err) 0)
+                      (flycheck-error-message err))
+              diagnostics)))
+    (cond
+     ((zerop backends) (list (format "%s: no diagnostics available" path)))
+     ((null diagnostics) (list (format "%s: no errors" path)))
+     (t (nreverse diagnostics)))))
+
 (defun copilot-chat--execute-get-errors (input)
   "Execute get_errors tool with INPUT."
-  (let ((file-paths (plist-get input :filePaths))
-        (results '()))
-    (copilot-chat--insert-tool-status "get_errors" "Collecting diagnostics...")
-    (dolist (path (append file-paths nil))
-      (let ((buf (find-buffer-visiting path)))
-        (if (and buf (buffer-live-p buf))
-            (with-current-buffer buf
-              (if (bound-and-true-p flymake-mode)
-                  (let ((diags (flymake-diagnostics)))
-                    (if diags
-                        (dolist (diag diags)
-                          (push (format "%s:%d: %s"
-                                        path
-                                        (line-number-at-pos
-                                         (flymake-diagnostic-beg diag))
-                                        (flymake-diagnostic-text diag))
-                                results))
-                      (push (format "%s: no errors" path) results)))
-                (push (format "%s: no diagnostics available" path) results)))
-          (push (format "%s: not open in editor" path) results))))
-    (copilot-chat--tool-result "success" (string-join (nreverse results) "\n"))))
+  (copilot-chat--insert-tool-status "get_errors" "Collecting diagnostics...")
+  (let ((results
+         (mapcan
+          (lambda (path)
+            (let ((buf (find-buffer-visiting path)))
+              (if (and buf (buffer-live-p buf))
+                  (with-current-buffer buf
+                    (copilot-chat--buffer-diagnostics path))
+                (list (format "%s: not open in editor" path)))))
+          (append (plist-get input :filePaths) nil))))
+    (copilot-chat--tool-result "success" (string-join results "\n"))))
 
 (defun copilot-chat--execute-fetch-web-page (input)
   "Execute fetch_web_page tool with INPUT."

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1132,6 +1132,49 @@
         (expect (plist-get (aref (plist-get result :content) 0) :value)
                 :to-match "not open in editor"))))
 
+  (describe "copilot-chat--buffer-diagnostics"
+    (it "uses flymake diagnostics when flymake-mode is on"
+      (with-temp-buffer
+        (setq-local flymake-mode t)
+        (cl-letf (((symbol-function 'flymake-diagnostics) (lambda () (list 'd)))
+                  ((symbol-function 'flymake-diagnostic-beg) (lambda (_) (point-min)))
+                  ((symbol-function 'flymake-diagnostic-text) (lambda (_) "flym err")))
+          (expect (copilot-chat--buffer-diagnostics "/x.el")
+                  :to-equal '("/x.el:1: flym err")))))
+
+    (it "falls back to flycheck diagnostics when only flycheck-mode is on"
+      (with-temp-buffer
+        (setq-local flycheck-mode t)
+        (cl-letf (((symbol-function 'flycheck-current-errors) (lambda () (list 'e)))
+                  ((symbol-function 'flycheck-error-line) (lambda (_) 7))
+                  ((symbol-function 'flycheck-error-message) (lambda (_) "flyc err")))
+          (expect (copilot-chat--buffer-diagnostics "/x.el")
+                  :to-equal '("/x.el:7: flyc err")))))
+
+    (it "reports no errors when a backend is on but clean"
+      (with-temp-buffer
+        (setq-local flycheck-mode t)
+        (cl-letf (((symbol-function 'flycheck-current-errors) (lambda () nil)))
+          (expect (copilot-chat--buffer-diagnostics "/x.el")
+                  :to-equal '("/x.el: no errors")))))
+
+    (it "reports when no diagnostics backend is available"
+      (with-temp-buffer
+        (expect (copilot-chat--buffer-diagnostics "/x.el")
+                :to-equal '("/x.el: no diagnostics available"))))
+
+    (it "merges both backends when flymake and flycheck are both on"
+      (with-temp-buffer
+        (setq-local flymake-mode t flycheck-mode t)
+        (cl-letf (((symbol-function 'flymake-diagnostics) (lambda () (list 'd)))
+                  ((symbol-function 'flymake-diagnostic-beg) (lambda (_) (point-min)))
+                  ((symbol-function 'flymake-diagnostic-text) (lambda (_) "flym err"))
+                  ((symbol-function 'flycheck-current-errors) (lambda () (list 'e)))
+                  ((symbol-function 'flycheck-error-line) (lambda (_) 7))
+                  ((symbol-function 'flycheck-error-message) (lambda (_) "flyc err")))
+          (expect (copilot-chat--buffer-diagnostics "/x.el")
+                  :to-equal '("/x.el:1: flym err" "/x.el:7: flyc err"))))))
+
   ;;
   ;; Tool status display
   ;;


### PR DESCRIPTION
The agent-mode `get_errors` tool only read Flymake diagnostics, so Flycheck users got "no diagnostics available" for every file. It now collects from whichever backends are active - Flymake, Flycheck, or both - and only reports no backend when neither is on.
