### PR TITLE
Send the chat model on every conversation turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug Fixes
+
+- Send the selected chat model on every conversation turn, not just the first one, so follow-up messages no longer fail with "A model id is required" on recent language-server versions. The model is now sent via the modern `modelInfo` field, with the deprecated `model` field kept as a fallback for older servers. ([#508](https://github.com/copilot-emacs/copilot.el/issues/508))
+
 ### Changes
 
 - Rename the public-code matching feature to use "references" consistently (matching GitHub's own "code references" terminology): `copilot-show-code-citations` is now `copilot-show-code-references` and `copilot-list-code-citations` is now `copilot-list-code-references`. The old names from 0.7.0 still work as obsolete aliases. ([#496](https://github.com/copilot-emacs/copilot.el/pull/496))

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -252,6 +252,15 @@ result, including nil, is cached."
 Use `copilot-chat-model' when set, otherwise a server-resolved default."
   (or copilot-chat-model (copilot-chat--default-model)))
 
+(defun copilot-chat--model-param ()
+  "Return request params identifying the chat model to use.
+Send the modern `modelInfo' object alongside the deprecated `model'
+field so both current and older language servers resolve a model.
+Return nil when no model can be resolved, letting the server pick."
+  (when-let* ((model (copilot-chat--model)))
+    (list :modelInfo (list :id model)
+          :model model)))
+
 ;;
 ;; Internal helpers
 ;;
@@ -1222,8 +1231,7 @@ CALLBACK is called with the response containing conversationId and turnId."
                    :capabilities (list :skills (vector "current-editor")
                                        :allSkills t)
                    :source "panel")
-             (when-let* ((model (copilot-chat--model)))
-               (list :model model))
+             (copilot-chat--model-param)
              (list :workspaceFolders
                    (vconcat
                     (when-let* ((root (copilot--workspace-root)))
@@ -1264,6 +1272,7 @@ CALLBACK is called with the response containing conversationId and turnId."
                       :conversationId conv-id
                       :message message
                       :source "panel")
+                (copilot-chat--model-param)
                 (when doc (list :doc doc))
                 (copilot-chat--references-param))
                :success-fn (lambda (result)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -677,7 +677,9 @@
                         (setq captured-params params)
                         (cons nil nil)))
               (copilot-chat--create "hello" #'ignore)
-              (expect (plist-get captured-params :model) :to-equal "gpt-4o"))
+              (expect (plist-get captured-params :model) :to-equal "gpt-4o")
+              (expect (plist-get (plist-get captured-params :modelInfo) :id)
+                      :to-equal "gpt-4o"))
           (kill-buffer buf))))
 
     (it "sends a server-resolved default when copilot-chat-model is nil"
@@ -696,7 +698,9 @@
                         (setq captured-params params)
                         (cons nil nil)))
               (copilot-chat--create "hello" #'ignore)
-              (expect (plist-get captured-params :model) :to-equal "auto"))
+              (expect (plist-get captured-params :model) :to-equal "auto")
+              (expect (plist-get (plist-get captured-params :modelInfo) :id)
+                      :to-equal "auto"))
           (kill-buffer buf))))
 
     (it "omits model when no default can be resolved"
@@ -715,7 +719,9 @@
                         (setq captured-params params)
                         (cons nil nil)))
               (copilot-chat--create "hello" #'ignore)
-              (expect (plist-member captured-params :model) :not :to-be-truthy))
+              (expect (plist-member captured-params :model) :not :to-be-truthy)
+              (expect (plist-member captured-params :modelInfo)
+                      :not :to-be-truthy))
           (kill-buffer buf))))
 
     (it "clears session tool approvals for a new conversation"
@@ -731,6 +737,76 @@
                       :and-return-value (cons nil nil))
               (copilot-chat--create "hello" #'ignore)
               (expect copilot-chat--session-approved-tools :to-be nil))
+          (kill-buffer buf)))))
+
+  ;;
+  ;; Follow-up turn params
+  ;;
+
+  (describe "copilot-chat--send-turn"
+    (it "includes model when copilot-chat-model is set"
+      (let ((captured-params nil)
+            (copilot-chat-model "gpt-4o")
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--send-turn "follow-up")
+              (expect (plist-get captured-params :model) :to-equal "gpt-4o")
+              (expect (plist-get (plist-get captured-params :modelInfo) :id)
+                      :to-equal "gpt-4o"))
+          (kill-buffer buf))))
+
+    (it "sends a server-resolved default when copilot-chat-model is nil"
+      (let ((captured-params nil)
+            (copilot-chat-model nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"))
+              (spy-on 'copilot-chat--default-model :and-return-value "auto")
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--send-turn "follow-up")
+              (expect (plist-get captured-params :model) :to-equal "auto")
+              (expect (plist-get (plist-get captured-params :modelInfo) :id)
+                      :to-equal "auto"))
+          (kill-buffer buf))))
+
+    (it "omits model when no default can be resolved"
+      (let ((captured-params nil)
+            (copilot-chat-model nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"))
+              (spy-on 'copilot-chat--default-model :and-return-value nil)
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--send-turn "follow-up")
+              (expect (plist-member captured-params :model) :not :to-be-truthy)
+              (expect (plist-member captured-params :modelInfo)
+                      :not :to-be-truthy))
           (kill-buffer buf)))))
 
   ;;


### PR DESCRIPTION
Follow-up chat messages were failing with `A model id is required` on recent language-server versions (see #508). We only sent the model on `conversation/create`; the server used to remember it for the rest of the conversation, but newer servers resolve the model per turn and reject turns that omit it.

This sends the model on every turn through a shared helper, using the modern `modelInfo.id` field and keeping the deprecated `model` field as a fallback so older servers keep working.

Fixes #508