### PR TITLE
Add commit message generation from the staged diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `copilot-chat-doc`
   - `copilot-chat-optimize`
   - `copilot-chat-write-tests`
+- Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - `copilot-chat-doc`
   - `copilot-chat-optimize`
   - `copilot-chat-write-tests`
-- Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt`.
+- Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt` and a pending generation cancellable with `copilot-chat-stop`.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Attach extra context for the next message with `copilot-chat-add-file-reference`
 
 The chat buffer's header line shows at a glance whether Agent or Ask mode is active, which model answers, and in agent mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
 
+`copilot-chat-insert-commit-message` generates a commit message from the staged changes and inserts it at point. It is meant to be called from a commit message buffer (e.g. Magit's `COMMIT_EDITMSG` or any `git-commit` buffer), but works from any buffer inside a git repository. It runs outside the chat panel, so it never disturbs an ongoing conversation; the instruction sent along with the diff can be customized via `copilot-chat-commit-message-prompt`.
+
 Customization:
 - **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)
 - **`copilot-chat-use-agent-mode`** — let Copilot run tools (shell commands, file edits, reads, etc.) during a chat (default `nil`)
@@ -463,6 +465,7 @@ For example:
 | `copilot-chat-write-tests` | Write tests for the region or defun at point |
 | `copilot-chat-stop` | Cancel streaming, or reset the conversation if idle |
 | `copilot-chat-reset` | Destroy the current conversation and clear the chat buffer |
+| `copilot-chat-insert-commit-message` | Generate a commit message for the staged changes and insert it at point |
 | **Next Edit Suggestions** | |
 | `copilot-nes-mode` | Toggle NES in the current buffer |
 | `copilot-nes-accept` | Accept (or jump to) the current NES suggestion |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -240,6 +240,11 @@ be a function called with each progress value (see
 `copilot-chat--collecting-sink'), which lets one-shot requests consume a
 reply without involving the chat buffer.")
 
+(defvar copilot-chat--one-shot-requests nil
+  "Alist of (TOKEN . REQUEST-ID) for in-flight one-shot conversations.
+Lets `copilot-chat-stop' cancel a pending one-shot instead of resetting
+the chat conversation.")
+
 ;;
 ;; Buffer name
 ;;
@@ -433,10 +438,15 @@ buffer."
                 (sink (cdr entry)))
       (if (functionp sink)
           (progn
-            (funcall sink value)
+            ;; Unregister before invoking the sink: if the sink's
+            ;; callback signals (it runs arbitrary user-facing code),
+            ;; the entry must not leak in the alist forever.
             (when (equal (plist-get value :kind) "end")
               (setq copilot-chat--active-buffers
-                    (assoc-delete-all token copilot-chat--active-buffers))))
+                    (assoc-delete-all token copilot-chat--active-buffers))
+              (setq copilot-chat--one-shot-requests
+                    (assoc-delete-all token copilot-chat--one-shot-requests)))
+            (funcall sink value))
         (copilot-chat--handle-buffer-progress token sink value)))))
 
 (defun copilot-chat--handle-buffer-progress (token chat-buf value)
@@ -1427,53 +1437,112 @@ the conversation is throwaway, so there is nothing useful to report."
      'conversation/destroy
      (list :conversationId conversation-id))))
 
+(defun copilot-chat--cancel-one-shots ()
+  "Cancel all in-flight one-shot requests.
+Their callbacks are invoked with a cancellation error so the initiating
+commands can report it.  Return non-nil when anything was cancelled."
+  (when copilot-chat--one-shot-requests
+    (let ((pending copilot-chat--one-shot-requests))
+      (setq copilot-chat--one-shot-requests nil)
+      (dolist (entry pending)
+        (let* ((token (car entry))
+               (request-id (cdr entry))
+               (sink (cdr (assoc token copilot-chat--active-buffers))))
+          (when (and request-id (copilot--connection-alivep))
+            (jsonrpc-notify copilot--connection '$/cancelRequest
+                            (list :id request-id)))
+          (setq copilot-chat--active-buffers
+                (assoc-delete-all token copilot-chat--active-buffers))
+          (when (functionp sink)
+            (funcall sink '(:kind "end" :result (:error "Cancelled")))))))
+    t))
+
 (defun copilot-chat--one-shot (message callback)
   "Send MESSAGE as a stand-alone, throwaway conversation.
 The reply is accumulated internally instead of streaming into the chat
 buffer, so this neither needs the chat panel nor disturbs an ongoing
 conversation there.  CALLBACK is called with the complete reply string
 and an error message string (or nil) once the turn finishes, after which
-the conversation is destroyed."
-  (let ((token (format "copilot-chat-one-shot-%s" (float-time)))
-        (conversation-id nil)
-        (finished nil))
-    (push (cons token
-                (copilot-chat--collecting-sink
-                 (lambda (reply error-msg)
-                   (setq finished t)
-                   ;; When the reply somehow completes before the create
-                   ;; response has delivered the conversation id, the
-                   ;; success handler below destroys the conversation.
-                   (copilot-chat--destroy-one-shot conversation-id)
-                   (funcall callback reply error-msg))))
-          copilot-chat--active-buffers)
-    (copilot--async-request
-     'conversation/create
-     (append
-      (list :workDoneToken token
-            :turns (vector
-                    (list :request message
-                          :response ""
-                          :turnId ""))
-            ;; No editor context: the request carries everything it needs.
-            :capabilities (list :skills (vector)
-                                :allSkills :json-false)
-            :source "panel")
-      (copilot-chat--model-param)
-      (list :workspaceFolders
-            (vconcat
-             (when-let* ((root (copilot--workspace-root)))
-               (list (list :uri (concat "file://" root)
-                           :name (file-name-nondirectory
-                                  (directory-file-name root))))))))
-     :success-fn (lambda (result)
-                   (setq conversation-id (plist-get result :conversationId))
-                   (when finished
-                     (copilot-chat--destroy-one-shot conversation-id)))
-     :error-fn (lambda (err)
-                 (setq copilot-chat--active-buffers
-                       (assoc-delete-all token copilot-chat--active-buffers))
-                 (funcall callback nil (format "%s" err))))))
+the conversation is destroyed.  Cancellable with `copilot-chat-stop'."
+  (let* ((token (format "copilot-chat-one-shot-%s" (float-time)))
+         (conversation-id nil)
+         (finished nil)
+         (called nil)
+         (errored nil)
+         ;; The server can end the turn and then fail the create
+         ;; response, or cancellation can race the reply; make sure the
+         ;; caller only ever hears back once.
+         (callback-once (lambda (reply error-msg)
+                          (unless called
+                            (setq called t)
+                            (funcall callback reply error-msg))))
+         (request-id
+          ;; Issue the request BEFORE registering the sink: starting the
+          ;; server can signal (e.g. binary not installed), and nothing
+          ;; must be left behind in the alist when it does.  Progress
+          ;; can't arrive before we get to register: notifications are
+          ;; only processed when Emacs reads process output.
+          ;;
+          ;; The response handlers below don't touch the calling buffer,
+          ;; but `copilot--async-request' drops the success handler when
+          ;; the buffer current at call time has been killed; issue the
+          ;; call from a buffer that is always live so an aborted commit
+          ;; buffer can't prevent the conversation id from being
+          ;; recorded (and the throwaway conversation from being
+          ;; destroyed).
+          (with-current-buffer (get-buffer-create " *copilot-chat-one-shot*")
+            (copilot--async-request
+             'conversation/create
+             (append
+              (list :workDoneToken token
+                    :turns (vector
+                            (list :request message
+                                  :response ""
+                                  :turnId ""))
+                    ;; No editor context: the request carries everything
+                    ;; it needs.
+                    :capabilities (list :skills (vector)
+                                        :allSkills :json-false)
+                    :source "panel")
+              (copilot-chat--model-param)
+              (list :workspaceFolders
+                    (vconcat
+                     (when-let* ((root (copilot--workspace-root)))
+                       (list (list :uri (concat "file://" root)
+                                   :name (file-name-nondirectory
+                                          (directory-file-name root))))))))
+             :success-fn (lambda (result)
+                           (setq conversation-id
+                                 (plist-get result :conversationId))
+                           (when finished
+                             (copilot-chat--destroy-one-shot conversation-id)))
+             :error-fn (lambda (err)
+                         ;; The flag covers an error delivered before the
+                         ;; registration below has even happened, in
+                         ;; which case the alist cleanups are no-ops.
+                         (setq errored t)
+                         (setq copilot-chat--active-buffers
+                               (assoc-delete-all
+                                token copilot-chat--active-buffers))
+                         (setq copilot-chat--one-shot-requests
+                               (assoc-delete-all
+                                token copilot-chat--one-shot-requests))
+                         (funcall callback-once nil
+                                  (or (copilot-chat--error-text err)
+                                      (format "%s" err))))))))
+    (unless errored
+      (push (cons token
+                  (copilot-chat--collecting-sink
+                   (lambda (reply error-msg)
+                     (setq finished t)
+                     ;; When the reply somehow completes before the
+                     ;; create response has delivered the conversation
+                     ;; id, the success handler above destroys the
+                     ;; conversation.
+                     (copilot-chat--destroy-one-shot conversation-id)
+                     (funcall callback-once reply error-msg))))
+            copilot-chat--active-buffers)
+      (push (cons token request-id) copilot-chat--one-shot-requests))))
 
 ;;
 ;; UI helpers
@@ -1662,23 +1731,25 @@ The context points at the current file with the region's range."
 
 (defun copilot-chat--staged-diff ()
   "Return the staged diff of the repository around `default-directory'.
-The diff is taken from the repository root, so all staged changes are
-included regardless of the buffer's own directory.  Signal a
-`user-error' when there is no repository, when git fails, or when
-nothing is staged."
-  (let ((root (locate-dominating-file default-directory ".git")))
-    (unless root
-      (user-error "Copilot Chat: Not inside a git repository"))
-    (let* ((default-directory root)
-           (diff (with-temp-buffer
-                   (let ((status (call-process "git" nil t nil
-                                               "diff" "--cached" "--no-color")))
-                     (unless (eql status 0)
-                       (user-error "Copilot Chat: git diff failed (%s)" status)))
-                   (buffer-string))))
-      (when (string-empty-p (string-trim diff))
-        (user-error "Copilot Chat: No staged changes"))
-      diff)))
+Run git in `default-directory' and let it resolve the repository
+itself: hunting for the root manually (e.g. `locate-dominating-file')
+picks the wrong index for linked worktrees, whose COMMIT_EDITMSG lives
+under the main checkout's .git directory.  Use `process-file' so remote
+\(TRAMP) buffers diff the remote repository rather than silently running
+git locally.  Signal a `user-error' when there is no repository, when
+git fails, or when nothing is staged."
+  (let* ((exit nil)
+         (diff (with-temp-buffer
+                 (setq exit (process-file "git" nil t nil
+                                          "diff" "--cached" "--no-color"))
+                 (buffer-string))))
+    (unless (eql exit 0)
+      (user-error
+       "Copilot Chat: git diff failed (%s); not inside a git repository?"
+       exit))
+    (when (string-empty-p (string-trim diff))
+      (user-error "Copilot Chat: No staged changes"))
+    diff))
 
 (defun copilot-chat--commit-message-request ()
   "Return the chat message asking for a commit message for the staged diff."
@@ -1689,7 +1760,8 @@ nothing is staged."
 The model is asked not to fence the commit message, but strip a fence
 wrapping the whole reply defensively when it adds one anyway."
   (let ((text (string-trim reply)))
-    (if (string-match "\\````[^\n]*\n\\(\\(?:.\\|\n\\)*?\\)\n?```\\'" text)
+    ;; Fences are three or more backticks (models occasionally use four).
+    (if (string-match "\\``\\{3,\\}[^\n]*\n\\(\\(?:.\\|\n\\)*?\\)\n?`\\{3,\\}\\'" text)
         (string-trim (match-string 1 text))
       text)))
 
@@ -1719,6 +1791,12 @@ chat panel and does not disturb an ongoing chat conversation."
            (message "Copilot Chat: Got an empty commit message"))
           ((not (buffer-live-p buf))
            (message "Copilot Chat: Commit message buffer is gone"))
+          ((buffer-local-value 'buffer-read-only buf)
+           ;; Don't signal inside the jsonrpc process filter; salvage
+           ;; the reply instead.
+           (kill-new reply)
+           (message
+            "Copilot Chat: Buffer is read-only; commit message copied to kill ring"))
           (t
            (with-current-buffer buf
              (save-excursion
@@ -2037,20 +2115,24 @@ command."
 ;;;###autoload
 (defun copilot-chat-stop ()
   "Cancel the in-flight request and stop streaming.
-If not currently streaming, reset the conversation instead."
+When nothing is streaming in the chat buffer, cancel any pending
+one-shot request (e.g. `copilot-chat-insert-commit-message') instead;
+only when there is nothing to cancel at all, reset the conversation."
   (interactive)
   (let ((chat-buf (get-buffer copilot-chat--buffer-name)))
-    (if (and chat-buf
-             (buffer-local-value 'copilot-chat--streaming-p chat-buf))
-        (with-current-buffer chat-buf
-          (when (and copilot-chat--request-id (copilot--connection-alivep))
-            (jsonrpc-notify copilot--connection
-                            '$/cancelRequest
-                            (list :id copilot-chat--request-id)))
-          (copilot-chat--end-streaming)
-          (copilot-chat--insert-error "Cancelled")
-          (copilot-chat--remove-active-tokens chat-buf))
-      (copilot-chat-reset))))
+    (cond
+     ((and chat-buf
+           (buffer-local-value 'copilot-chat--streaming-p chat-buf))
+      (with-current-buffer chat-buf
+        (when (and copilot-chat--request-id (copilot--connection-alivep))
+          (jsonrpc-notify copilot--connection
+                          '$/cancelRequest
+                          (list :id copilot-chat--request-id)))
+        (copilot-chat--end-streaming)
+        (copilot-chat--insert-error "Cancelled")
+        (copilot-chat--remove-active-tokens chat-buf)))
+     ((copilot-chat--cancel-one-shots))
+     (t (copilot-chat-reset)))))
 
 ;;;###autoload
 (defun copilot-chat-reset ()

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -152,6 +152,18 @@ extra entries become available through `copilot-chat-task'."
   :group 'copilot-chat
   :package-version '(copilot . "0.8"))
 
+(defcustom copilot-chat-commit-message-prompt
+  "Write a commit message for the following staged diff.
+Use the conventional commit format: a concise summary line of at most
+72 characters, then a blank line, then an optional short body explaining
+the why behind the change.  Return ONLY the commit message text, without
+markdown code fences and without any commentary."
+  "Instruction prepended to the staged diff when generating a commit message.
+Used by `copilot-chat-insert-commit-message'."
+  :type 'string
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
 (defface copilot-chat-error-face
   '((t :inherit error))
   "Face for error messages in the chat buffer."
@@ -222,7 +234,11 @@ A list of plists like (:type \"file\" :uri URI), sent as the turn's
 ;;
 
 (defvar copilot-chat--active-buffers nil
-  "Alist of (TOKEN . CHAT-BUFFER) for routing `$/progress'.")
+  "Alist of (TOKEN . SINK) for routing `$/progress'.
+SINK is normally the chat buffer the reply streams into, but it can also
+be a function called with each progress value (see
+`copilot-chat--collecting-sink'), which lets one-shot requests consume a
+reply without involving the chat buffer.")
 
 ;;
 ;; Buffer name
@@ -385,50 +401,85 @@ ERR may be a string, a structured object with a `:message', or absent."
   "Return MSG rendered as a styled chat error line."
   (propertize (format "[Error: %s]\n\n" msg) 'face 'copilot-chat-error-face))
 
+(defun copilot-chat--collecting-sink (callback)
+  "Return a progress sink that accumulates a whole reply for CALLBACK.
+The returned function consumes the `$/progress' values of one turn and
+concatenates the streamed reply chunks.  When the turn ends, CALLBACK is
+called with two arguments: the accumulated reply string and an error
+message string reported by the server (or nil)."
+  (let ((chunks '()))
+    (lambda (value)
+      (pcase (plist-get value :kind)
+        ("report"
+         (when-let* ((reply (copilot-chat--extract-reply value)))
+           (push reply chunks)))
+        ("end"
+         (let* ((result (plist-get value :result))
+                ;; The server normally sends an object here, but guard
+                ;; against any other shape.
+                (result (and (listp result) result)))
+           (funcall callback
+                    (apply #'concat (nreverse chunks))
+                    (copilot-chat--error-text (plist-get result :error)))))))))
+
 (defun copilot-chat--handle-progress (msg)
-  "Handle `$/progress' notification MSG for chat streaming."
+  "Handle `$/progress' notification MSG for chat streaming.
+Dispatch on the sink registered for the token in
+`copilot-chat--active-buffers': a function sink consumes the progress
+values itself, while a buffer sink streams the reply into the chat
+buffer."
   (copilot--dbind (token value) msg
     (when-let* ((entry (assoc token copilot-chat--active-buffers))
-                (chat-buf (cdr entry)))
-      (when (buffer-live-p chat-buf)
-        (with-current-buffer chat-buf
-          (let ((kind (plist-get value :kind)))
-            (cond
-             ((equal kind "begin")
-              (setq copilot-chat--streaming-p t)
-              (force-mode-line-update))
-             ((equal kind "report")
-              (when-let* ((reply (copilot-chat--extract-reply value)))
-                (let ((inhibit-read-only t))
-                  (goto-char (point-max))
-                  (insert reply))
-                (copilot-chat--scroll-to-bottom)))
-             ((equal kind "end")
-              (copilot-chat--end-streaming)
-              (let* ((result (plist-get value :result))
-                     ;; The server normally sends an object here, but
-                     ;; guard against any other shape.
-                     (result (and (listp result) result))
-                     (error-msg (copilot-chat--error-text
-                                 (plist-get result :error))))
-                ;; Reset the follow-up every turn so a stale one from a
-                ;; previous turn is never re-inserted.
-                (setq copilot-chat--follow-up (plist-get result :followUp))
-                (let ((inhibit-read-only t))
-                  (goto-char (point-max))
-                  (insert "\n\n")
-                  ;; Surface a turn-level error the server reports at the
-                  ;; end, which would otherwise leave only an empty reply.
-                  (when error-msg
-                    (insert (copilot-chat--format-error error-msg)))
-                  (when (and (stringp copilot-chat--follow-up)
-                             (not (string-empty-p copilot-chat--follow-up)))
-                    (insert (propertize
-                             (format "Follow-up: %s\n\n" copilot-chat--follow-up)
-                             'face 'copilot-chat-follow-up-face)))))
-              (copilot-chat--scroll-to-bottom)
+                (sink (cdr entry)))
+      (if (functionp sink)
+          (progn
+            (funcall sink value)
+            (when (equal (plist-get value :kind) "end")
               (setq copilot-chat--active-buffers
-                    (assoc-delete-all token copilot-chat--active-buffers))))))))))
+                    (assoc-delete-all token copilot-chat--active-buffers))))
+        (copilot-chat--handle-buffer-progress token sink value)))))
+
+(defun copilot-chat--handle-buffer-progress (token chat-buf value)
+  "Stream the progress VALUE of turn TOKEN into CHAT-BUF."
+  (when (buffer-live-p chat-buf)
+    (with-current-buffer chat-buf
+      (let ((kind (plist-get value :kind)))
+        (cond
+         ((equal kind "begin")
+          (setq copilot-chat--streaming-p t)
+          (force-mode-line-update))
+         ((equal kind "report")
+          (when-let* ((reply (copilot-chat--extract-reply value)))
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (insert reply))
+            (copilot-chat--scroll-to-bottom)))
+         ((equal kind "end")
+          (copilot-chat--end-streaming)
+          (let* ((result (plist-get value :result))
+                 ;; The server normally sends an object here, but
+                 ;; guard against any other shape.
+                 (result (and (listp result) result))
+                 (error-msg (copilot-chat--error-text
+                             (plist-get result :error))))
+            ;; Reset the follow-up every turn so a stale one from a
+            ;; previous turn is never re-inserted.
+            (setq copilot-chat--follow-up (plist-get result :followUp))
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (insert "\n\n")
+              ;; Surface a turn-level error the server reports at the
+              ;; end, which would otherwise leave only an empty reply.
+              (when error-msg
+                (insert (copilot-chat--format-error error-msg)))
+              (when (and (stringp copilot-chat--follow-up)
+                         (not (string-empty-p copilot-chat--follow-up)))
+                (insert (propertize
+                         (format "Follow-up: %s\n\n" copilot-chat--follow-up)
+                         'face 'copilot-chat-follow-up-face)))))
+          (copilot-chat--scroll-to-bottom)
+          (setq copilot-chat--active-buffers
+                (assoc-delete-all token copilot-chat--active-buffers))))))))
 
 (copilot-on-notification '$/progress #'copilot-chat--handle-progress)
 
@@ -1367,6 +1418,63 @@ CALLBACK is called with the response containing conversationId and turnId."
           (copilot-chat--end-streaming)
           (copilot-chat--remove-active-tokens chat-buf))))))
 
+(defun copilot-chat--destroy-one-shot (conversation-id)
+  "Destroy the one-shot conversation CONVERSATION-ID, if any.
+A nil CONVERSATION-ID and a dead connection are both quietly ignored:
+the conversation is throwaway, so there is nothing useful to report."
+  (when (and conversation-id (copilot--connection-alivep))
+    (copilot--async-request
+     'conversation/destroy
+     (list :conversationId conversation-id))))
+
+(defun copilot-chat--one-shot (message callback)
+  "Send MESSAGE as a stand-alone, throwaway conversation.
+The reply is accumulated internally instead of streaming into the chat
+buffer, so this neither needs the chat panel nor disturbs an ongoing
+conversation there.  CALLBACK is called with the complete reply string
+and an error message string (or nil) once the turn finishes, after which
+the conversation is destroyed."
+  (let ((token (format "copilot-chat-one-shot-%s" (float-time)))
+        (conversation-id nil)
+        (finished nil))
+    (push (cons token
+                (copilot-chat--collecting-sink
+                 (lambda (reply error-msg)
+                   (setq finished t)
+                   ;; When the reply somehow completes before the create
+                   ;; response has delivered the conversation id, the
+                   ;; success handler below destroys the conversation.
+                   (copilot-chat--destroy-one-shot conversation-id)
+                   (funcall callback reply error-msg))))
+          copilot-chat--active-buffers)
+    (copilot--async-request
+     'conversation/create
+     (append
+      (list :workDoneToken token
+            :turns (vector
+                    (list :request message
+                          :response ""
+                          :turnId ""))
+            ;; No editor context: the request carries everything it needs.
+            :capabilities (list :skills (vector)
+                                :allSkills :json-false)
+            :source "panel")
+      (copilot-chat--model-param)
+      (list :workspaceFolders
+            (vconcat
+             (when-let* ((root (copilot--workspace-root)))
+               (list (list :uri (concat "file://" root)
+                           :name (file-name-nondirectory
+                                  (directory-file-name root))))))))
+     :success-fn (lambda (result)
+                   (setq conversation-id (plist-get result :conversationId))
+                   (when finished
+                     (copilot-chat--destroy-one-shot conversation-id)))
+     :error-fn (lambda (err)
+                 (setq copilot-chat--active-buffers
+                       (assoc-delete-all token copilot-chat--active-buffers))
+                 (funcall callback nil (format "%s" err))))))
+
 ;;
 ;; UI helpers
 ;;
@@ -1547,6 +1655,77 @@ The context points at the current file with the region's range."
     (with-current-buffer buf
       (copilot-chat--consume-references)))
   (message "Copilot Chat: Cleared pending context"))
+
+;;
+;; Commit message generation
+;;
+
+(defun copilot-chat--staged-diff ()
+  "Return the staged diff of the repository around `default-directory'.
+The diff is taken from the repository root, so all staged changes are
+included regardless of the buffer's own directory.  Signal a
+`user-error' when there is no repository, when git fails, or when
+nothing is staged."
+  (let ((root (locate-dominating-file default-directory ".git")))
+    (unless root
+      (user-error "Copilot Chat: Not inside a git repository"))
+    (let* ((default-directory root)
+           (diff (with-temp-buffer
+                   (let ((status (call-process "git" nil t nil
+                                               "diff" "--cached" "--no-color")))
+                     (unless (eql status 0)
+                       (user-error "Copilot Chat: git diff failed (%s)" status)))
+                   (buffer-string))))
+      (when (string-empty-p (string-trim diff))
+        (user-error "Copilot Chat: No staged changes"))
+      diff)))
+
+(defun copilot-chat--commit-message-request ()
+  "Return the chat message asking for a commit message for the staged diff."
+  (concat copilot-chat-commit-message-prompt "\n\n" (copilot-chat--staged-diff)))
+
+(defun copilot-chat--strip-code-fences (reply)
+  "Return REPLY without enclosing markdown code fences, trimmed.
+The model is asked not to fence the commit message, but strip a fence
+wrapping the whole reply defensively when it adds one anyway."
+  (let ((text (string-trim reply)))
+    (if (string-match "\\````[^\n]*\n\\(\\(?:.\\|\n\\)*?\\)\n?```\\'" text)
+        (string-trim (match-string 1 text))
+      text)))
+
+;;;###autoload
+(defun copilot-chat-insert-commit-message ()
+  "Generate a commit message from the staged diff and insert it at point.
+Meant to be called from a commit message buffer (e.g. Magit's
+COMMIT_EDITMSG), but works from any buffer inside a git repository.
+The staged diff is sent to Copilot with
+`copilot-chat-commit-message-prompt', and the reply is inserted
+asynchronously at point once it arrives.  The request runs outside the
+chat panel and does not disturb an ongoing chat conversation."
+  (interactive)
+  (let ((request (copilot-chat--commit-message-request))
+        (buf (current-buffer))
+        (pos (point-marker)))
+    (message "Copilot Chat: Generating commit message...")
+    (copilot-chat--one-shot
+     request
+     (lambda (reply error-msg)
+       (let ((reply (and reply (copilot-chat--strip-code-fences reply))))
+         (cond
+          (error-msg
+           (message "Copilot Chat: Commit message generation failed: %s"
+                    error-msg))
+          ((or (null reply) (string-empty-p reply))
+           (message "Copilot Chat: Got an empty commit message"))
+          ((not (buffer-live-p buf))
+           (message "Copilot Chat: Commit message buffer is gone"))
+          (t
+           (with-current-buffer buf
+             (save-excursion
+               (goto-char pos)
+               (insert reply)))
+           (set-marker pos nil)
+           (message "Copilot Chat: Commit message inserted"))))))))
 
 ;;
 ;; Major mode

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2228,6 +2228,165 @@
             (copilot-mcp-servers '(:fetch (:command "uvx"))))
         (copilot-chat-list-mcp-tools)
         (with-current-buffer "*copilot-mcp-tools*"
-          (expect (buffer-string) :to-match "reported yet"))))))
+          (expect (buffer-string) :to-match "reported yet")))))
+
+  ;;
+  ;; Commit message generation
+  ;;
+
+  (describe "copilot-chat--staged-diff"
+    (it "errors when not inside a git repository"
+      (spy-on 'locate-dominating-file :and-return-value nil)
+      (expect (copilot-chat--staged-diff) :to-throw 'user-error))
+
+    (it "errors when there are no staged changes"
+      (spy-on 'locate-dominating-file :and-return-value "/tmp/repo/")
+      (spy-on 'call-process :and-return-value 0)
+      (expect (copilot-chat--staged-diff) :to-throw 'user-error))
+
+    (it "errors when git fails"
+      (spy-on 'locate-dominating-file :and-return-value "/tmp/repo/")
+      (spy-on 'call-process :and-return-value 128)
+      (expect (copilot-chat--staged-diff) :to-throw 'user-error))
+
+    (it "returns the staged diff, collected from the repository root"
+      (spy-on 'locate-dominating-file :and-return-value "/tmp/repo/")
+      (let ((git-dir nil))
+        (spy-on 'call-process :and-call-fake
+                (lambda (&rest _args)
+                  (setq git-dir default-directory)
+                  (insert "diff --git a/f b/f\n+new line\n")
+                  0))
+        (expect (copilot-chat--staged-diff)
+                :to-equal "diff --git a/f b/f\n+new line\n")
+        (expect git-dir :to-equal "/tmp/repo/"))))
+
+  (describe "copilot-chat--commit-message-request"
+    (it "prepends the prompt to the staged diff"
+      (spy-on 'copilot-chat--staged-diff :and-return-value "THE DIFF")
+      (let ((copilot-chat-commit-message-prompt "Write a commit message."))
+        (expect (copilot-chat--commit-message-request)
+                :to-equal "Write a commit message.\n\nTHE DIFF"))))
+
+  (describe "copilot-chat--strip-code-fences"
+    (it "strips a fence wrapping the whole reply"
+      (expect (copilot-chat--strip-code-fences "```\nfeat: x\n\nbody\n```")
+              :to-equal "feat: x\n\nbody"))
+
+    (it "strips a fence with a language tag and trailing whitespace"
+      (expect (copilot-chat--strip-code-fences "```text\nfeat: x\n```\n")
+              :to-equal "feat: x"))
+
+    (it "leaves an unfenced reply alone, trimmed"
+      (expect (copilot-chat--strip-code-fences "feat: x\n\nbody\n")
+              :to-equal "feat: x\n\nbody"))
+
+    (it "keeps a fence that does not wrap the whole reply"
+      (expect (copilot-chat--strip-code-fences "feat: x\n\n```\ncode\n```")
+              :to-equal "feat: x\n\n```\ncode\n```")))
+
+  (describe "copilot-chat--handle-progress with a function sink"
+    (it "passes progress values to the sink and unregisters it on end"
+      (let* ((seen '())
+             (copilot-chat--active-buffers
+              (list (cons "tok" (lambda (value) (push value seen))))))
+        (copilot-chat--handle-progress
+         (list :token "tok" :value '(:kind "report" :reply "x")))
+        (copilot-chat--handle-progress
+         (list :token "tok" :value '(:kind "end")))
+        (expect (length seen) :to-equal 2)
+        (expect copilot-chat--active-buffers :not :to-be-truthy))))
+
+  (describe "copilot-chat--one-shot"
+    (it "collects the streamed reply and destroys the conversation"
+      (let ((copilot-chat--active-buffers nil)
+            (requests '())
+            (results '()))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'copilot-chat--default-model :and-return-value nil)
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn method params &rest args)
+                  (push (cons method params) requests)
+                  (when (eq method 'conversation/create)
+                    (funcall (plist-get args :success-fn)
+                             '(:conversationId "conv-1" :turnId "t-1")))
+                  (cons 1 nil)))
+        (copilot-chat--one-shot
+         "hello"
+         (lambda (reply error-msg) (push (list reply error-msg) results)))
+        (let ((token (plist-get (cdr (assq 'conversation/create requests))
+                                :workDoneToken)))
+          (copilot-chat--handle-progress
+           (list :token token :value '(:kind "report" :reply "feat: ")))
+          (copilot-chat--handle-progress
+           (list :token token :value '(:kind "report" :reply "thing")))
+          (copilot-chat--handle-progress
+           (list :token token :value '(:kind "end"))))
+        (expect results :to-equal '(("feat: thing" nil)))
+        (expect (plist-get (cdr (assq 'conversation/destroy requests))
+                           :conversationId)
+                :to-equal "conv-1")
+        (expect copilot-chat--active-buffers :not :to-be-truthy)))
+
+    (it "reports a request error and unregisters the token"
+      (let ((copilot-chat--active-buffers nil)
+            (results '()))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'copilot-chat--default-model :and-return-value nil)
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (funcall (plist-get args :error-fn) "boom")
+                  (cons 1 nil)))
+        (copilot-chat--one-shot
+         "hello"
+         (lambda (reply error-msg) (push (list reply error-msg) results)))
+        (expect results :to-equal '((nil "boom")))
+        (expect copilot-chat--active-buffers :not :to-be-truthy))))
+
+  (describe "copilot-chat-insert-commit-message"
+    (it "errors before sending when the diff cannot be collected"
+      (spy-on 'copilot-chat--staged-diff :and-throw-error 'user-error)
+      (spy-on 'copilot-chat--one-shot)
+      (expect (copilot-chat-insert-commit-message) :to-throw 'user-error)
+      (expect 'copilot-chat--one-shot :not :to-have-been-called))
+
+    (it "sends the prompt followed by the staged diff"
+      (spy-on 'copilot-chat--staged-diff :and-return-value "THE DIFF")
+      (spy-on 'copilot-chat--one-shot)
+      (spy-on 'message)
+      (let ((copilot-chat-commit-message-prompt "PROMPT"))
+        (with-temp-buffer (copilot-chat-insert-commit-message)))
+      (expect (car (spy-calls-args-for 'copilot-chat--one-shot 0))
+              :to-equal "PROMPT\n\nTHE DIFF"))
+
+    (it "inserts the fence-stripped reply into the originating buffer"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--staged-diff :and-return-value "diff")
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'message)
+        (with-temp-buffer
+          (copilot-chat-insert-commit-message)
+          (let ((origin (current-buffer)))
+            ;; The reply arrives later, with another buffer current.
+            (with-temp-buffer
+              (funcall reply-fn "```\nfeat: add thing\n```" nil))
+            (expect (with-current-buffer origin (buffer-string))
+                    :to-equal "feat: add thing")))))
+
+    (it "reports a server error instead of inserting"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--staged-diff :and-return-value "diff")
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'message)
+        (with-temp-buffer
+          (copilot-chat-insert-commit-message)
+          (funcall reply-fn nil "boom")
+          (expect (buffer-string) :to-equal ""))))))
 
 ;;; copilot-chat-test.el ends here

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2235,31 +2235,23 @@
   ;;
 
   (describe "copilot-chat--staged-diff"
+    ;; Real git in temp directories: the earlier spy-based specs stubbed
+    ;; out exactly the root resolution this function must get right.
     (it "errors when not inside a git repository"
-      (spy-on 'locate-dominating-file :and-return-value nil)
-      (expect (copilot-chat--staged-diff) :to-throw 'user-error))
+      (let ((default-directory (make-temp-file "copilot-no-repo" t)))
+        (expect (copilot-chat--staged-diff) :to-throw 'user-error)))
 
     (it "errors when there are no staged changes"
-      (spy-on 'locate-dominating-file :and-return-value "/tmp/repo/")
-      (spy-on 'call-process :and-return-value 0)
-      (expect (copilot-chat--staged-diff) :to-throw 'user-error))
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (expect (copilot-chat--staged-diff) :to-throw 'user-error)))
 
-    (it "errors when git fails"
-      (spy-on 'locate-dominating-file :and-return-value "/tmp/repo/")
-      (spy-on 'call-process :and-return-value 128)
-      (expect (copilot-chat--staged-diff) :to-throw 'user-error))
-
-    (it "returns the staged diff, collected from the repository root"
-      (spy-on 'locate-dominating-file :and-return-value "/tmp/repo/")
-      (let ((git-dir nil))
-        (spy-on 'call-process :and-call-fake
-                (lambda (&rest _args)
-                  (setq git-dir default-directory)
-                  (insert "diff --git a/f b/f\n+new line\n")
-                  0))
-        (expect (copilot-chat--staged-diff)
-                :to-equal "diff --git a/f b/f\n+new line\n")
-        (expect git-dir :to-equal "/tmp/repo/"))))
+    (it "returns the staged diff with git resolving the repository"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (write-region "hello\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "f.txt")
+        (expect (copilot-chat--staged-diff) :to-match "\\+hello"))))
 
   (describe "copilot-chat--commit-message-request"
     (it "prepends the prompt to the staged diff"
@@ -2283,7 +2275,11 @@
 
     (it "keeps a fence that does not wrap the whole reply"
       (expect (copilot-chat--strip-code-fences "feat: x\n\n```\ncode\n```")
-              :to-equal "feat: x\n\n```\ncode\n```")))
+              :to-equal "feat: x\n\n```\ncode\n```"))
+
+    (it "strips four-backtick fences"
+      (expect (copilot-chat--strip-code-fences "````\nfeat: x\n````")
+              :to-equal "feat: x")))
 
   (describe "copilot-chat--handle-progress with a function sink"
     (it "passes progress values to the sink and unregisters it on end"
@@ -2295,7 +2291,17 @@
         (copilot-chat--handle-progress
          (list :token "tok" :value '(:kind "end")))
         (expect (length seen) :to-equal 2)
-        (expect copilot-chat--active-buffers :not :to-be-truthy))))
+        (expect copilot-chat--active-buffers :not :to-be-truthy)))
+
+    (it "unregisters the sink even when its callback signals"
+      (let ((copilot-chat--active-buffers
+             (list (cons "tok" (lambda (_value) (error "boom")))))
+            (copilot-chat--one-shot-requests '(("tok" . 1))))
+        (expect (copilot-chat--handle-progress
+                 (list :token "tok" :value '(:kind "end")))
+                :to-throw 'error)
+        (expect copilot-chat--active-buffers :not :to-be-truthy)
+        (expect copilot-chat--one-shot-requests :not :to-be-truthy))))
 
   (describe "copilot-chat--one-shot"
     (it "collects the streamed reply and destroys the conversation"
@@ -2343,7 +2349,35 @@
          "hello"
          (lambda (reply error-msg) (push (list reply error-msg) results)))
         (expect results :to-equal '((nil "boom")))
-        (expect copilot-chat--active-buffers :not :to-be-truthy))))
+        (expect copilot-chat--active-buffers :not :to-be-truthy)))
+
+    (it "registers nothing when the request cannot be issued"
+      (let ((copilot-chat--active-buffers nil)
+            (copilot-chat--one-shot-requests nil))
+        (spy-on 'copilot--connection-alivep :and-return-value nil)
+        (spy-on 'copilot--start-server :and-throw-error 'user-error)
+        (expect (copilot-chat--one-shot "hi" #'ignore) :to-throw 'user-error)
+        (expect copilot-chat--active-buffers :not :to-be-truthy)
+        (expect copilot-chat--one-shot-requests :not :to-be-truthy))))
+
+  (describe "copilot-chat-stop with a pending one-shot"
+    (it "cancels the one-shot instead of resetting the conversation"
+      (let* ((results '())
+             (copilot-chat--one-shot-requests '(("tok" . 42)))
+             (copilot-chat--active-buffers
+              (list (cons "tok"
+                          (copilot-chat--collecting-sink
+                           (lambda (reply err)
+                             (push (list reply err) results)))))))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc-notify)
+        (spy-on 'copilot-chat-reset)
+        (copilot-chat-stop)
+        (expect 'copilot-chat-reset :not :to-have-been-called)
+        (expect 'jsonrpc-notify :to-have-been-called)
+        (expect copilot-chat--active-buffers :not :to-be-truthy)
+        (expect copilot-chat--one-shot-requests :not :to-be-truthy)
+        (expect results :to-equal '(("" "Cancelled"))))))
 
   (describe "copilot-chat-insert-commit-message"
     (it "errors before sending when the diff cannot be collected"
@@ -2387,6 +2421,20 @@
         (with-temp-buffer
           (copilot-chat-insert-commit-message)
           (funcall reply-fn nil "boom")
-          (expect (buffer-string) :to-equal ""))))))
+          (expect (buffer-string) :to-equal ""))))
+
+    (it "copies the reply to the kill ring when the buffer is read-only"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--staged-diff :and-return-value "diff")
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'message)
+        (with-temp-buffer
+          (copilot-chat-insert-commit-message)
+          (setq buffer-read-only t)
+          (funcall reply-fn "feat: x" nil)
+          (expect (buffer-string) :to-equal ""))
+        (expect (current-kill 0) :to-equal "feat: x")))))
 
 ;;; copilot-chat-test.el ends here


### PR DESCRIPTION
Adds `copilot-chat-insert-commit-message`: run it in a Magit/`git-commit` buffer (or anywhere in a repo) and it generates a commit message from the staged diff and inserts it at point. This is the most-loved feature of chep's copilot-chat.el, adapted to the language-server architecture.

Implementation notes:

- The request runs as a throwaway one-shot conversation, so it neither needs the chat panel open nor disturbs an ongoing conversation there. To support that, `copilot-chat--active-buffers` entries can now hold a function sink besides a chat buffer; the buffer streaming path is unchanged, just factored into `copilot-chat--handle-buffer-progress`.
- The one-shot conversation is destroyed after the reply arrives, including the race where the reply completes before `conversation/create` returns the conversation id.
- The instruction is customizable via `copilot-chat-commit-message-prompt` (defaults to a conventional 72-char-summary format). Code fences are stripped defensively if the model adds them anyway.
- The server is auto-started if needed (same as other requests), so this works straight from a commit buffer in a fresh session.

425 specs pass, checkdoc clean, no new compile warnings.