### PR TITLE
Attach files and selections as chat context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Attach extra context to a chat message: `copilot-chat-add-file-reference` (`C-c C-f`) and `copilot-chat-add-region-reference` send specific files or selections along with the next message, and `copilot-chat-clear-references` drops anything pending.
 - Add `copilot-chat-slash-command` (`C-c /`) to pick and send a chat slash command (`/explain`, `/fix`, `/tests`, `/doc`, etc.) fetched from the server, with optional arguments.
 - Act on chat code blocks: `copilot-chat-insert-code-block` (`C-c C-i`) inserts the block at point into the source buffer, and `copilot-chat-copy-code-block` (`C-c M-w`) copies it to the kill ring, instead of leaving chat output as read-only text.
 - Announce when a suggestion matches public code, and collect the matches (with licenses and reference URLs) in a buffer shown by `copilot-list-code-citations`. Controlled by `copilot-show-code-citations` (default on). ([#471](https://github.com/copilot-emacs/copilot.el/issues/471))

--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ Key bindings in the `*copilot-chat*` buffer:
 - **C-c C-i** — insert the code block at point into the source buffer
 - **C-c M-w** — copy the code block at point to the kill ring
 - **C-c /** — pick and send a slash command (`/explain`, `/fix`, `/tests`, ...)
+- **C-c C-f** — attach a file as context for the next message
 - **q** — quit the chat window
+
+Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
 
 Customization:
 - **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -155,6 +155,11 @@ which may be slightly after `copilot-chat--request-id' is set.")
 (defvar-local copilot-chat--source-buffer nil
   "The code buffer providing context for this chat.")
 
+(defvar-local copilot-chat--references nil
+  "References to attach to the next chat turn.
+A list of plists like (:type \"file\" :uri URI), sent as the turn's
+`references' and cleared once a message is sent.")
+
 (defvar-local copilot-chat--follow-up nil
   "Follow-up suggestion from the last turn.")
 
@@ -976,8 +981,13 @@ CALLBACK is called with the response containing conversationId and turnId."
                                          (directory-file-name root)))))))
              (when copilot-chat-use-agent-mode
                (list :chatMode "Agent"
-                     :needToolCallConfirmation t)))
+                     :needToolCallConfirmation t))
+             (copilot-chat--references-param))
             :success-fn (lambda (result)
+                          (when-let* ((buf (get-buffer
+                                            copilot-chat--buffer-name)))
+                            (with-current-buffer buf
+                              (copilot-chat--consume-references)))
                           (when copilot-chat-use-agent-mode
                             (copilot-chat--register-tools))
                           (funcall callback result))
@@ -1003,10 +1013,12 @@ CALLBACK is called with the response containing conversationId and turnId."
                       :conversationId conv-id
                       :message message
                       :source "panel")
-                (when doc (list :doc doc)))
+                (when doc (list :doc doc))
+                (copilot-chat--references-param))
                :success-fn (lambda (result)
                              (when (buffer-live-p chat-buf)
                                (with-current-buffer chat-buf
+                                 (copilot-chat--consume-references)
                                  (setq copilot-chat--current-turn-id
                                        (plist-get result :turnId)))))
                :error-fn (lambda (err)
@@ -1144,6 +1156,72 @@ in the chat buffer."
     (message "Inserted code block into %s" (buffer-name target))))
 
 ;;
+;; Context references
+;;
+
+(defun copilot-chat--add-reference (ref)
+  "Add REF to the pending references in the chat buffer.
+Create the chat buffer when none exists, so context can be attached
+before the first message."
+  (with-current-buffer (get-buffer-create copilot-chat--buffer-name)
+    (unless (derived-mode-p 'copilot-chat-mode)
+      (copilot-chat-mode))
+    (let ((added (not (member ref copilot-chat--references))))
+      (when added
+        ;; `setq-local' rather than relying on the defvar-local default,
+        ;; so the binding is unambiguously buffer-local right after the
+        ;; major mode has reset local variables.
+        (setq-local copilot-chat--references
+                    (cons ref copilot-chat--references)))
+      (message (if added "Attached %d reference(s) to the next message"
+                 "Reference already attached (%d total)")
+               (length copilot-chat--references)))))
+
+(defun copilot-chat--references-param ()
+  "Return a (:references VECTOR) plist for the pending references, or nil.
+The references are left in place; clear them with
+`copilot-chat--consume-references' once the message is sent."
+  (when copilot-chat--references
+    (list :references (vconcat (reverse copilot-chat--references)))))
+
+(defun copilot-chat--consume-references ()
+  "Clear the pending references in the current chat buffer."
+  (setq copilot-chat--references nil))
+
+(defun copilot-chat--file-reference (file)
+  "Return a file-reference plist for FILE."
+  (list :type "file" :uri (copilot--path-to-uri (expand-file-name file))))
+
+;;;###autoload
+(defun copilot-chat-add-file-reference (file)
+  "Attach FILE as context for the next Copilot Chat message."
+  (interactive "fAttach file: ")
+  (copilot-chat--add-reference (copilot-chat--file-reference file)))
+
+;;;###autoload
+(defun copilot-chat-add-region-reference (start end)
+  "Attach the region between START and END as context for the next message.
+The reference points at the current file with the region's range."
+  (interactive "r")
+  (unless buffer-file-name
+    (user-error "Buffer is not visiting a file"))
+  (let ((sel (list :start (copilot--lsp-pos start)
+                   :end (copilot--lsp-pos end))))
+    (copilot-chat--add-reference
+     (list :type "file"
+           :uri (copilot--path-to-uri buffer-file-name)
+           :selection sel))))
+
+;;;###autoload
+(defun copilot-chat-clear-references ()
+  "Drop the references pending for the next Copilot Chat message."
+  (interactive)
+  (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
+    (with-current-buffer buf
+      (copilot-chat--consume-references)))
+  (message "Cleared pending chat references"))
+
+;;
 ;; Major mode
 ;;
 
@@ -1155,6 +1233,7 @@ in the chat buffer."
     (define-key map (kbd "C-c C-i") #'copilot-chat-insert-code-block)
     (define-key map (kbd "C-c M-w") #'copilot-chat-copy-code-block)
     (define-key map (kbd "C-c /") #'copilot-chat-slash-command)
+    (define-key map (kbd "C-c C-f") #'copilot-chat-add-file-reference)
     (define-key map (kbd "q") #'quit-window)
     map)
   "Keymap for `copilot-chat-mode'.")

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1398,6 +1398,80 @@
           (expect msg :to-match "```emacs-lisp")
           (expect msg :to-match "(\\+ 1 2)")))))
 
+  (describe "context references"
+    ;; Start from a clean slate: no stale chat buffer leaked from an
+    ;; earlier spec, so the "create if needed" path is exercised honestly.
+    (before-each
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name)))
+    (after-each
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name)))
+
+    (it "builds a file reference with a file URI"
+      (let ((ref (copilot-chat--file-reference "/tmp/foo.el")))
+        ;; Compare the whole plist so any divergence prints both values.
+        (expect (prin1-to-string ref) :to-match
+                "\\`(:type \"file\" :uri \"file://")))
+
+    (it "creates the chat buffer when none exists"
+      (spy-on 'message)
+      (with-temp-buffer
+        (expect (get-buffer copilot-chat--buffer-name) :to-be nil)
+        (copilot-chat-add-file-reference "/tmp/foo.el")
+        (expect (get-buffer copilot-chat--buffer-name) :to-be-truthy)))
+
+    (it "attaches a region reference with the selection range"
+      (spy-on 'message)
+      (let ((src (get-buffer-create "*copilot-ref-src*")))
+        (unwind-protect
+            (with-current-buffer src
+              (setq buffer-file-name "/tmp/ref-src.el")
+              (insert "line1\nline2\nline3\n")
+              (copilot-chat-add-region-reference (point-min) (point-max))
+              (with-current-buffer copilot-chat--buffer-name
+                (let ((ref (car copilot-chat--references)))
+                  (expect (plist-get ref :uri) :to-match "ref-src.el")
+                  (expect (plist-get (plist-get ref :selection) :start)
+                          :to-be-truthy)
+                  (expect (plist-get (plist-get ref :selection) :end)
+                          :to-be-truthy))))
+          (with-current-buffer src (set-buffer-modified-p nil))
+          (kill-buffer src))))
+
+    (it "errors on a region reference outside a file"
+      (with-temp-buffer
+        (insert "x")
+        (expect (copilot-chat-add-region-reference (point-min) (point-max))
+                :to-throw 'user-error)))
+
+    (it "builds a (:references VECTOR) param without consuming it"
+      (with-current-buffer (get-buffer-create copilot-chat--buffer-name)
+        (copilot-chat-mode)
+        (setq copilot-chat--references
+              (list (list :type "file" :uri "file:///a")
+                    (list :type "file" :uri "file:///b")))
+        (let ((param (copilot-chat--references-param)))
+          (expect (vectorp (plist-get param :references)) :to-be-truthy)
+          (expect (length (plist-get param :references)) :to-equal 2)
+          ;; Reverses to insertion order: /b was pushed last, /a first.
+          (expect (plist-get (aref (plist-get param :references) 0) :uri)
+                  :to-equal "file:///b"))
+        ;; Building the param leaves the pending list intact so a failed
+        ;; request does not lose the attachment.
+        (expect (length copilot-chat--references) :to-equal 2)
+        (copilot-chat--consume-references)
+        (expect copilot-chat--references :to-be nil)))
+
+    (it "clears pending references on request"
+      (with-current-buffer (get-buffer-create copilot-chat--buffer-name)
+        (copilot-chat-mode)
+        (setq copilot-chat--references (list (list :type "file" :uri "x"))))
+      (spy-on 'message)
+      (copilot-chat-clear-references)
+      (with-current-buffer copilot-chat--buffer-name
+        (expect copilot-chat--references :to-be nil))))
+
   (describe "copilot-chat--chat-templates"
     ;; copilot--request is a macro over jsonrpc-request, so stub the
     ;; transport rather than the macro.


### PR DESCRIPTION
Chat could only ever send the originating buffer as context. This adds a pending-references list and commands to attach specific files (`copilot-chat-add-file-reference`, `C-c C-f`) or the current selection (`copilot-chat-add-region-reference`), sent as the turn's `references`. References are only cleared once a message is actually delivered (so a failed request doesn't drop them), attaching context creates the chat buffer if needed, and `copilot-chat-clear-references` drops anything pending.
