### PR TITLE
Surface public code citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Announce when a suggestion matches public code, and collect the matches (with licenses and reference URLs) in a buffer shown by `copilot-list-code-citations`. Controlled by `copilot-show-code-citations` (default on). ([#471](https://github.com/copilot-emacs/copilot.el/issues/471))
 - Track Copilot usage quota: surface the server's quota warnings and add `copilot-quota` to show how much of your chat, completion, and premium-request allowance is left.
 - Run the agent-mode `run_in_terminal` tool asynchronously instead of blocking Emacs for the whole command. The editor stays responsive, the language-server connection keeps flowing, `C-g` aborts a running command, and `copilot-chat-terminal-timeout` (default 30s) kills runaways. The command's exit status is now reported back to the model.
 - Show a status line in the chat buffer when Copilot runs one of its own built-in or MCP tools that asks for confirmation (`read_file`, the edit tools, etc.), so those tool calls leave a trace, not just the ones copilot.el executes locally.

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ For example:
 | `copilot-logout` | Log out from GitHub Copilot |
 | `copilot-diagnose` | Restart the server and show diagnostic info |
 | `copilot-quota` | Show the current Copilot usage quota |
+| `copilot-list-code-citations` | Show suggestions that matched public code |
 | `copilot-select-completion-model` | Choose which model to use for completions |
 | `copilot-chat-select-model` | Choose which model to use for chat |
 | **Completion** | |

--- a/copilot.el
+++ b/copilot.el
@@ -137,6 +137,16 @@ find indentation offset."
   :type 'boolean
   :package-version '(copilot . "0.1"))
 
+(defcustom copilot-show-code-citations t
+  "When non-nil, report when a suggestion matches public code.
+GitHub Copilot can detect when a suggestion closely matches public
+code.  When enabled, such matches are announced in the echo area and
+collected, with their licenses and reference URLs, in the
+`*copilot-code-references*' buffer (see `copilot-list-code-citations')."
+  :group 'copilot
+  :type 'boolean
+  :package-version '(copilot . "0.7"))
+
 (defcustom copilot-enable-parentheses-balancer t
   "Whether to post-process completions to balance parentheses in Lisp modes.
 When non-nil, completions in Lisp modes are adjusted to ensure that
@@ -788,7 +798,13 @@ You can change the installed version with `M-x copilot-reinstall-server` or remo
           (:workspaceFolders t)
           :textDocument
           (:inlineCompletion
-           (:dynamicRegistration :json-false)))
+           (:dynamicRegistration :json-false))
+          ;; Opt into the server's public-code matching notifications
+          ;; (`copilot/ipCodeCitation'); off by default server-side, and
+          ;; only requested when the user wants them so disabling the
+          ;; option also stops the underlying traffic.
+          :copilot
+          (:ipCodeCitation ,(if copilot-show-code-citations t :json-false)))
          ,@(when folders `(:workspaceFolders ,folders))
          :initializationOptions
          (:editorInfo
@@ -1010,6 +1026,13 @@ Sends `$/cancelRequest' to the server and resets the stored request ID."
     (concat "file:///" (url-encode-url path)))
    (t
     (concat "file://" (url-encode-url path)))))
+
+(defun copilot--uri-to-path (uri)
+  "Convert a file URI to a percent-decoded path.
+Non-file URIs are returned unchanged."
+  (if (string-prefix-p "file://" uri)
+      (url-unhex-string (string-remove-prefix "file://" uri))
+    uri))
 
 (defun copilot--get-uri ()
   "Get URI of current buffer."
@@ -1324,6 +1347,69 @@ SNAPSHOT is a plist with :percentRemaining and :unlimited."
       (if parts
           (message "Copilot quota - %s" (string-join parts ", "))
         (message "Copilot: quota details unavailable.")))))
+
+(defconst copilot--code-references-buffer-name "*copilot-code-references*"
+  "Name of the buffer collecting public-code citation details.")
+
+(defun copilot--citation-licenses (citations)
+  "Return a comma-separated, de-duplicated license list from CITATIONS."
+  (let ((seen '()))
+    (dolist (c (append citations nil))
+      (when-let* ((license (plist-get c :license)))
+        (cl-pushnew license seen :test #'equal)))
+    (string-join (nreverse seen) ", ")))
+
+(defun copilot--citation-file-name (uri)
+  "Return a display file name for citation URI, or a placeholder."
+  (if (and (stringp uri) (not (string-empty-p uri)))
+      (file-name-nondirectory (copilot--uri-to-path uri))
+    "unknown file"))
+
+(defun copilot--record-code-citation (name line matching citations)
+  "Append a public-code match to the code references buffer.
+NAME, LINE, MATCHING and CITATIONS describe the matched region."
+  (with-current-buffer (get-buffer-create copilot--code-references-buffer-name)
+    ;; Set the mode only when the buffer is first created, so reading it
+    ;; isn't disturbed as later matches are appended.
+    (unless (derived-mode-p 'special-mode)
+      (special-mode))
+    (let ((inhibit-read-only t))
+      (goto-char (point-max))
+      (insert (propertize (format "%s:%s\n" name line) 'face 'bold))
+      (when (and (stringp matching) (not (string-empty-p matching)))
+        (insert (format "  near: %s\n" (car (split-string matching "\n")))))
+      (dolist (c (append citations nil))
+        (insert (format "  [%s] %s\n"
+                        (or (plist-get c :license) "unknown")
+                        (or (plist-get c :url) ""))))
+      (insert "\n"))))
+
+(defun copilot--handle-code-citation (msg)
+  "Handle a `copilot/ipCodeCitation' notification MSG.
+Announce the public-code match and record its details."
+  (when copilot-show-code-citations
+    (let* ((name (copilot--citation-file-name (plist-get msg :uri)))
+           (citations (plist-get msg :citations))
+           (start (plist-get (plist-get msg :range) :start))
+           (line (if (numberp (plist-get start :line))
+                     (1+ (plist-get start :line))
+                   "-"))
+           (licenses (copilot--citation-licenses citations)))
+      (copilot--record-code-citation name line (plist-get msg :matchingText)
+                                     citations)
+      (message "Copilot: suggestion near %s:%s matches public code%s"
+               name line
+               (if (string-empty-p licenses) "" (format " (%s)" licenses))))))
+
+(copilot-on-notification 'copilot/ipCodeCitation
+                         #'copilot--handle-code-citation)
+
+(defun copilot-list-code-citations ()
+  "Show the buffer collecting public-code citation details."
+  (interactive)
+  (if-let* ((buf (get-buffer copilot--code-references-buffer-name)))
+      (display-buffer buf)
+    (message "Copilot: no public-code matches recorded yet.")))
 
 (copilot-on-request
  'window/showMessageRequest

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -752,6 +752,63 @@
       (expect 'copilot--log :to-have-been-called-with 'info "%s" "fyi")))
 
   ;;
+  ;; Public code citations (#471)
+  ;;
+
+  (describe "copilot--citation-licenses"
+    (it "joins and de-duplicates licenses"
+      (expect (copilot--citation-licenses
+               (vector '(:license "MIT") '(:license "GPL-2.0") '(:license "MIT")))
+              :to-equal "MIT, GPL-2.0"))
+
+    (it "returns empty string when there are no licenses"
+      (expect (copilot--citation-licenses []) :to-equal "")))
+
+  (describe "copilot--handle-code-citation"
+    (after-each
+      (when (get-buffer "*copilot-code-references*")
+        (kill-buffer "*copilot-code-references*")))
+
+    (it "announces a match and records its details"
+      (let ((copilot-show-code-citations t))
+        (spy-on 'message)
+        (copilot--handle-code-citation
+         (list :uri "file:///tmp/foo%20bar.js"
+               :range '(:start (:line 6 :character 12))
+               :matchingText "function fizzBuzz() {"
+               :citations (vector '(:license "GPL-2.0"
+                                    :url "https://example.com/ref"))))
+        ;; Echo-area announcement names the decoded file, 1-based line,
+        ;; and license.
+        (expect 'message :to-have-been-called-with
+                "Copilot: suggestion near %s:%s matches public code%s"
+                "foo bar.js" 7 " (GPL-2.0)")
+        ;; Full detail, with URL, is collected in the references buffer.
+        (with-current-buffer "*copilot-code-references*"
+          (let ((text (buffer-string)))
+            (expect text :to-match "foo bar.js:7")
+            (expect text :to-match "GPL-2.0")
+            (expect text :to-match "https://example.com/ref")))))
+
+    (it "uses a placeholder when the uri is missing"
+      (let ((copilot-show-code-citations t))
+        (spy-on 'message)
+        (copilot--handle-code-citation
+         (list :citations (vector '(:license "MIT" :url "u"))))
+        (expect 'message :to-have-been-called-with
+                "Copilot: suggestion near %s:%s matches public code%s"
+                "unknown file" "-" " (MIT)")))
+
+    (it "does nothing when copilot-show-code-citations is nil"
+      (let ((copilot-show-code-citations nil))
+        (spy-on 'message)
+        (copilot--handle-code-citation
+         (list :uri "file:///tmp/foo.js"
+               :citations (vector '(:license "MIT" :url "u"))))
+        (expect 'message :not :to-have-been-called)
+        (expect (get-buffer "*copilot-code-references*") :to-be nil))))
+
+  ;;
   ;; didChangeStatus notification
   ;;
 


### PR DESCRIPTION
GitHub Copilot can detect when a suggestion closely matches public code, but the server only emitted these as log lines. This declares the `ipCodeCitation` capability (only when the feature is enabled) and handles the `copilot/ipCodeCitation` notification: it announces the match in the echo area and collects each one, with its licenses and reference URLs, in a `*copilot-code-references*` buffer reachable via `M-x copilot-list-code-citations`. Controlled by `copilot-show-code-citations` (default on).

Fixes #471
