### PR TITLE
Track and surface Copilot usage quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Track Copilot usage quota: surface the server's quota warnings and add `copilot-quota` to show how much of your chat, completion, and premium-request allowance is left.
 - Run the agent-mode `run_in_terminal` tool asynchronously instead of blocking Emacs for the whole command. The editor stays responsive, the language-server connection keeps flowing, `C-g` aborts a running command, and `copilot-chat-terminal-timeout` (default 30s) kills runaways. The command's exit status is now reported back to the model.
 - Show a status line in the chat buffer when Copilot runs one of its own built-in or MCP tools that asks for confirmation (`read_file`, the edit tools, etc.), so those tool calls leave a trace, not just the ones copilot.el executes locally.
 - Offer an `always` choice at agent-mode tool confirmation prompts, alongside yes and no, to approve a tool for the rest of the conversation instead of confirming each call. The choice is remembered until a new conversation starts.

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ For example:
 | `copilot-login` | Log in to GitHub Copilot |
 | `copilot-logout` | Log out from GitHub Copilot |
 | `copilot-diagnose` | Restart the server and show diagnostic info |
+| `copilot-quota` | Show the current Copilot usage quota |
 | `copilot-select-completion-model` | Choose which model to use for completions |
 | `copilot-chat-select-model` | Choose which model to use for chat |
 | **Completion** | |

--- a/copilot.el
+++ b/copilot.el
@@ -298,6 +298,15 @@ Incremented after each change.")
   "Current server status from `didChangeStatus' notification.
 Plist with keys :kind, :busy, and :message.")
 
+(defvar copilot--quota nil
+  "Latest quota snapshot from the `copilot/quotaChange' notification.
+A plist with keys such as :chat, :completions, :premium_interactions
+\(each a snapshot plist with :percentRemaining and :unlimited),
+:copilotPlan, and :canUpgradePlan.  Nil until the server reports it.
+
+Note `:premium_interactions' is snake_case in the server payload even
+though its siblings are camelCase; this matches the wire format.")
+
 (defvar copilot--progress-sessions (make-hash-table :test 'equal)
   "Hash table of active progress sessions, keyed by token.
 Each value is a plist with :title, :message, and :percentage.")
@@ -684,7 +693,8 @@ reaped by Emacs anyway, so the `exit' notification is enough."
     (setq copilot--connection nil)
     (setq copilot--opened-buffers nil)
     (setq copilot--workspace-folders nil)
-    (setq copilot--status nil)))
+    (setq copilot--status nil)
+    (setq copilot--quota nil)))
 
 (defun copilot--shutdown-server-at-exit ()
   "Shut down the Copilot server from `kill-emacs-hook'.
@@ -1261,6 +1271,59 @@ Each request METHOD can have only one HANDLER."
    (copilot--dbind (kind busy message) msg
      (setq copilot--status (list :kind kind :busy (eq busy t) :message message))
      (force-mode-line-update t))))
+
+(copilot-on-notification
+ 'copilot/quotaChange
+ (lambda (msg)
+   (setq copilot--quota msg)))
+
+(copilot-on-notification
+ 'copilot/quotaWarning
+ (lambda (msg)
+   (when-let* ((message (plist-get msg :message)))
+     (let ((type (plist-get msg :type)))
+       ;; The server flags the urgent ones as type "warning"; everything
+       ;; else is informational.
+       (copilot--log (if (and (stringp type)
+                              (string-equal-ignore-case type "warning"))
+                         'warning 'info)
+                     "%s" message)))))
+
+(defun copilot--quota-snapshot-string (label snapshot)
+  "Return a one-line description of quota SNAPSHOT under LABEL, or nil.
+SNAPSHOT is a plist with :percentRemaining and :unlimited."
+  (when snapshot
+    (let ((pct (plist-get snapshot :percentRemaining)))
+      (cond
+       ((eq (plist-get snapshot :unlimited) t)
+        (format "%s: unlimited" label))
+       ((numberp pct)
+        ;; Round rather than %d-truncate so a fractional sliver such as
+        ;; 0.4% doesn't read as a flat "0% remaining".
+        (format "%s: %s%% remaining" label
+                (string-trim-right (format "%.1f" pct) "\\.0")))
+       (t nil)))))
+
+(defun copilot-quota ()
+  "Show the current Copilot usage quota reported by the server."
+  (interactive)
+  (if (null copilot--quota)
+      (message "Copilot: no quota information reported yet.")
+    (let* ((plan (plist-get copilot--quota :copilotPlan))
+           (parts (delq nil
+                        (list (and plan (format "plan: %s" plan))
+                              (copilot--quota-snapshot-string
+                               "chat" (plist-get copilot--quota :chat))
+                              (copilot--quota-snapshot-string
+                               "completions"
+                               (plist-get copilot--quota :completions))
+                              (copilot--quota-snapshot-string
+                               "premium"
+                               (plist-get copilot--quota
+                                          :premium_interactions))))))
+      (if parts
+          (message "Copilot quota - %s" (string-join parts ", "))
+        (message "Copilot: quota details unavailable.")))))
 
 (copilot-on-request
  'window/showMessageRequest

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -690,6 +690,68 @@
           (expect (get-text-property 0 'face result) :to-equal 'shadow)))))
 
   ;;
+  ;; Quota
+  ;;
+
+  (describe "copilot--quota-snapshot-string"
+    (it "describes an unlimited snapshot"
+      (expect (copilot--quota-snapshot-string "chat" '(:unlimited t))
+              :to-equal "chat: unlimited"))
+
+    (it "describes a percent-remaining snapshot"
+      (expect (copilot--quota-snapshot-string "premium" '(:percentRemaining 42))
+              :to-equal "premium: 42% remaining"))
+
+    (it "keeps a fractional sliver from rounding to zero"
+      (expect (copilot--quota-snapshot-string "premium" '(:percentRemaining 0.4))
+              :to-equal "premium: 0.4% remaining"))
+
+    (it "returns nil when the snapshot has no usable data"
+      (expect (copilot--quota-snapshot-string "chat" '(:foo "bar")) :to-be nil))
+
+    (it "returns nil for a nil snapshot"
+      (expect (copilot--quota-snapshot-string "chat" nil) :to-be nil)))
+
+  (describe "copilot-quota"
+    (it "reports when no quota has been seen"
+      (let ((copilot--quota nil))
+        (spy-on 'message)
+        (copilot-quota)
+        (expect 'message :to-have-been-called-with
+                "Copilot: no quota information reported yet.")))
+
+    (it "summarizes the reported quota"
+      (let ((copilot--quota '(:copilotPlan "individual_pro"
+                              :premium_interactions (:percentRemaining 80)
+                              :chat (:unlimited t))))
+        (spy-on 'message)
+        (copilot-quota)
+        (expect 'message :to-have-been-called-with
+                "Copilot quota - %s"
+                "plan: individual_pro, chat: unlimited, premium: 80% remaining"))))
+
+  (describe "copilot/quotaChange handler"
+    (it "stores the reported quota"
+      (let ((copilot--quota nil))
+        (copilot--handle-notification nil 'copilot/quotaChange
+                                      '(:copilotPlan "business"))
+        (expect (plist-get copilot--quota :copilotPlan) :to-equal "business"))))
+
+  (describe "copilot/quotaWarning handler"
+    (it "logs the warning message"
+      (spy-on 'copilot--log)
+      (copilot--handle-notification nil 'copilot/quotaWarning
+                                    '(:type "warning" :message "almost out"))
+      (expect 'copilot--log :to-have-been-called-with
+              'warning "%s" "almost out"))
+
+    (it "logs an informational message at info level"
+      (spy-on 'copilot--log)
+      (copilot--handle-notification nil 'copilot/quotaWarning
+                                    '(:type "info" :message "fyi"))
+      (expect 'copilot--log :to-have-been-called-with 'info "%s" "fyi")))
+
+  ;;
   ;; didChangeStatus notification
   ;;
 


### PR DESCRIPTION
The server reports usage via `copilot/quotaChange` and `copilot/quotaWarning` notifications, which we ignored. This caches the latest quota snapshot, surfaces the server's warning messages (at warning/info level per the server's own severity), and adds `M-x copilot-quota` to show how much of your chat, completion, and premium-request allowance is left. Handy now that premium models draw on a quota.
