### PR TITLE
Add opt-in workspace semantic search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Answer the server's `workspace/findFiles` and `workspace/findTextInFiles` requests so agent mode can search the project by file glob and by text/regex (via ripgrep), a step toward whole-workspace questions.
 - Answer the server's `workspace/readFile` and `workspace/readDirectory` requests so agent mode can read files and list directories across the project.
+- Add opt-in semantic search (`copilot-chat-enable-semantic-search`): declare the `watchedFiles` capability and answer the server's `copilot/watchedFiles` request with the project's file list, so the server can build a workspace index for whole-codebase questions.
 - Attach extra context to a chat message: `copilot-chat-add-file-reference` (`C-c C-f`) and `copilot-chat-add-region-reference` send specific files or selections along with the next message, and `copilot-chat-clear-references` drops anything pending.
 - Add `copilot-chat-slash-command` (`C-c /`) to pick and send a chat slash command (`/explain`, `/fix`, `/tests`, `/doc`, etc.) fetched from the server, with optional arguments.
 - Act on chat code blocks: `copilot-chat-insert-code-block` (`C-c C-i`) inserts the block at point into the source buffer, and `copilot-chat-copy-code-block` (`C-c M-w`) copies it to the kill ring, instead of leaving chat output as read-only text.

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ A server with a `:command` is launched locally over stdio; one with a `:type` of
 
 Run `M-x copilot-chat-list-mcp-tools` to see the connected servers, their status, and the tools they expose. A server that fails to start is reported as a warning.
 
+#### Workspace search
+
+In agent mode, Copilot can search the project: copilot.el answers the server's file-glob, text-search, file-read, and directory-list requests using [ripgrep](https://github.com/BurntSushi/ripgrep) (so `.gitignore` is honored). Make sure `rg` is on your `PATH`, or point `copilot-chat-ripgrep-program` at it.
+
+Set `copilot-chat-enable-semantic-search` to `t` to also let the server build a semantic index of the workspace, for whole-codebase ("@workspace"-style) questions. Indexing computes embeddings server-side, so it uses CPU and network; it is off by default and takes effect when the server next starts.
+
 For a more feature-rich chat experience, take a look at [copilot-chat.el](https://github.com/chep/copilot-chat.el).
 
 > [!WARNING]

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -109,6 +109,21 @@ running command with \\[keyboard-quit]."
   :group 'copilot-chat
   :package-version '(copilot . "0.7"))
 
+(defcustom copilot-chat-enable-semantic-search nil
+  "When non-nil, let the server build a semantic-search index of the project.
+This declares the `watchedFiles' capability at server start, after
+which the server asks copilot.el for the workspace file list (via the
+`copilot/watchedFiles' request) and indexes it for whole-codebase
+\(\"@workspace\"-style) questions in chat.
+
+Indexing computes embeddings server-side over the project's files, so it
+uses CPU and network; leave it off if you do not need codebase-wide
+search.  Changing this takes effect when the server next starts (e.g.
+after \\[copilot-diagnose])."
+  :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.7"))
+
 (defface copilot-chat-error-face
   '((t :inherit error))
   "Face for error messages in the chat buffer."
@@ -835,6 +850,9 @@ unavailable the search requests return an error result."
 (defconst copilot-chat--workspace-search-max-results 100
   "Fallback cap on workspace search results when the server sends none.")
 
+(defvar copilot-chat--ripgrep-warned nil
+  "Non-nil once the missing-ripgrep warning has been shown this session.")
+
 (defun copilot-chat--ripgrep ()
   "Return the ripgrep executable path, or nil when unavailable."
   (executable-find copilot-chat-ripgrep-program))
@@ -856,8 +874,9 @@ exits non-zero with no matches, which is treated as an empty result."
 
 (defun copilot-chat--search-dir (msg)
   "Return the directory to search for request MSG, or nil.
-Prefer the request's `:baseUri', else the workspace root."
-  (let ((base (plist-get msg :baseUri)))
+Prefer the request's base directory URI (`:baseUri' for the search
+requests, `:uri' for `copilot/watchedFiles'), else the workspace root."
+  (let ((base (or (plist-get msg :baseUri) (plist-get msg :uri))))
     (cond
      ((and (stringp base) (not (string-empty-p base)))
       (copilot--uri-to-path base))
@@ -869,6 +888,12 @@ Prefer the request's `:baseUri', else the workspace root."
   "Return the result cap for request MSG."
   (or (plist-get msg :maxResults)
       copilot-chat--workspace-search-max-results))
+
+(defun copilot-chat--rels-to-uri-vector (rels dir)
+  "Return a vector of file URIs for relative paths RELS under DIR."
+  (vconcat (mapcar (lambda (rel)
+                     (copilot--path-to-uri (expand-file-name rel dir)))
+                   rels)))
 
 (defun copilot-chat--handle-find-files (msg)
   "Handle a `workspace/findFiles' request MSG.
@@ -882,10 +907,7 @@ relative paths match the glob pattern."
                                   (not (string-empty-p pattern)))
                          (list "-g" pattern))))
          (files (and dir (copilot-chat--run-ripgrep args dir))))
-    (list :uris
-          (vconcat (mapcar (lambda (rel)
-                             (copilot--path-to-uri (expand-file-name rel dir)))
-                           (seq-take files max))))))
+    (list :uris (copilot-chat--rels-to-uri-vector (seq-take files max) dir))))
 
 (defun copilot-chat--parse-rg-match (line dir)
   "Parse a ripgrep LINE of the form PATH:LINENO:TEXT into a match plist.
@@ -938,6 +960,28 @@ Return (:matches VECTOR) of {uri, lineNumber, lineText} for the query."
 (copilot-on-request 'workspace/findFiles #'copilot-chat--handle-find-files)
 (copilot-on-request 'workspace/findTextInFiles
                     #'copilot-chat--handle-find-text-in-files)
+
+(defun copilot-chat--handle-watched-files (msg)
+  "Handle a `copilot/watchedFiles' request MSG.
+Return (:files VECTOR) of file URIs for the workspace, which the server
+indexes for semantic search.  Files are enumerated with ripgrep, so
+ignored files (per `.gitignore') are excluded.  The full list is
+returned deliberately: the server wants the whole tree to index and caps
+it on its end."
+  ;; Warn (once per session) when the index source can't be produced, so
+  ;; enabling semantic search without ripgrep doesn't silently no-op.
+  (unless (or (copilot-chat--ripgrep) copilot-chat--ripgrep-warned)
+    (setq copilot-chat--ripgrep-warned t)
+    (display-warning
+     'copilot
+     (format "Semantic search needs ripgrep; %s not found on PATH"
+             copilot-chat-ripgrep-program)
+     :warning))
+  (let* ((dir (copilot-chat--search-dir msg))
+         (files (and dir (copilot-chat--run-ripgrep '("--files") dir))))
+    (list :files (copilot-chat--rels-to-uri-vector files dir))))
+
+(copilot-on-request 'copilot/watchedFiles #'copilot-chat--handle-watched-files)
 
 (defconst copilot-chat--read-file-max-bytes 1000000
   "Maximum number of bytes read for a `workspace/readFile' request.")

--- a/copilot.el
+++ b/copilot.el
@@ -769,6 +769,22 @@ Return nil when no servers are configured or encoding fails."
       (setq settings (plist-put settings :mcp mcp)))
     settings))
 
+(defun copilot--client-capabilities ()
+  "Return the client capabilities sent in the `initialize' request.
+The `copilot' block opts into server features the user has enabled:
+public-code citations (`copilot/ipCodeCitation') and, for whole-codebase
+semantic search, watched files (`copilot/watchedFiles')."
+  `(:workspace
+    (:workspaceFolders t)
+    :textDocument
+    (:inlineCompletion (:dynamicRegistration :json-false))
+    :copilot
+    (:ipCodeCitation ,(if copilot-show-code-citations t :json-false)
+     ;; Gated on a chat-side option, read defensively in case chat
+     ;; isn't loaded.
+     :watchedFiles ,(if (bound-and-true-p copilot-chat-enable-semantic-search)
+                        t :json-false))))
+
 (defun copilot--start-server ()
   "Start the copilot server process in local."
   (cond
@@ -793,18 +809,7 @@ You can change the installed version with `M-x copilot-reinstall-server` or remo
        `(:processId
          ,(emacs-pid)
          ,@(when root-uri `(:rootUri ,root-uri))
-         :capabilities
-         (:workspace
-          (:workspaceFolders t)
-          :textDocument
-          (:inlineCompletion
-           (:dynamicRegistration :json-false))
-          ;; Opt into the server's public-code matching notifications
-          ;; (`copilot/ipCodeCitation'); off by default server-side, and
-          ;; only requested when the user wants them so disabling the
-          ;; option also stops the underlying traffic.
-          :copilot
-          (:ipCodeCitation ,(if copilot-show-code-citations t :json-false)))
+         :capabilities ,(copilot--client-capabilities)
          ,@(when folders `(:workspaceFolders ,folders))
          :initializationOptions
          (:editorInfo

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1294,6 +1294,40 @@
         (expect (plist-get result :matches) :to-equal [])
         (expect 'copilot-chat--run-ripgrep :not :to-have-been-called))))
 
+  (describe "copilot-chat--handle-watched-files"
+    (it "returns workspace files as a vector of URIs"
+      (spy-on 'copilot-chat--run-ripgrep :and-return-value
+              '("a.el" "src/b.el"))
+      (let* ((result (copilot-chat--handle-watched-files
+                      (list :uri "file:///proj")))
+             (files (plist-get result :files)))
+        (expect (vectorp files) :to-be-truthy)
+        (expect (length files) :to-equal 2)
+        (expect (aref files 0) :to-match "/proj/a\\.el")))
+
+    (it "enumerates files with ripgrep --files"
+      (let (captured)
+        (spy-on 'copilot-chat--run-ripgrep :and-call-fake
+                (lambda (args _dir) (setq captured args) nil))
+        (copilot-chat--handle-watched-files (list :uri "file:///proj"))
+        (expect (member "--files" captured) :to-be-truthy)))
+
+    (it "returns an empty vector when no directory resolves"
+      (spy-on 'copilot--workspace-root :and-return-value nil)
+      (spy-on 'copilot-chat--run-ripgrep)
+      (let ((result (copilot-chat--handle-watched-files nil)))
+        (expect (plist-get result :files) :to-equal [])
+        (expect 'copilot-chat--run-ripgrep :not :to-have-been-called)))
+
+    (it "warns once when ripgrep is unavailable"
+      (let ((copilot-chat--ripgrep-warned nil))
+        (spy-on 'copilot-chat--ripgrep :and-return-value nil)
+        (spy-on 'copilot-chat--run-ripgrep)
+        (spy-on 'display-warning)
+        (copilot-chat--handle-watched-files (list :uri "file:///proj"))
+        (copilot-chat--handle-watched-files (list :uri "file:///proj"))
+        (expect 'display-warning :to-have-been-called-times 1))))
+
   (describe "copilot-chat--handle-read-file"
     (it "returns the file contents"
       (let ((tmp (make-temp-file "copilot-read")))

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -8,6 +8,9 @@
 
 (require 'buttercup)
 (require 'copilot)
+;; `copilot--client-capabilities' reads a chat-side option; load it so the
+;; variable is a known special for dynamic let-binding in the specs.
+(require 'copilot-chat)
 
 (describe "copilot"
   (describe "loading"
@@ -473,6 +476,25 @@
   ;;
   ;; Effective LSP settings
   ;;
+
+  (describe "copilot--client-capabilities"
+    (it "declares watchedFiles when semantic search is enabled"
+      (let ((copilot-chat-enable-semantic-search t))
+        (expect (plist-get (plist-get (copilot--client-capabilities) :copilot)
+                           :watchedFiles)
+                :to-equal t)))
+
+    (it "disables watchedFiles when semantic search is off"
+      (let ((copilot-chat-enable-semantic-search nil))
+        (expect (plist-get (plist-get (copilot--client-capabilities) :copilot)
+                           :watchedFiles)
+                :to-equal :json-false)))
+
+    (it "reflects the code-citations option"
+      (let ((copilot-show-code-citations nil))
+        (expect (plist-get (plist-get (copilot--client-capabilities) :copilot)
+                           :ipCodeCitation)
+                :to-equal :json-false))))
 
   (describe "copilot--effective-lsp-settings"
     (it "returns copilot-lsp-settings unchanged when completion model is nil"


### PR DESCRIPTION
The final piece of the `@workspace` work. Set `copilot-chat-enable-semantic-search` to `t` to declare the `watchedFiles` capability at server start; the server then asks copilot.el for the project's file list (the `copilot/watchedFiles` request), which we answer by enumerating files with ripgrep (honoring `.gitignore`). The server indexes those for whole-codebase ("@workspace"-style) questions.

Off by default since indexing computes embeddings server-side (CPU + network). If enabled without ripgrep on PATH, it warns once rather than silently returning nothing. Incremental re-indexing on file change (`didChangeWatchedFiles`) is left for a follow-up; the initial index is built from the file list.

Heads-up: unlike the search/read handlers (which I smoke-tested live against the repo), the end-to-end semantic-search behavior can't be verified offline - it needs an authenticated agent session. The handler and capability gating are unit-tested and the file enumeration is verified live.
