### PR TITLE
Add one-shot chat task commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### New Features
 
 - Show a status header line in the chat buffer with the chat mode (Agent or Ask), the active model, and in agent mode the number of available tools; disable it with `copilot-chat-show-status-header`. ([#509](https://github.com/copilot-emacs/copilot.el/discussions/509))
+- Add one-shot chat task commands that send the active region (or the defun at point) with a canned prompt, with the answer streaming into the regular chat buffer. The prompts are customizable via `copilot-chat-task-prompts`, and `copilot-chat-task` picks a task with completion:
+  - `copilot-chat-review`
+  - `copilot-chat-fix`
+  - `copilot-chat-doc`
+  - `copilot-chat-optimize`
+  - `copilot-chat-write-tests`
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ M-x copilot-chat
 M-x copilot-chat-send-region
 ```
 
+There are also one-shot task commands that send the active region (or the function at point when no region is active) with a canned prompt, so you don't have to type anything; the answer streams into the chat buffer as usual:
+
+- `copilot-chat-review` — review the code for bugs, risks, and improvements
+- `copilot-chat-fix` — fix bugs or problems in the code
+- `copilot-chat-doc` — document the code (docstrings and comments)
+- `copilot-chat-optimize` — optimize the code for performance and readability
+- `copilot-chat-write-tests` — write unit tests for the code
+
+`copilot-chat-task` prompts for the task with completion and dispatches to the same machinery. The prompts live in `copilot-chat-task-prompts` and can be customized (or extended with your own tasks).
+
 Key bindings in the `*copilot-chat*` buffer:
 - **C-c RET** or **C-c C-c** — send a follow-up message
 - **C-c C-k** — cancel streaming, or reset if idle
@@ -445,6 +455,12 @@ For example:
 | `copilot-chat` | Open Copilot Chat and send a message |
 | `copilot-chat-send` | Send a follow-up message in the current chat |
 | `copilot-chat-send-region` | Send the selected region as context with an optional prompt |
+| `copilot-chat-task` | Pick a one-shot task and run it on the region or defun at point |
+| `copilot-chat-review` | Review the region or defun at point |
+| `copilot-chat-fix` | Fix the region or defun at point |
+| `copilot-chat-doc` | Document the region or defun at point |
+| `copilot-chat-optimize` | Optimize the region or defun at point |
+| `copilot-chat-write-tests` | Write tests for the region or defun at point |
 | `copilot-chat-stop` | Cancel streaming, or reset the conversation if idle |
 | `copilot-chat-reset` | Destroy the current conversation and clear the chat buffer |
 | **Next Edit Suggestions** | |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -34,6 +34,7 @@
 ;;; Code:
 
 (require 'copilot)
+(require 'thingatpt)
 
 (declare-function flymake-diagnostics "flymake")
 (declare-function flymake-diagnostic-beg "flymake")
@@ -131,6 +132,23 @@ model answers, and in agent mode how many tools are available.  It is
 set up when the chat buffer is created, so changing this takes effect
 for new chat buffers."
   :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
+(defcustom copilot-chat-task-prompts
+  '((review . "Review the following code and point out bugs, risks, and possible improvements:")
+    (fix . "Fix the bugs or problems in the following code and explain what was wrong:")
+    (doc . "Document the following code: add docstrings and comments in the conventional style for its language:")
+    (optimize . "Optimize the following code for performance and readability, and explain each change:")
+    (tests . "Write a comprehensive set of unit tests for the following code:"))
+  "Prompts used by the one-shot Copilot Chat task commands.
+An alist mapping a task symbol to the instruction sent along with the
+selected code.  The known tasks are `review' (`copilot-chat-review'),
+`fix' (`copilot-chat-fix'), `doc' (`copilot-chat-doc'), `optimize'
+\(`copilot-chat-optimize'), and `tests' (`copilot-chat-write-tests');
+extra entries become available through `copilot-chat-task'."
+  :type '(alist :key-type (symbol :tag "Task")
+                :value-type (string :tag "Prompt"))
   :group 'copilot-chat
   :package-version '(copilot . "0.8"))
 
@@ -1705,6 +1723,68 @@ When called interactively, prompt for the message."
                       (format "%s\n\n```%s\n%s\n```" prompt lang code)
                     (format "```%s\n%s\n```" lang code))))
     (copilot-chat message)))
+
+;;
+;; One-shot task commands
+;;
+
+(defun copilot-chat--task-bounds ()
+  "Return the bounds of the code a task command should act on.
+Use the active region when there is one, otherwise the defun at point.
+Signal a `user-error' when neither is available."
+  (or (and (use-region-p) (cons (region-beginning) (region-end)))
+      (bounds-of-thing-at-point 'defun)
+      (user-error "Copilot Chat: No active region or function at point")))
+
+(defun copilot-chat--task-prompt (task)
+  "Return the prompt configured for TASK in `copilot-chat-task-prompts'.
+Signal a `user-error' when TASK has no prompt."
+  (or (alist-get task copilot-chat-task-prompts)
+      (user-error "Copilot Chat: No prompt configured for task `%s'" task)))
+
+;;;###autoload
+(defun copilot-chat-task (task)
+  "Send the region (or the defun at point) to Copilot Chat for TASK.
+TASK is a key of `copilot-chat-task-prompts', whose prompt is sent
+along with the code.  Interactively, pick the task with completion.
+The answer streams into the regular chat buffer."
+  (interactive
+   (list (intern (completing-read "Copilot Chat task: "
+                                  (mapcar #'car copilot-chat-task-prompts)
+                                  nil t))))
+  (let ((bounds (copilot-chat--task-bounds)))
+    (copilot-chat-send-region (car bounds) (cdr bounds)
+                              (copilot-chat--task-prompt task))))
+
+;;;###autoload
+(defun copilot-chat-review ()
+  "Ask Copilot Chat to review the region or the defun at point."
+  (interactive)
+  (copilot-chat-task 'review))
+
+;;;###autoload
+(defun copilot-chat-fix ()
+  "Ask Copilot Chat to fix the region or the defun at point."
+  (interactive)
+  (copilot-chat-task 'fix))
+
+;;;###autoload
+(defun copilot-chat-doc ()
+  "Ask Copilot Chat to document the region or the defun at point."
+  (interactive)
+  (copilot-chat-task 'doc))
+
+;;;###autoload
+(defun copilot-chat-optimize ()
+  "Ask Copilot Chat to optimize the region or the defun at point."
+  (interactive)
+  (copilot-chat-task 'optimize))
+
+;;;###autoload
+(defun copilot-chat-write-tests ()
+  "Ask Copilot Chat to write a test suite for the region or the defun at point."
+  (interactive)
+  (copilot-chat-task 'tests))
 
 (defvar copilot-chat--templates nil
   "Cached slash-command templates from `conversation/templates'.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -1731,9 +1731,14 @@ When called interactively, prompt for the message."
 (defun copilot-chat--task-bounds ()
   "Return the bounds of the code a task command should act on.
 Use the active region when there is one, otherwise the defun at point.
-Signal a `user-error' when neither is available."
+The defun fallback only applies in `prog-mode' buffers: outside of them
+\(markdown, text, ...) `bounds-of-thing-at-point' happily returns a
+whole prose section or a parenthesized fragment, which is never what a
+code task should be sent.  Signal a `user-error' when nothing suitable
+is available."
   (or (and (use-region-p) (cons (region-beginning) (region-end)))
-      (bounds-of-thing-at-point 'defun)
+      (and (derived-mode-p 'prog-mode)
+           (bounds-of-thing-at-point 'defun))
       (user-error "Copilot Chat: No active region or function at point")))
 
 (defun copilot-chat--task-prompt (task)
@@ -1749,9 +1754,17 @@ TASK is a key of `copilot-chat-task-prompts', whose prompt is sent
 along with the code.  Interactively, pick the task with completion.
 The answer streams into the regular chat buffer."
   (interactive
-   (list (intern (completing-read "Copilot Chat task: "
-                                  (mapcar #'car copilot-chat-task-prompts)
-                                  nil t))))
+   (let ((choice (completing-read
+                  "Copilot Chat task: "
+                  ;; Offer only symbol keys: a string key sneaked into
+                  ;; the alist could be offered but never looked up.
+                  (seq-filter #'symbolp (mapcar #'car copilot-chat-task-prompts))
+                  nil t)))
+     ;; With no default, an empty minibuffer input returns "" even
+     ;; though REQUIRE-MATCH is t.
+     (when (string-empty-p choice)
+       (user-error "Copilot Chat: No task selected"))
+     (list (intern choice))))
   (let ((bounds (copilot-chat--task-bounds)))
     (copilot-chat-send-region (car bounds) (cdr bounds)
                               (copilot-chat--task-prompt task))))

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1868,7 +1868,23 @@
 
     (it "errors with neither a region nor a defun at point"
       (with-temp-buffer
-        (expect (copilot-chat--task-bounds) :to-throw 'user-error))))
+        (expect (copilot-chat--task-bounds) :to-throw 'user-error)))
+
+    (it "does not treat prose as a defun outside prog-mode"
+      ;; In text-ish modes `bounds-of-thing-at-point' returns sections or
+      ;; parenthesized fragments; the fallback must not fire there.
+      (with-temp-buffer
+        (text-mode)
+        (insert "Steps:\n(1) do this\n(2) do that\n")
+        (goto-char (+ (point-min) 8))
+        (expect (copilot-chat--task-bounds) :to-throw 'user-error)))
+
+    (it "still finds the defun in prog-mode buffers"
+      (with-temp-buffer
+        (emacs-lisp-mode)
+        (insert "(defun foo ()\n  42)\n")
+        (goto-char (+ (point-min) 3))
+        (expect (copilot-chat--task-bounds) :not :to-be nil))))
 
   (describe "copilot-chat--task-prompt"
     (it "looks up the task's prompt in copilot-chat-task-prompts"
@@ -1915,7 +1931,24 @@
         (spy-on 'copilot-chat-send-region)
         (call-interactively #'copilot-chat-task)
         (expect (nth 2 (spy-calls-args-for 'copilot-chat-send-region 0))
-                :to-equal (alist-get 'tests copilot-chat-task-prompts)))))
+                :to-equal (alist-get 'tests copilot-chat-task-prompts))))
+
+    (it "rejects empty interactive input instead of interning it"
+      (spy-on 'completing-read :and-return-value "")
+      (expect (call-interactively #'copilot-chat-task) :to-throw 'user-error))
+
+    (it "offers only symbol keys for completion"
+      (let ((copilot-chat-task-prompts '((review . "Do review:")
+                                         ("rogue" . "String key:"))))
+        (spy-on 'completing-read :and-return-value "review")
+        (spy-on 'copilot-chat-send-region)
+        (with-temp-buffer
+          (emacs-lisp-mode)
+          (insert "(defun foo () 1)")
+          (goto-char (+ (point-min) 3))
+          (call-interactively #'copilot-chat-task))
+        (expect (cadr (spy-calls-args-for 'completing-read 0))
+                :to-equal '(review)))))
 
   (describe "named task commands"
     (it "dispatches each command to its task"

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1842,6 +1842,95 @@
           (expect msg :to-match "```emacs-lisp")
           (expect msg :to-match "(\\+ 1 2)")))))
 
+  ;;
+  ;; One-shot task commands
+  ;;
+
+  (describe "copilot-chat--task-bounds"
+    (it "uses the active region when there is one"
+      (with-temp-buffer
+        (insert "(defun foo () 1)\n(defun bar () 2)\n")
+        (let ((transient-mark-mode t))
+          (goto-char (point-min))
+          (set-mark (point))
+          (goto-char (line-end-position))
+          (expect (copilot-chat--task-bounds)
+                  :to-equal (cons (point-min) (line-end-position))))))
+
+    (it "falls back to the defun at point when no region is active"
+      (with-temp-buffer
+        (emacs-lisp-mode)
+        (insert "(defun foo ()\n  42)\n")
+        (goto-char (+ (point-min) 3))
+        (let ((bounds (copilot-chat--task-bounds)))
+          (expect (buffer-substring (car bounds) (cdr bounds))
+                  :to-match "defun foo"))))
+
+    (it "errors with neither a region nor a defun at point"
+      (with-temp-buffer
+        (expect (copilot-chat--task-bounds) :to-throw 'user-error))))
+
+  (describe "copilot-chat--task-prompt"
+    (it "looks up the task's prompt in copilot-chat-task-prompts"
+      (let ((copilot-chat-task-prompts '((review . "Do review:"))))
+        (expect (copilot-chat--task-prompt 'review) :to-equal "Do review:")))
+
+    (it "errors for a task without a configured prompt"
+      (let ((copilot-chat-task-prompts nil))
+        (expect (copilot-chat--task-prompt 'review) :to-throw 'user-error))))
+
+  (describe "copilot-chat-task"
+    (it "sends the defun at point with the task prompt through the chat"
+      (with-temp-buffer
+        (emacs-lisp-mode)
+        (insert "(defun foo ()\n  42)\n")
+        (goto-char (+ (point-min) 3))
+        (spy-on 'copilot-chat)
+        (copilot-chat-task 'review)
+        (let ((msg (car (spy-calls-args-for 'copilot-chat 0))))
+          (expect msg :to-match "Review the following code")
+          (expect msg :to-match "```emacs-lisp")
+          (expect msg :to-match "defun foo"))))
+
+    (it "sends only the active region, not the surrounding code"
+      (with-temp-buffer
+        (emacs-lisp-mode)
+        (insert "(defun foo () 1)\n(defun bar () 2)\n")
+        (spy-on 'copilot-chat)
+        (let ((transient-mark-mode t))
+          (goto-char (point-min))
+          (set-mark (point))
+          (goto-char (line-end-position))
+          (copilot-chat-task 'fix))
+        (let ((msg (car (spy-calls-args-for 'copilot-chat 0))))
+          (expect msg :to-match "defun foo")
+          (expect msg :not :to-match "defun bar"))))
+
+    (it "reads the task with completion when called interactively"
+      (with-temp-buffer
+        (emacs-lisp-mode)
+        (insert "(defun foo () 1)")
+        (goto-char (+ (point-min) 3))
+        (spy-on 'completing-read :and-return-value "tests")
+        (spy-on 'copilot-chat-send-region)
+        (call-interactively #'copilot-chat-task)
+        (expect (nth 2 (spy-calls-args-for 'copilot-chat-send-region 0))
+                :to-equal (alist-get 'tests copilot-chat-task-prompts)))))
+
+  (describe "named task commands"
+    (it "dispatches each command to its task"
+      (spy-on 'copilot-chat-task)
+      (copilot-chat-review)
+      (copilot-chat-fix)
+      (copilot-chat-doc)
+      (copilot-chat-optimize)
+      (copilot-chat-write-tests)
+      (expect 'copilot-chat-task :to-have-been-called-with 'review)
+      (expect 'copilot-chat-task :to-have-been-called-with 'fix)
+      (expect 'copilot-chat-task :to-have-been-called-with 'doc)
+      (expect 'copilot-chat-task :to-have-been-called-with 'optimize)
+      (expect 'copilot-chat-task :to-have-been-called-with 'tests)))
+
   (describe "context references"
     ;; Start from a clean slate: no stale chat buffer leaked from an
     ;; earlier spec, so the "create if needed" path is exercised honestly.


### PR DESCRIPTION
Adds five commands that send the active region (or the defun at point) to the chat with a canned instruction, so the common "review this / fix this / test this" asks don't require opening the chat and composing a prompt:

- `copilot-chat-review`
- `copilot-chat-fix`
- `copilot-chat-doc`
- `copilot-chat-optimize`
- `copilot-chat-write-tests`

`copilot-chat-task` offers the same via completion, and the prompts are customizable through `copilot-chat-task-prompts` (extra alist entries become new tasks automatically). Everything routes through the existing `copilot-chat-send-region`, so answers stream into the regular chat buffer with the usual language-tagged code block.

418 specs pass, checkdoc clean, no new compile warnings.