### PR TITLE
Warn when agent mode uses a model that can't call tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Rename the public-code matching feature to use "references" consistently (matching GitHub's own "code references" terminology): `copilot-show-code-citations` is now `copilot-show-code-references` and `copilot-list-code-citations` is now `copilot-list-code-references`. The old names from 0.7.0 still work as obsolete aliases. ([#496](https://github.com/copilot-emacs/copilot.el/pull/496))
 - Give user-facing messages a consistent `Copilot:`/`Copilot Chat:` prefix, and describe attached chat context as "context" throughout (the `copilot-chat-add-file-reference` family keeps its names, which match the server's `references` field).
+- Warn when starting an agent-mode chat with a model that can't call tools, so it's clear why Copilot describes commands to run instead of running them itself. ([#509](https://github.com/copilot-emacs/copilot.el/discussions/509))
 
 ## 0.7.0 (2026-06-26)
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ Customization:
 
 At each tool confirmation prompt you can answer `yes`, `no`, or `always`; `always` approves that tool for the rest of the conversation so it stops asking.
 
+> [!IMPORTANT]
+>
+> Agent mode only works with a model that can call tools. Some chat models (and whatever default the server resolves when `copilot-chat-model` is `nil`) can't, and then Copilot just describes the commands to run instead of running them, so agent mode looks inactive. Pick a tool-capable model with `M-x copilot-chat-select-model`. copilot.el also warns when it starts an agent-mode conversation whose model lacks tool support.
+
 > [!TIP]
 >
 > Install [`markdown-mode`](https://github.com/jrblevin/markdown-mode) for rich markdown rendering (headings, code blocks, emphasis, etc.) in the chat buffer. Without it, only basic highlighting is used.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -252,6 +252,36 @@ result, including nil, is cached."
 Use `copilot-chat-model' when set, otherwise a server-resolved default."
   (or copilot-chat-model (copilot-chat--default-model)))
 
+(defun copilot-chat--model-supports-tools-p (model-id)
+  "Return non-nil unless MODEL-ID is known to lack tool-call support.
+Consult the model's `capabilities.supports.tool_calls' flag from the
+server's model list.  Return non-nil when the flag is absent (older
+servers omit it, and the `auto' router model carries no capabilities) so
+agent mode is never wrongly flagged; return nil only when the server
+positively reports that the model cannot call tools."
+  (let* ((model (seq-find (lambda (m) (equal (plist-get m :id) model-id))
+                          (copilot-chat--chat-models)))
+         (supports (plist-get (plist-get model :capabilities) :supports)))
+    (not (eq (plist-get supports :tool_calls) :json-false))))
+
+(defun copilot-chat--maybe-warn-model-lacks-tools ()
+  "Warn when agent mode is on but the active model cannot call tools.
+Without tool support the model just tells the user which commands to run
+instead of running them, which reads as agent mode not working.  This is
+best-effort: it stays silent when tool support can't be determined and
+never blocks starting a conversation."
+  (when copilot-chat-use-agent-mode
+    (condition-case nil
+        (when-let* ((model (copilot-chat--model)))
+          (unless (copilot-chat--model-supports-tools-p model)
+            (message
+             (concat "Copilot Chat: Agent mode is on but model %s does not "
+                     "support tool calls, so Copilot can't run tools itself.  "
+                     "Pick a tool-capable model with "
+                     "M-x copilot-chat-select-model.")
+             model)))
+      (error nil))))
+
 (defun copilot-chat--model-param ()
   "Return request params identifying the chat model to use.
 Send the modern `modelInfo' object alongside the deprecated `model'
@@ -1216,6 +1246,7 @@ CALLBACK is called with the response containing conversationId and turnId."
   (let ((token (format "copilot-chat-%s" (float-time))))
     ;; A fresh conversation starts with a clean slate of session approvals.
     (setq copilot-chat--session-approved-tools nil)
+    (copilot-chat--maybe-warn-model-lacks-tools)
     (with-current-buffer (get-buffer copilot-chat--buffer-name)
       (setq copilot-chat--work-done-token token)
       (push (cons token (current-buffer)) copilot-chat--active-buffers))

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -853,6 +853,60 @@
       (copilot-chat--default-model)
       (expect 'copilot-chat--chat-models :to-have-been-called-times 1)))
 
+  (describe "copilot-chat--model-supports-tools-p"
+    (it "returns non-nil when the model reports tool support"
+      (spy-on 'copilot-chat--chat-models :and-return-value
+              (list (list :id "gpt-4o"
+                          :capabilities (list :supports (list :tool_calls t)))))
+      (expect (copilot-chat--model-supports-tools-p "gpt-4o") :to-be-truthy))
+
+    (it "returns nil when the model reports no tool support"
+      (spy-on 'copilot-chat--chat-models :and-return-value
+              (list (list :id "gpt-4o"
+                          :capabilities (list :supports
+                                              (list :tool_calls :json-false)))))
+      (expect (copilot-chat--model-supports-tools-p "gpt-4o") :to-be nil))
+
+    (it "assumes support when capabilities are absent"
+      (spy-on 'copilot-chat--chat-models :and-return-value
+              (list (list :id "auto")))
+      (expect (copilot-chat--model-supports-tools-p "auto") :to-be-truthy))
+
+    (it "assumes support when the model is unknown"
+      (spy-on 'copilot-chat--chat-models :and-return-value nil)
+      (expect (copilot-chat--model-supports-tools-p "mystery") :to-be-truthy)))
+
+  (describe "copilot-chat--maybe-warn-model-lacks-tools"
+    (before-each
+      (spy-on 'message))
+
+    (it "warns in agent mode when the model can't call tools"
+      (let ((copilot-chat-use-agent-mode t))
+        (spy-on 'copilot-chat--model :and-return-value "gpt-4o")
+        (spy-on 'copilot-chat--model-supports-tools-p :and-return-value nil)
+        (copilot-chat--maybe-warn-model-lacks-tools)
+        (expect 'message :to-have-been-called)))
+
+    (it "stays quiet when the model supports tools"
+      (let ((copilot-chat-use-agent-mode t))
+        (spy-on 'copilot-chat--model :and-return-value "gpt-4o")
+        (spy-on 'copilot-chat--model-supports-tools-p :and-return-value t)
+        (copilot-chat--maybe-warn-model-lacks-tools)
+        (expect 'message :not :to-have-been-called)))
+
+    (it "stays quiet when agent mode is off"
+      (let ((copilot-chat-use-agent-mode nil))
+        (spy-on 'copilot-chat--model-supports-tools-p)
+        (copilot-chat--maybe-warn-model-lacks-tools)
+        (expect 'copilot-chat--model-supports-tools-p :not :to-have-been-called)
+        (expect 'message :not :to-have-been-called)))
+
+    (it "never signals when tool support can't be determined"
+      (let ((copilot-chat-use-agent-mode t))
+        (spy-on 'copilot-chat--model :and-return-value "gpt-4o")
+        (spy-on 'copilot-chat--model-supports-tools-p :and-throw-error 'error)
+        (expect (copilot-chat--maybe-warn-model-lacks-tools) :not :to-throw))))
+
   ;;
   ;; Streaming cancellation
   ;;


### PR DESCRIPTION
Follow-up to discussion #509, where agent mode looked broken: Copilot kept describing the commands to run instead of running them.

The cause is the model. When `copilot-chat-model` is `nil` the server resolves a default, and if that model can't do tool/function calling, Copilot can only describe tool use, never invoke it. Nothing in copilot.el signaled this, so it read as agent mode not working.

This adds a best-effort check at conversation creation: when agent mode is on and the active model's `capabilities.supports.tool_calls` flag is positively `false`, copilot.el warns and points the user at `copilot-chat-select-model`. Missing capability data (older servers, the `auto` router model) is treated as supported, so there are no false alarms, and the check never blocks starting a chat. The README gains a note about the requirement.

Tests cover the capability lookup and each branch of the warning. `eask test buttercup`, `eask compile`, and `eask lint checkdoc` are all clean.