### PR TITLE
Add workspace file and directory read for agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - Answer the server's `workspace/findFiles` and `workspace/findTextInFiles` requests so agent mode can search the project by file glob and by text/regex (via ripgrep), a step toward whole-workspace questions.
+- Answer the server's `workspace/readFile` and `workspace/readDirectory` requests so agent mode can read files and list directories across the project.
 - Attach extra context to a chat message: `copilot-chat-add-file-reference` (`C-c C-f`) and `copilot-chat-add-region-reference` send specific files or selections along with the next message, and `copilot-chat-clear-references` drops anything pending.
 - Add `copilot-chat-slash-command` (`C-c /`) to pick and send a chat slash command (`/explain`, `/fix`, `/tests`, `/doc`, etc.) fetched from the server, with optional arguments.
 - Act on chat code blocks: `copilot-chat-insert-code-block` (`C-c C-i`) inserts the block at point into the source buffer, and `copilot-chat-copy-code-block` (`C-c M-w`) copies it to the kill ring, instead of leaving chat output as read-only text.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -939,6 +939,76 @@ Return (:matches VECTOR) of {uri, lineNumber, lineText} for the query."
 (copilot-on-request 'workspace/findTextInFiles
                     #'copilot-chat--handle-find-text-in-files)
 
+(defconst copilot-chat--read-file-max-bytes 1000000
+  "Maximum number of bytes read for a `workspace/readFile' request.")
+
+(defun copilot-chat--file-uri-path (uri)
+  "Return the local path for file URI, or signal an error.
+The workspace read requests only make sense for `file://' URIs."
+  (unless (and (stringp uri) (string-prefix-p "file://" uri))
+    (error "Cannot handle non-file URI: %S" uri))
+  (copilot--uri-to-path uri))
+
+(defun copilot-chat--handle-read-file (msg)
+  "Handle a `workspace/readFile' request MSG.
+Return (:content STRING) with the requested file's contents, capped at
+`copilot-chat--read-file-max-bytes'.  Signal an error (reported to the
+server) when the file cannot be read, rather than masking it as empty."
+  (let ((path (copilot-chat--file-uri-path (plist-get msg :uri)))
+        ;; Decode as UTF-8 (what the protocol assumes) so a byte cap that
+        ;; splits a character leaves an eight-bit char consistently across
+        ;; platforms, rather than a latin-1-decoded byte on some.
+        (coding-system-for-read 'utf-8))
+    (with-temp-buffer
+      (insert-file-contents path nil 0 copilot-chat--read-file-max-bytes)
+      ;; Drop any partial multibyte sequence (eight-bit chars) left at the
+      ;; tail by the byte cap.
+      (goto-char (point-max))
+      (while (and (> (point) (point-min))
+                  (>= (char-before) #x3fff80))
+        (delete-char -1))
+      (list :content (buffer-string)))))
+
+(defun copilot-chat--attr-file-type (name dir attr-type)
+  "Return the VS Code FileType integer for an entry.
+NAME is the entry under DIR and ATTR-TYPE is its `file-attribute-type'
+\(t for a directory, nil for a regular file, a string for a symlink).
+1 is a regular file, 2 a directory, 64 the symbolic-link bit combined
+with the link target's type."
+  (cond
+   ((eq attr-type t) 2)
+   ((null attr-type) 1)
+   ;; Symlink: resolve the target's type for the combined bit.  This is
+   ;; the only case needing an extra stat, and symlinks are rare.
+   ((stringp attr-type)
+    (logior 64 (if (file-directory-p (expand-file-name name dir)) 2 1)))
+   (t 0)))
+
+(defun copilot-chat--handle-read-directory (msg)
+  "Handle a `workspace/readDirectory' request MSG.
+Return (:entries VECTOR) of {name, type} for the directory's children,
+fetched in a single directory scan."
+  (let ((dir (copilot-chat--file-uri-path (plist-get msg :uri))))
+    (list :entries
+          (vconcat
+           (when (file-directory-p dir)
+             (delq nil
+                   (mapcar
+                    (lambda (entry)
+                      (let ((name (car entry)))
+                        ;; `directory-files-and-attributes' includes "."
+                        ;; and ".."; skip them.  Hidden files are kept.
+                        (unless (member name '("." ".."))
+                          (list :name name
+                                :type (copilot-chat--attr-file-type
+                                       name dir
+                                       (file-attribute-type (cdr entry)))))))
+                    (directory-files-and-attributes dir))))))))
+
+(copilot-on-request 'workspace/readFile #'copilot-chat--handle-read-file)
+(copilot-on-request 'workspace/readDirectory
+                    #'copilot-chat--handle-read-directory)
+
 ;;
 ;; MCP server status
 ;;

--- a/copilot.el
+++ b/copilot.el
@@ -1031,7 +1031,14 @@ Sends `$/cancelRequest' to the server and resets the stored request ID."
   "Convert a file URI to a percent-decoded path.
 Non-file URIs are returned unchanged."
   (if (string-prefix-p "file://" uri)
-      (url-unhex-string (string-remove-prefix "file://" uri))
+      (let ((path (url-unhex-string (string-remove-prefix "file://" uri))))
+        ;; A Windows file URI is file:///c:/...; drop the leading slash
+        ;; before the drive letter so the path isn't read as /c:/...
+        ;; (which Emacs resolves against the current drive).
+        (if (and (eq system-type 'windows-nt)
+                 (string-match-p "\\`/[a-zA-Z]:" path))
+            (substring path 1)
+          path))
     uri))
 
 (defun copilot--get-uri ()

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1294,6 +1294,93 @@
         (expect (plist-get result :matches) :to-equal [])
         (expect 'copilot-chat--run-ripgrep :not :to-have-been-called))))
 
+  (describe "copilot-chat--handle-read-file"
+    (it "returns the file contents"
+      (let ((tmp (make-temp-file "copilot-read")))
+        (unwind-protect
+            (progn
+              (with-temp-file tmp (insert "hello world\n"))
+              (let ((result (copilot-chat--handle-read-file
+                             (list :uri (copilot--path-to-uri tmp)))))
+                (expect (plist-get result :content) :to-equal "hello world\n")))
+          (delete-file tmp))))
+
+    (it "caps content at the byte limit without splitting a character"
+      (let ((tmp (make-temp-file "copilot-read"))
+            (copilot-chat--read-file-max-bytes 5)
+            (coding-system-for-write 'utf-8-unix))
+        (unwind-protect
+            (progn
+              ;; "é" is two UTF-8 bytes; the 5-byte cap lands mid-character.
+              (with-temp-file tmp (insert "aaaaéb"))
+              (let ((content (plist-get (copilot-chat--handle-read-file
+                                         (list :uri (copilot--path-to-uri tmp)))
+                                        :content)))
+                ;; No raw partial byte at the tail.
+                (expect content :to-equal "aaaa")))
+          (delete-file tmp))))
+
+    (it "signals an error for an unreadable file"
+      (expect (copilot-chat--handle-read-file
+               (list :uri "file:///no/such/file.xyz"))
+              :to-throw))
+
+    (it "signals an error for a non-file URI"
+      (expect (copilot-chat--handle-read-file (list :uri "untitled:/x"))
+              :to-throw)))
+
+  (describe "copilot-chat--attr-file-type"
+    (it "reports 1 for a regular file (nil attr type)"
+      (expect (copilot-chat--attr-file-type "f" "/d" nil) :to-equal 1))
+
+    (it "reports 2 for a directory (t attr type)"
+      (expect (copilot-chat--attr-file-type "d" "/d" t) :to-equal 2))
+
+    (it "sets the symlink bit over the target type"
+      (let ((target (make-temp-file "copilot-ft"))
+            (dir (make-temp-file "copilot-ft" t)))
+        (unwind-protect
+            (progn
+              (make-symbolic-link target (expand-file-name "flink" dir))
+              ;; attr type for a symlink is the target path string.
+              (expect (copilot-chat--attr-file-type "flink" dir target)
+                      :to-equal 65))
+          (delete-file target)
+          (delete-directory dir t)))))
+
+  (describe "copilot-chat--handle-read-directory"
+    (it "lists children with their file types"
+      (let ((dir (make-temp-file "copilot-rd" t)))
+        (unwind-protect
+            (progn
+              (with-temp-file (expand-file-name "a.txt" dir) (insert "x"))
+              (make-directory (expand-file-name "sub" dir))
+              (let* ((result (copilot-chat--handle-read-directory
+                              (list :uri (copilot--path-to-uri dir))))
+                     ;; Render the entries and match structurally, avoiding
+                     ;; a byte-compiled `plist-get' quirk on some Emacsen.
+                     (s (prin1-to-string (plist-get result :entries))))
+                (expect (length (plist-get result :entries)) :to-equal 2)
+                (expect s :to-match ":name \"a.txt\" :type 1")
+                (expect s :to-match ":name \"sub\" :type 2")))
+          (delete-directory dir t))))
+
+    (it "returns an empty vector for a non-directory file URI"
+      (let ((result (copilot-chat--handle-read-directory
+                     (list :uri "file:///no/such/dir"))))
+        (expect (plist-get result :entries) :to-equal [])))
+
+    (it "lists hidden entries too"
+      (let ((dir (make-temp-file "copilot-rd" t)))
+        (unwind-protect
+            (progn
+              (with-temp-file (expand-file-name ".hidden" dir) (insert "x"))
+              (let ((result (copilot-chat--handle-read-directory
+                             (list :uri (copilot--path-to-uri dir)))))
+                (expect (prin1-to-string (plist-get result :entries))
+                        :to-match ":name \"\\.hidden\"")))
+          (delete-directory dir t)))))
+
   (describe "copilot-chat--truncate-output"
     (it "keeps short output unchanged"
       (expect (copilot-chat--truncate-output "short") :to-equal "short"))


### PR DESCRIPTION
Rounds out the agent content provider alongside #500: answer the server's `workspace/readFile` and `workspace/readDirectory` requests so agent mode can read file contents and list directory entries across the project, not just search.

`readFile` is capped at a max-byte read (trimming any partial multibyte character at the boundary) and signals an error to the server on read failure instead of masking it as empty content. `readDirectory` lists children (including hidden files) with VS Code file-type integers, fetched in a single directory scan, and only handles `file://` URIs.
