### PR TITLE
Show a status header line in the chat buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### New Features
+
+- Show a status header line in the chat buffer with the chat mode (Agent or Ask), the active model, and in agent mode the number of available tools; disable it with `copilot-chat-show-status-header`. ([#509](https://github.com/copilot-emacs/copilot.el/discussions/509))
+
 ### Bug Fixes
 
 - Send the selected chat model on every conversation turn, not just the first one, so follow-up messages no longer fail with "A model id is required" on recent language-server versions. The model is now sent via the modern `modelInfo` field, with the deprecated `model` field kept as a fallback for older servers. ([#508](https://github.com/copilot-emacs/copilot.el/issues/508))

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Key bindings in the `*copilot-chat*` buffer:
 
 Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
 
+The chat buffer's header line shows at a glance whether Agent or Ask mode is active, which model answers, and in agent mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it.
+
 Customization:
 - **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)
 - **`copilot-chat-use-agent-mode`** — let Copilot run tools (shell commands, file edits, reads, etc.) during a chat (default `nil`)

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Key bindings in the `*copilot-chat*` buffer:
 
 Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
 
-The chat buffer's header line shows at a glance whether Agent or Ask mode is active, which model answers, and in agent mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it.
+The chat buffer's header line shows at a glance whether Agent or Ask mode is active, which model answers, and in agent mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
 
 Customization:
 - **`copilot-chat-model`** — model to use for chat (default `nil`, meaning a default chat model is resolved from the server)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -140,8 +140,11 @@ for new chat buffers."
   :group 'copilot-chat)
 
 (defface copilot-chat-status-header-face
-  '((t :inherit (shadow header-line)))
-  "Face for the status header line in the chat buffer."
+  '((t :inherit shadow))
+  "Face for the status header line in the chat buffer.
+Inheriting `header-line' as well would paint active-window colors into
+inactive windows on Emacs 31+, which splits the two into separate
+faces; the underlying `header-line' face still applies on its own."
   :group 'copilot-chat)
 
 (defface copilot-chat-follow-up-face
@@ -1555,11 +1558,18 @@ The context points at the current file with the region's range."
       " Copilot-Chat[Streaming]"
     " Copilot-Chat"))
 
+(defvar copilot-chat--client-tool-count nil
+  "Cached count of copilot.el's own client tools.
+The definitions are static, but building them allocates; the header
+line evaluates on every redisplay, so it must not do that each time.")
+
 (defun copilot-chat--tool-count ()
   "Return the number of tools available in agent mode.
 Count copilot.el's own client tools plus the tools of the MCP servers
 last reported by the language server (`copilot-chat--mcp-servers')."
-  (+ (length (copilot-chat--client-tool-names))
+  (+ (or copilot-chat--client-tool-count
+         (setq copilot-chat--client-tool-count
+               (length (copilot-chat--client-tool-names))))
      (seq-reduce (lambda (acc server)
                    (+ acc (length (plist-get server :tools))))
                  copilot-chat--mcp-servers
@@ -1568,10 +1578,11 @@ last reported by the language server (`copilot-chat--mcp-servers')."
 (defun copilot-chat--status-header ()
   "Return the status header line for the chat buffer.
 Show the chat mode (Agent or Ask), the active model, and in agent mode
-the number of available tools.  Built only from variables already in
-memory (`copilot-chat-model', the cached `copilot-chat--resolved-model'
-and `copilot-chat--mcp-servers'), so it is cheap enough to evaluate on
-every redisplay and never contacts the server."
+the number of available tools.  Built from variables already in memory
+\(`copilot-chat-model', the cached `copilot-chat--resolved-model' and
+`copilot-chat--mcp-servers') plus a memoized client-tool count, so it
+is cheap enough to evaluate on every redisplay and never contacts the
+server."
   (let ((segments
          (list (concat "Copilot Chat  "
                        (if copilot-chat-use-agent-mode "Agent mode" "Ask mode"))

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -124,9 +124,24 @@ after \\[copilot-diagnose])."
   :group 'copilot-chat
   :package-version '(copilot . "0.7"))
 
+(defcustom copilot-chat-show-status-header t
+  "When non-nil, show a status header line in the chat buffer.
+The header shows at a glance whether Agent or Ask mode is active, which
+model answers, and in agent mode how many tools are available.  It is
+set up when the chat buffer is created, so changing this takes effect
+for new chat buffers."
+  :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
 (defface copilot-chat-error-face
   '((t :inherit error))
   "Face for error messages in the chat buffer."
+  :group 'copilot-chat)
+
+(defface copilot-chat-status-header-face
+  '((t :inherit (shadow header-line)))
+  "Face for the status header line in the chat buffer."
   :group 'copilot-chat)
 
 (defface copilot-chat-follow-up-face
@@ -1540,12 +1555,41 @@ The context points at the current file with the region's range."
       " Copilot-Chat[Streaming]"
     " Copilot-Chat"))
 
+(defun copilot-chat--tool-count ()
+  "Return the number of tools available in agent mode.
+Count copilot.el's own client tools plus the tools of the MCP servers
+last reported by the language server (`copilot-chat--mcp-servers')."
+  (+ (length (copilot-chat--client-tool-names))
+     (seq-reduce (lambda (acc server)
+                   (+ acc (length (plist-get server :tools))))
+                 copilot-chat--mcp-servers
+                 0)))
+
+(defun copilot-chat--status-header ()
+  "Return the status header line for the chat buffer.
+Show the chat mode (Agent or Ask), the active model, and in agent mode
+the number of available tools.  Built only from variables already in
+memory (`copilot-chat-model', the cached `copilot-chat--resolved-model'
+and `copilot-chat--mcp-servers'), so it is cheap enough to evaluate on
+every redisplay and never contacts the server."
+  (let ((segments
+         (list (concat "Copilot Chat  "
+                       (if copilot-chat-use-agent-mode "Agent mode" "Ask mode"))
+               (or copilot-chat-model
+                   copilot-chat--resolved-model
+                   "default model")
+               (when copilot-chat-use-agent-mode
+                 (format "%d tools" (copilot-chat--tool-count))))))
+    (propertize (string-join (delq nil segments) "  •  ")
+                'face 'copilot-chat-status-header-face)))
+
 (declare-function gfm-mode "ext:markdown-mode" ())
 
 (defun copilot-chat--setup-mode ()
-  "Set up font-lock, mode-line, and visual-line for `copilot-chat-mode'.
-When `markdown-mode' is available, enable GFM font-lock for full
-markdown rendering; otherwise use basic highlighting."
+  "Set up font-lock, mode-line, header-line, and visual-line settings.
+Used by `copilot-chat-mode'.  When `markdown-mode' is available, enable
+GFM font-lock for full markdown rendering; otherwise use basic
+highlighting."
   (when (require 'markdown-mode nil t)
     (setq-local markdown-fontify-code-blocks-natively t)
     (setq-local font-lock-defaults
@@ -1555,6 +1599,8 @@ markdown rendering; otherwise use basic highlighting."
     (font-lock-flush))
   (font-lock-add-keywords nil copilot-chat--font-lock-keywords t)
   (setq mode-name '(:eval (copilot-chat--mode-line)))
+  (when copilot-chat-show-status-header
+    (setq header-line-format '(:eval (copilot-chat--status-header))))
   (visual-line-mode 1)
   (setq word-wrap t))
 

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -60,10 +60,16 @@
         (expect (lookup-key copilot-chat-mode-map (kbd "C-c C-i"))
                 :to-equal #'copilot-chat-insert-code-block)))
 
-    (it "sets a status header line"
+    (it "sets a status header line whose :eval yields the status string"
       (with-temp-buffer
         (copilot-chat-mode)
-        (expect header-line-format :to-be-truthy)))
+        (expect header-line-format :to-be-truthy)
+        ;; Evaluate the actual `(:eval FORM)' element the way redisplay
+        ;; would, so a typo in the referenced function fails the test.
+        (expect (car header-line-format) :to-be :eval)
+        (expect (substring-no-properties (eval (nth 1 header-line-format) t))
+                :to-equal
+                (substring-no-properties (copilot-chat--status-header)))))
 
     (it "sets no header line when copilot-chat-show-status-header is nil"
       (let ((copilot-chat-show-status-header nil))
@@ -115,7 +121,7 @@
                 :tools [(:name "store")]))))
         (expect (substring-no-properties (copilot-chat--status-header))
                 :to-match
-                (format "%d tools\\'"
+                (format "  %d tools\\'"
                         (+ 3 (length (copilot-chat--client-tool-names))))))))
 
   ;;

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -58,7 +58,65 @@
         (expect (lookup-key copilot-chat-mode-map (kbd "C-c C-k"))
                 :to-equal #'copilot-chat-stop)
         (expect (lookup-key copilot-chat-mode-map (kbd "C-c C-i"))
-                :to-equal #'copilot-chat-insert-code-block))))
+                :to-equal #'copilot-chat-insert-code-block)))
+
+    (it "sets a status header line"
+      (with-temp-buffer
+        (copilot-chat-mode)
+        (expect header-line-format :to-be-truthy)))
+
+    (it "sets no header line when copilot-chat-show-status-header is nil"
+      (let ((copilot-chat-show-status-header nil))
+        (with-temp-buffer
+          (copilot-chat-mode)
+          (expect header-line-format :to-be nil)))))
+
+  ;;
+  ;; Status header
+  ;;
+
+  (describe "copilot-chat--status-header"
+    (it "shows agent mode with the model and the tool count"
+      (let ((copilot-chat-use-agent-mode t)
+            (copilot-chat-model "gpt-5-codex")
+            (copilot-chat--mcp-servers nil))
+        (expect (substring-no-properties (copilot-chat--status-header))
+                :to-equal
+                (format "Copilot Chat  Agent mode  •  gpt-5-codex  •  %d tools"
+                        (length (copilot-chat--client-tool-names))))))
+
+    (it "shows ask mode without a tool count"
+      (let ((copilot-chat-use-agent-mode nil)
+            (copilot-chat-model "gpt-4o"))
+        (expect (substring-no-properties (copilot-chat--status-header))
+                :to-equal "Copilot Chat  Ask mode  •  gpt-4o")))
+
+    (it "falls back to the resolved model when no model is customized"
+      (let ((copilot-chat-use-agent-mode nil)
+            (copilot-chat-model nil)
+            (copilot-chat--resolved-model "gpt-4.1"))
+        (expect (substring-no-properties (copilot-chat--status-header))
+                :to-equal "Copilot Chat  Ask mode  •  gpt-4.1")))
+
+    (it "falls back to the default model when nothing is resolved"
+      (let ((copilot-chat-use-agent-mode nil)
+            (copilot-chat-model nil)
+            (copilot-chat--resolved-model nil))
+        (expect (substring-no-properties (copilot-chat--status-header))
+                :to-equal "Copilot Chat  Ask mode  •  default model")))
+
+    (it "counts MCP tools reported by the server"
+      (let ((copilot-chat-use-agent-mode t)
+            (copilot-chat-model "gpt-5-codex")
+            (copilot-chat--mcp-servers
+             '((:name "fetch" :status "running"
+                :tools [(:name "fetch_url") (:name "fetch_html")])
+               (:name "memory" :status "running"
+                :tools [(:name "store")]))))
+        (expect (substring-no-properties (copilot-chat--status-header))
+                :to-match
+                (format "%d tools\\'"
+                        (+ 3 (length (copilot-chat--client-tool-names))))))))
 
   ;;
   ;; Code blocks


### PR DESCRIPTION
Adds a header line to the `*copilot-chat*` buffer showing the chat mode (Agent or Ask), the active model, and in agent mode the number of available tools (client tools plus MCP-server tools):

```
Copilot Chat  Agent mode  •  gpt-5-codex  •  8 tools
```

Motivation: in discussion #509 agent mode silently looked broken because nothing in the UI says whether it's active or which model answers. Together with #512 (the tool-support warning), this makes the agent-mode state visible at a glance.

The header is built via `:eval` from variables already in memory (`copilot-chat-model`, the cached resolved model, cached MCP server list), so it never contacts the server and costs nothing on redisplay. `copilot-chat-show-status-header` (default `t`) disables it.

416 specs pass, checkdoc clean, no new compile warnings.