### PR TITLE
Insert and copy chat code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Act on chat code blocks: `copilot-chat-insert-code-block` (`C-c C-i`) inserts the block at point into the source buffer, and `copilot-chat-copy-code-block` (`C-c M-w`) copies it to the kill ring, instead of leaving chat output as read-only text.
 - Announce when a suggestion matches public code, and collect the matches (with licenses and reference URLs) in a buffer shown by `copilot-list-code-citations`. Controlled by `copilot-show-code-citations` (default on). ([#471](https://github.com/copilot-emacs/copilot.el/issues/471))
 - Track Copilot usage quota: surface the server's quota warnings and add `copilot-quota` to show how much of your chat, completion, and premium-request allowance is left.
 - Run the agent-mode `run_in_terminal` tool asynchronously instead of blocking Emacs for the whole command. The editor stays responsive, the language-server connection keeps flowing, `C-g` aborts a running command, and `copilot-chat-terminal-timeout` (default 30s) kills runaways. The command's exit status is now reported back to the model.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ M-x copilot-chat-send-region
 Key bindings in the `*copilot-chat*` buffer:
 - **C-c RET** or **C-c C-c** — send a follow-up message
 - **C-c C-k** — cancel streaming, or reset if idle
+- **C-c C-i** — insert the code block at point into the source buffer
+- **C-c M-w** — copy the code block at point to the kill ring
 - **q** — quit the chat window
 
 Customization:

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -1048,6 +1048,102 @@ CALLBACK is called with the response containing conversationId and turnId."
             (propertize "Copilot:" 'face 'bold) "\n")))
 
 ;;
+;; Code blocks
+;;
+
+(defconst copilot-chat--code-block-re
+  "^[ \t]*```[ \t]*\\([^\n]*\\)\n\\(\\(?:.*\n\\)*?\\)[ \t]*```[ \t]*$"
+  "Regexp matching a fenced code block.
+Group 1 is the info string (language); group 2 is the body.")
+
+(defun copilot-chat--code-blocks ()
+  "Return the fenced code blocks in the current buffer.
+Each element is a plist with :lang, :code, :start, and :end.
+
+Note: a block whose body itself contains an indented ``` line ends at
+that inner fence, since the parser does not track fence nesting."
+  (let ((blocks '()))
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward copilot-chat--code-block-re nil t)
+        ;; Read every match-data-derived field before any call (such as
+        ;; `string-trim') that could clobber the match data.
+        (let ((lang (match-string-no-properties 1))
+              (code (match-string-no-properties 2))
+              (start (match-beginning 0))
+              (end (match-end 0)))
+          (push (list :lang (string-trim lang) :code code
+                      :start start :end end)
+                blocks))))
+    (nreverse blocks)))
+
+(defun copilot-chat--read-code-block (blocks)
+  "Return a code block from BLOCKS: the one at point, or one chosen.
+Signal a `user-error' when BLOCKS is empty."
+  (or (seq-find (lambda (b)
+                  (and (>= (point) (plist-get b :start))
+                       (<= (point) (plist-get b :end))))
+                blocks)
+      (cond
+       ((null blocks) (user-error "No code blocks in this chat"))
+       ((= (length blocks) 1) (car blocks))
+       (t
+        (let* ((choices
+                (seq-map-indexed
+                 (lambda (b i)
+                   (cons (format "%d: [%s] %s" (1+ i)
+                                 (if (string-empty-p (plist-get b :lang))
+                                     "?" (plist-get b :lang))
+                                 (car (split-string (plist-get b :code) "\n")))
+                         b))
+                 blocks))
+               (choice (completing-read "Code block: " choices nil t)))
+          (cdr (assoc choice choices)))))))
+
+(defun copilot-chat--current-code-block ()
+  "Return a chosen code block from the chat buffer.
+Signal a `user-error' outside the chat buffer or when the block is empty."
+  (unless (derived-mode-p 'copilot-chat-mode)
+    (user-error "Not in a Copilot chat buffer"))
+  (let* ((block (copilot-chat--read-code-block (copilot-chat--code-blocks)))
+         (code (plist-get block :code)))
+    (when (or (null code) (string-empty-p (string-trim code)))
+      (user-error "That code block is empty"))
+    block))
+
+(defun copilot-chat-copy-code-block ()
+  "Copy a chat code block to the kill ring.
+Use the block at point, or prompt when point is not inside one."
+  (interactive)
+  (kill-new (plist-get (copilot-chat--current-code-block) :code))
+  (message "Copied code block to kill ring"))
+
+(defun copilot-chat-insert-code-block ()
+  "Insert a chat code block into the source buffer at its point.
+Use the block at point, or prompt when point is not inside one.  When
+there is no live source buffer, prompt for a target buffer.  Focus stays
+in the chat buffer."
+  (interactive)
+  (let* ((code (plist-get (copilot-chat--current-code-block) :code))
+         (target (if (buffer-live-p copilot-chat--source-buffer)
+                     copilot-chat--source-buffer
+                   (get-buffer (read-buffer "Insert into buffer: "
+                                            nil t)))))
+    (unless (buffer-live-p target)
+      (user-error "No target buffer to insert into"))
+    (with-current-buffer target
+      (when buffer-read-only
+        (user-error "Target buffer %s is read-only" (buffer-name)))
+      ;; Insert at point in the target's visible window when there is
+      ;; one, so the snippet lands where the user is looking rather than
+      ;; at a stale point; never steal focus from the chat.
+      (let ((win (get-buffer-window target t)))
+        (if win
+            (with-selected-window win (insert code))
+          (insert code))))
+    (message "Inserted code block into %s" (buffer-name target))))
+
+;;
 ;; Major mode
 ;;
 
@@ -1056,6 +1152,8 @@ CALLBACK is called with the response containing conversationId and turnId."
     (define-key map (kbd "C-c RET") #'copilot-chat-send)
     (define-key map (kbd "C-c C-c") #'copilot-chat-send)
     (define-key map (kbd "C-c C-k") #'copilot-chat-stop)
+    (define-key map (kbd "C-c C-i") #'copilot-chat-insert-code-block)
+    (define-key map (kbd "C-c M-w") #'copilot-chat-copy-code-block)
     (define-key map (kbd "q") #'quit-window)
     map)
   "Keymap for `copilot-chat-mode'.")

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -56,7 +56,114 @@
         (expect (lookup-key copilot-chat-mode-map (kbd "C-c C-c"))
                 :to-equal #'copilot-chat-send)
         (expect (lookup-key copilot-chat-mode-map (kbd "C-c C-k"))
-                :to-equal #'copilot-chat-stop))))
+                :to-equal #'copilot-chat-stop)
+        (expect (lookup-key copilot-chat-mode-map (kbd "C-c C-i"))
+                :to-equal #'copilot-chat-insert-code-block))))
+
+  ;;
+  ;; Code blocks
+  ;;
+
+  (describe "copilot-chat--code-blocks"
+    (it "parses fenced blocks with language and body"
+      (with-temp-buffer
+        (insert "intro\n```elisp\n(foo)\n(bar)\n```\nmid\n```\nplain\n```\n")
+        (let ((blocks (copilot-chat--code-blocks)))
+          (expect (length blocks) :to-equal 2)
+          (expect (plist-get (nth 0 blocks) :lang) :to-equal "elisp")
+          (expect (plist-get (nth 0 blocks) :code) :to-equal "(foo)\n(bar)\n")
+          (expect (plist-get (nth 1 blocks) :lang) :to-equal "")
+          (expect (plist-get (nth 1 blocks) :code) :to-equal "plain\n"))))
+
+    (it "returns nil when there are no code blocks"
+      (with-temp-buffer
+        (insert "just prose, no fences")
+        (expect (copilot-chat--code-blocks) :to-be nil))))
+
+  (describe "copilot-chat--read-code-block"
+    (it "returns the block surrounding point"
+      (with-temp-buffer
+        (insert "```js\nconsole.log(1)\n```\n")
+        (goto-char (point-min))
+        (forward-line 1)
+        (let ((blocks (copilot-chat--code-blocks)))
+          (expect (plist-get (copilot-chat--read-code-block blocks) :code)
+                  :to-equal "console.log(1)\n"))))
+
+    (it "uses the only block when point is outside any block"
+      (with-temp-buffer
+        (insert "prose\n```js\nx\n```\n")
+        (goto-char (point-min))
+        (let ((blocks (copilot-chat--code-blocks)))
+          (expect (plist-get (copilot-chat--read-code-block blocks) :code)
+                  :to-equal "x\n"))))
+
+    (it "errors when there are no blocks"
+      (expect (copilot-chat--read-code-block nil) :to-throw 'user-error)))
+
+  (describe "copilot-chat-copy-code-block"
+    (it "copies the block at point to the kill ring"
+      (with-temp-buffer
+        (copilot-chat-mode)
+        (let ((inhibit-read-only t))
+          (insert "```py\nprint(1)\n```\n"))
+        (goto-char (point-min))
+        (forward-line 1)
+        (spy-on 'message)
+        (copilot-chat-copy-code-block)
+        (expect (current-kill 0) :to-equal "print(1)\n")))
+
+    (it "errors when there are no code blocks"
+      (with-temp-buffer
+        (copilot-chat-mode)
+        (expect (copilot-chat-copy-code-block) :to-throw 'user-error)))
+
+    (it "errors on an empty code block"
+      (with-temp-buffer
+        (copilot-chat-mode)
+        (let ((inhibit-read-only t))
+          (insert "```\n\n```\n"))
+        (goto-char (point-min))
+        (forward-line 1)
+        (expect (copilot-chat-copy-code-block) :to-throw 'user-error)))
+
+    (it "errors outside a chat buffer"
+      (with-temp-buffer
+        (insert "```py\nx\n```\n")
+        (expect (copilot-chat-copy-code-block) :to-throw 'user-error))))
+
+  (describe "copilot-chat-insert-code-block"
+    (it "inserts the block into the source buffer"
+      (let ((src (get-buffer-create "*copilot-apply-src*")))
+        (unwind-protect
+            (with-temp-buffer
+              (copilot-chat-mode)
+              (setq copilot-chat--source-buffer src)
+              (let ((inhibit-read-only t))
+                (insert "```c\nint x;\n```\n"))
+              (goto-char (point-min))
+              (forward-line 1)
+              (spy-on 'message)
+              (copilot-chat-insert-code-block)
+              (expect (with-current-buffer src (buffer-string))
+                      :to-match "int x;"))
+          (kill-buffer src))))
+
+    (it "refuses to insert into a read-only target"
+      (let ((src (get-buffer-create "*copilot-apply-ro*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer src (setq buffer-read-only t))
+              (with-temp-buffer
+                (copilot-chat-mode)
+                (setq copilot-chat--source-buffer src)
+                (let ((inhibit-read-only t))
+                  (insert "```c\ny\n```\n"))
+                (goto-char (point-min))
+                (forward-line 1)
+                (expect (copilot-chat-insert-code-block)
+                        :to-throw 'user-error)))
+          (kill-buffer src)))))
 
   ;;
   ;; Progress handler


### PR DESCRIPTION
Chat output was read-only text, so applying a suggested snippet meant retyping it. This parses the fenced code blocks in the chat buffer and adds two commands: `copilot-chat-insert-code-block` (`C-c C-i`) inserts the block at point into the originating source buffer, and `copilot-chat-copy-code-block` (`C-c M-w`) copies it to the kill ring. When point isn't inside a block, both prompt for which one. Inserts land at point in the source window without stealing focus from the chat, and both commands refuse to run outside the chat buffer or on an empty block.
