### PR TITLE
Clarify the issue-reference commit convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ do so.
 
 * Use a topic branch to easily amend a pull request later, if necessary.
 * Write [good commit messages][2].
-* Mention related tickets in the commit messages (e.g. `[Fix #N] Make balancer syntax-aware`).
+* Reference related tickets as a prefix in the commit subject: `[#N]` for a related issue, or `[Fix #N]` when the commit fully closes it (e.g. `[Fix #N] Make balancer syntax-aware`).
 * Update the [changelog][3].
 * Use the same coding conventions as the rest of the project.
 * Verify your Emacs Lisp code with `checkdoc` (<kbd>C-c ? d</kbd>).


### PR DESCRIPTION
Small docs tweak: make the CONTRIBUTING guideline explicit that issue references go as a *prefix* in the commit subject, and distinguish `[#N]` (related issue) from `[Fix #N]` (fully closes it). The example was already prefix-style; this just spells out the rule.