### PR TITLE
Add chat slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Add `copilot-chat-slash-command` (`C-c /`) to pick and send a chat slash command (`/explain`, `/fix`, `/tests`, `/doc`, etc.) fetched from the server, with optional arguments.
 - Act on chat code blocks: `copilot-chat-insert-code-block` (`C-c C-i`) inserts the block at point into the source buffer, and `copilot-chat-copy-code-block` (`C-c M-w`) copies it to the kill ring, instead of leaving chat output as read-only text.
 - Announce when a suggestion matches public code, and collect the matches (with licenses and reference URLs) in a buffer shown by `copilot-list-code-citations`. Controlled by `copilot-show-code-citations` (default on). ([#471](https://github.com/copilot-emacs/copilot.el/issues/471))
 - Track Copilot usage quota: surface the server's quota warnings and add `copilot-quota` to show how much of your chat, completion, and premium-request allowance is left.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Key bindings in the `*copilot-chat*` buffer:
 - **C-c C-k** — cancel streaming, or reset if idle
 - **C-c C-i** — insert the code block at point into the source buffer
 - **C-c M-w** — copy the code block at point to the kill ring
+- **C-c /** — pick and send a slash command (`/explain`, `/fix`, `/tests`, ...)
 - **q** — quit the chat window
 
 Customization:

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -1154,6 +1154,7 @@ in the chat buffer."
     (define-key map (kbd "C-c C-k") #'copilot-chat-stop)
     (define-key map (kbd "C-c C-i") #'copilot-chat-insert-code-block)
     (define-key map (kbd "C-c M-w") #'copilot-chat-copy-code-block)
+    (define-key map (kbd "C-c /") #'copilot-chat-slash-command)
     (define-key map (kbd "q") #'quit-window)
     map)
   "Keymap for `copilot-chat-mode'.")
@@ -1277,6 +1278,62 @@ When called interactively, prompt for the message."
                       (format "%s\n\n```%s\n%s\n```" prompt lang code)
                     (format "```%s\n%s\n```" lang code))))
     (copilot-chat message)))
+
+(defvar copilot-chat--templates nil
+  "Cached slash-command templates from `conversation/templates'.
+The set is static per session, so it is fetched once.")
+
+(defun copilot-chat--chat-templates ()
+  "Return the server's slash-command templates for the chat.
+Filter to the scope matching the current mode (`agent-panel' when
+`copilot-chat-use-agent-mode' is on, otherwise `chat-panel').  The
+server query is made at most once per session and cached; a failed
+query yields no templates rather than an error."
+  (unless copilot-chat--templates
+    (setq copilot-chat--templates
+          (condition-case err
+              (let* ((root (copilot--workspace-root))
+                     (params (when root
+                               (list :workspaceFolders
+                                     (vector (list :uri (copilot--path-to-uri root)
+                                                   :name (file-name-nondirectory
+                                                          (directory-file-name root))))))))
+                (or (append (copilot--request 'conversation/templates params)
+                            nil)
+                    ;; Distinguish "fetched, none" from "not fetched yet".
+                    'none))
+            (error
+             (copilot--log 'warning "Could not fetch chat templates: %S" err)
+             'none))))
+  (let ((scope (if copilot-chat-use-agent-mode "agent-panel" "chat-panel")))
+    (seq-filter (lambda (tpl)
+                  (seq-contains-p (plist-get tpl :scopes) scope))
+                (if (eq copilot-chat--templates 'none) nil
+                  copilot-chat--templates))))
+
+;;;###autoload
+(defun copilot-chat-slash-command ()
+  "Choose a Copilot Chat slash command and send it.
+Slash commands (such as `/explain', `/fix', `/tests', `/doc') are
+fetched from the server.  You can supply optional arguments after the
+command."
+  (interactive)
+  (let ((templates (copilot-chat--chat-templates)))
+    (unless templates
+      (user-error "No slash commands available"))
+    (let* ((choices
+            (mapcar (lambda (tpl)
+                      (cons (format "/%s  %s" (plist-get tpl :id)
+                                    (or (plist-get tpl :description) ""))
+                            (plist-get tpl :id)))
+                    templates))
+           (choice (completing-read "Slash command: " choices nil t))
+           (id (cdr (assoc choice choices)))
+           (args (read-string (format "/%s " id)))
+           (message (if (string-empty-p (string-trim args))
+                        (format "/%s" id)
+                      (format "/%s %s" id args))))
+      (copilot-chat message))))
 
 ;;;###autoload
 (defun copilot-chat-stop ()

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1398,6 +1398,84 @@
           (expect msg :to-match "```emacs-lisp")
           (expect msg :to-match "(\\+ 1 2)")))))
 
+  (describe "copilot-chat--chat-templates"
+    ;; copilot--request is a macro over jsonrpc-request, so stub the
+    ;; transport rather than the macro.
+    (before-each
+      (setq copilot-chat--templates nil)
+      (spy-on 'copilot--workspace-root :and-return-value nil)
+      (spy-on 'copilot--connection-alivep :and-return-value t))
+    (after-each (setq copilot-chat--templates nil))
+
+    (it "filters templates to the chat-panel scope"
+      (let ((copilot-chat-use-agent-mode nil))
+        (spy-on 'jsonrpc-request :and-return-value
+                (vector (list :id "explain" :scopes ["chat-panel"])
+                        (list :id "agentonly" :scopes ["agent-panel"])))
+        (let ((tpls (copilot-chat--chat-templates)))
+          (expect (length tpls) :to-equal 1)
+          (expect (plist-get (car tpls) :id) :to-equal "explain"))))
+
+    (it "filters to the agent-panel scope in agent mode"
+      (let ((copilot-chat-use-agent-mode t))
+        (spy-on 'jsonrpc-request :and-return-value
+                (vector (list :id "explain" :scopes ["chat-panel"])
+                        (list :id "agentcmd" :scopes ["agent-panel"])))
+        (expect (plist-get (car (copilot-chat--chat-templates)) :id)
+                :to-equal "agentcmd")))
+
+    (it "sends a percent-encoded workspace-folder URI"
+      (let ((copilot-chat-use-agent-mode nil)
+            (captured nil))
+        (spy-on 'copilot--workspace-root :and-return-value "/tmp/My Project")
+        (spy-on 'jsonrpc-request :and-call-fake
+                (lambda (_conn _method params &rest _)
+                  (setq captured params)
+                  []))
+        (copilot-chat--chat-templates)
+        (let ((uri (plist-get (aref (plist-get captured :workspaceFolders) 0)
+                              :uri)))
+          (expect uri :to-match "My%20Project"))))
+
+    (it "caches the result and queries the server once"
+      (let ((copilot-chat-use-agent-mode nil))
+        (spy-on 'jsonrpc-request :and-return-value
+                (vector (list :id "explain" :scopes ["chat-panel"])))
+        (copilot-chat--chat-templates)
+        (copilot-chat--chat-templates)
+        (expect 'jsonrpc-request :to-have-been-called-times 1)))
+
+    (it "returns no templates when the query fails"
+      (let ((copilot-chat-use-agent-mode nil))
+        (spy-on 'copilot--log)
+        (spy-on 'jsonrpc-request :and-throw-error 'error)
+        (expect (copilot-chat--chat-templates) :to-be nil))))
+
+  (describe "copilot-chat-slash-command"
+    (it "sends the chosen command with arguments as a message"
+      (spy-on 'copilot-chat--chat-templates :and-return-value
+              (list (list :id "explain" :description "Explain code"
+                          :scopes ["chat-panel"])))
+      (spy-on 'completing-read :and-return-value "/explain  Explain code")
+      (spy-on 'read-string :and-return-value "this function")
+      (spy-on 'copilot-chat)
+      (copilot-chat-slash-command)
+      (expect 'copilot-chat :to-have-been-called-with "/explain this function"))
+
+    (it "sends a bare command when no arguments are given"
+      (spy-on 'copilot-chat--chat-templates :and-return-value
+              (list (list :id "tests" :description "Generate tests"
+                          :scopes ["chat-panel"])))
+      (spy-on 'completing-read :and-return-value "/tests  Generate tests")
+      (spy-on 'read-string :and-return-value "  ")
+      (spy-on 'copilot-chat)
+      (copilot-chat-slash-command)
+      (expect 'copilot-chat :to-have-been-called-with "/tests"))
+
+    (it "errors when no slash commands are available"
+      (spy-on 'copilot-chat--chat-templates :and-return-value nil)
+      (expect (copilot-chat-slash-command) :to-throw 'user-error)))
+
   (describe "copilot-chat-select-model"
     (it "sets copilot-chat-model from user selection"
       (let ((copilot-chat-model nil))


### PR DESCRIPTION
Slash commands (`/explain`, `/fix`, `/tests`, `/doc`, ...) are a staple of the VS Code chat but were unavailable here. This fetches the server's templates via `conversation/templates` (filtered to the scope for the current mode, cached per session, failing soft) and adds `copilot-chat-slash-command` (`C-c /`) to pick one and send it - with optional arguments - as a `/<id>` message.
