### PR TITLE
Report the in-use language-server version in copilot-installed-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Report the version of the copilot-language-server that is actually in use. `copilot-installed-version` now queries the resolved `copilot-server-executable` with `--version`, falling back to the package metadata under `copilot-install-dir`. This fixes a spurious NES "requires copilot-language-server >= X" warning (and the "tested for version X" warning) when `copilot-server-executable` points to a binary outside `copilot-install-dir`, such as one provided by the system package manager.
 - Send the selected chat model on every conversation turn, not just the first one, so follow-up messages no longer fail with "A model id is required" on recent language-server versions. The model is now sent via the modern `modelInfo` field, with the deprecated `model` field kept as a fallback for older servers. ([#508](https://github.com/copilot-emacs/copilot.el/issues/508))
 
 ### Changes

--- a/copilot.el
+++ b/copilot.el
@@ -410,8 +410,10 @@ recently updated session."
 ;;; Copilot Server Installation
 ;;
 
-(defun copilot-installed-version ()
-  "Return the version number of currently installed `copilot-server-package-name'."
+(defun copilot--install-dir-version ()
+  "Return the server version installed under `copilot-install-dir'.
+Read it from the `package.json' dropped by `copilot-install-server'.
+Return nil when no installed package is found."
   (let ((possible-paths (list
                          (when (eq system-type 'windows-nt)
                            (file-name-concat copilot-install-dir "node_modules" copilot-server-package-name "package.json"))
@@ -472,6 +474,45 @@ native binary from the npm package."
         (error "The package %s is not installed.  Unable to find %s"
                copilot-server-package-name path))
       path))))
+
+(defvar copilot--executable-version-cache nil
+  "Cached version of the resolved Copilot server executable.
+A cons cell of (EXECUTABLE-PATH . VERSION) so a change to
+`copilot-server-executable' is picked up automatically.  Cleared by
+`copilot-uninstall-server'.")
+
+(defun copilot--executable-version ()
+  "Return the version reported by the resolved server executable.
+Run the executable returned by `copilot-server-executable' with
+`--version' and parse a semantic version from its output.  Return nil
+when the executable cannot be found or run, or when its output has no
+recognizable version.  The result is cached per executable path in
+`copilot--executable-version-cache'."
+  (when-let* ((executable (ignore-errors (copilot-server-executable))))
+    (if (equal (car copilot--executable-version-cache) executable)
+        (cdr copilot--executable-version-cache)
+      (let ((version
+             (with-temp-buffer
+               (when (ignore-errors
+                       (eq 0 (call-process executable nil t nil "--version")))
+                 (goto-char (point-min))
+                 (when (re-search-forward
+                        "\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" nil t)
+                   (match-string 1))))))
+        (setq copilot--executable-version-cache (cons executable version))
+        version))))
+
+(defun copilot-installed-version ()
+  "Return the version of the copilot-language-server copilot.el will use.
+Query the resolved `copilot-server-executable' with `--version', so the
+reported version reflects the server actually in use even when
+`copilot-server-executable' points to a binary outside
+`copilot-install-dir' (for example one provided by the system
+package manager).  Fall back to the package metadata under
+`copilot-install-dir' when the executable cannot be queried.  Return
+nil when no version can be determined."
+  (or (copilot--executable-version)
+      (copilot--install-dir-version)))
 
 ;; XXX: This function is modified from `lsp-mode'; see `lsp-async-start-process'
 ;; function for more information.
@@ -611,6 +652,7 @@ downloading precompiled native binaries from the npm registry."
   (unless (file-directory-p copilot-install-dir)
     (user-error "Copilot: Couldn't find %s directory" copilot-install-dir))
   (delete-directory copilot-install-dir 'recursive)
+  (setq copilot--executable-version-cache nil)
   (copilot--log 'warning "Server `%s' uninstalled." (file-name-nondirectory (directory-file-name copilot-install-dir))))
 
 ;;;###autoload

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -1242,6 +1242,51 @@
       (let ((system-type 'windows-nt))
         (expect (copilot--native-binary-name) :to-equal "copilot-language-server.exe"))))
 
+  (describe "copilot--executable-version"
+    (before-each
+      (setq copilot--executable-version-cache nil))
+
+    (it "parses the version from the executable's --version output"
+      (spy-on 'copilot-server-executable :and-return-value "/opt/copilot-language-server")
+      (spy-on 'call-process :and-call-fake
+              (lambda (&rest _) (insert "1.504.0\n") 0))
+      (expect (copilot--executable-version) :to-equal "1.504.0"))
+
+    (it "returns nil when the executable exits non-zero"
+      (spy-on 'copilot-server-executable :and-return-value "/opt/copilot-language-server")
+      (spy-on 'call-process :and-call-fake
+              (lambda (&rest _) (insert "boom\n") 1))
+      (expect (copilot--executable-version) :to-be nil))
+
+    (it "returns nil when no executable can be resolved"
+      (spy-on 'copilot-server-executable :and-call-fake
+              (lambda () (error "not installed")))
+      (expect (copilot--executable-version) :to-be nil))
+
+    (it "caches the result per executable path"
+      (spy-on 'copilot-server-executable :and-return-value "/opt/copilot-language-server")
+      (spy-on 'call-process :and-call-fake
+              (lambda (&rest _) (insert "1.504.0\n") 0))
+      (copilot--executable-version)
+      (copilot--executable-version)
+      (expect 'call-process :to-have-been-called-times 1)))
+
+  (describe "copilot-installed-version"
+    (it "prefers the resolved executable version"
+      (spy-on 'copilot--executable-version :and-return-value "1.504.0")
+      (spy-on 'copilot--install-dir-version :and-return-value "1.272.0")
+      (expect (copilot-installed-version) :to-equal "1.504.0"))
+
+    (it "falls back to the install-dir version when the executable is unavailable"
+      (spy-on 'copilot--executable-version :and-return-value nil)
+      (spy-on 'copilot--install-dir-version :and-return-value "1.272.0")
+      (expect (copilot-installed-version) :to-equal "1.272.0"))
+
+    (it "returns nil when no version can be determined"
+      (spy-on 'copilot--executable-version :and-return-value nil)
+      (spy-on 'copilot--install-dir-version :and-return-value nil)
+      (expect (copilot-installed-version) :to-be nil)))
+
   (describe "copilot--path-to-uri"
     (it "creates a file URI for unix paths"
       (expect (copilot--path-to-uri "/home/user/project")


### PR DESCRIPTION
## Problem

`copilot-installed-version` only read the package metadata under `copilot-install-dir`, so it reported the version of a server installed via `copilot-install-server` — even when `copilot-server-executable` points somewhere else.

Users who run a `copilot-language-server` provided by their system package manager (Nix, Homebrew, distro package, …) therefore got a stale or `nil` version. Two things break as a result:

- `copilot-nes-mode` warns `NES requires copilot-language-server >= 1.434.0, but <old> is installed` even though the server actually in use is new enough (or no install-dir copy exists at all).
- `copilot--start-server` emits a misleading "tested for version X but Y detected" warning.

Both compare against a server that is not the one being launched.

## Fix

Report the version of the server copilot.el will actually run:

- `copilot--executable-version` runs the resolved `copilot-server-executable` with `--version`, parses the semantic version, and caches it per executable path (cleared by `copilot-uninstall-server`).
- The previous `package.json` logic moves verbatim to `copilot--install-dir-version`.
- `copilot-installed-version` now returns the executable version, falling back to the install-dir metadata when the executable can't be queried, and `nil` when neither is available.

This corrects both warnings for anyone whose server lives outside `copilot-install-dir`, while keeping the existing behavior when the bundled installer is used.

## Testing

- `eask compile` — clean (no new warnings)
- `eask test buttercup` — 408 specs, 0 failed (adds coverage for the executable probe, its caching, and the fallback ordering)
- `eask lint checkdoc` — no new findings
