### PR TITLE
Add a transient menu for the most common commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `copilot-chat-optimize`
   - `copilot-chat-write-tests`
 - Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt` and a pending generation cancellable with `copilot-chat-stop`.
+- Add `copilot-menu`, a transient (magit-style) menu that gathers the most common Copilot commands (completions, chat, agent mode, account and usage info, and server management) and shows the current state of `copilot-mode`, agent mode, and the selected chat model. Requires the `transient` package (bundled with Emacs 28.1 and newer) but only when the menu itself is used.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -419,14 +419,28 @@ For example:
   (lambda (msg) (message (plist-get msg :message))))
 ```
 
+## The Copilot Menu
+
+`M-x copilot-menu` opens a transient menu (in the style of Magit) that puts the
+most common commands one keystroke away: completions, chat, agent mode, account
+and usage info, and server management. It also shows the current state of
+`copilot-mode`, agent mode, and the selected chat model, so it doubles as a
+quick status overview.
+
+The menu is built on the `transient` package, which is bundled with Emacs 28.1
+and newer. It is a soft dependency: on Emacs 27.2 (where current transient
+releases are not installable) the rest of copilot.el works as usual and
+`copilot-menu` explains what is missing if invoked.
+
 ## Commands
 
 > [!TIP]
 >
-> You don't need to memorize the list — just type `M-x copilot-` followed by TAB, or use the Copilot menu in the menubar.
+> You don't need to memorize the list — just type `M-x copilot-` followed by TAB, use `M-x copilot-menu`, or use the Copilot menu in the menubar.
 
 | Command | Description |
 |---------|-------------|
+| `copilot-menu` | Open a transient menu with the most common commands |
 | **Setup** | |
 | `copilot-install-server` | Install the language server |
 | `copilot-uninstall-server` | Remove the installed language server |

--- a/copilot-menu.el
+++ b/copilot-menu.el
@@ -94,7 +94,7 @@
      "Transient menu for the most common Copilot commands."
      [["Completions"
        ("t" copilot-mode
-        :description (lambda () (copilot-menu--copilot-mode-description))
+        :description copilot-menu--copilot-mode-description
         :transient t)
        ("c" "Complete at point" copilot-complete)
        ("p" "Panel completions" copilot-panel-complete)]
@@ -105,10 +105,10 @@
        ("f" "Attach file as context" copilot-chat-add-file-reference)
        ("k" "Clear pending context" copilot-chat-clear-references)
        ("m" copilot-chat-select-model
-        :description (lambda () (copilot-menu--chat-model-description)))]
+        :description copilot-menu--chat-model-description)]
       ["Agent"
        ("a" copilot-menu-toggle-agent-mode
-        :description (lambda () (copilot-menu--agent-mode-description))
+        :description copilot-menu--agent-mode-description
         :transient t)
        ("T" "List MCP tools" copilot-chat-list-mcp-tools)]]
      [["Account"
@@ -136,10 +136,17 @@ transient releases are not installable.")
 (if (require 'transient nil t)
     (eval copilot-menu--definition t)
   (defun copilot-menu ()
-    "Placeholder for the Copilot menu when `transient' is missing."
+    "Placeholder for the Copilot menu when `transient' is missing.
+Retries loading transient, so installing it mid-session is picked up
+without re-loading copilot-menu.el."
     (interactive)
-    (user-error
-     "Copilot: `copilot-menu' requires the `transient' package (bundled with Emacs 28.1 and newer)")))
+    (if (require 'transient nil t)
+        (progn
+          (eval copilot-menu--definition t)
+          ;; By now the transient prefix has replaced this placeholder.
+          (call-interactively 'copilot-menu))
+      (user-error
+       "Copilot: `copilot-menu' requires the `transient' package (bundled with Emacs 28.1 and newer)"))))
 
 (provide 'copilot-menu)
 ;;; copilot-menu.el ends here

--- a/copilot-menu.el
+++ b/copilot-menu.el
@@ -1,0 +1,145 @@
+;;; copilot-menu.el --- Transient menu for Copilot -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022-2026 copilot-emacs maintainers
+
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+;; URL: https://github.com/copilot-emacs/copilot.el
+;; Keywords: convenience copilot
+
+;; The MIT License (MIT)
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; A transient (magit-style) menu that collects the most common Copilot
+;; commands in one place: completions, chat, agent mode, account and
+;; usage information, and server management.  Invoke it with
+;; `M-x copilot-menu'.
+;;
+;; The menu needs the `transient' package, which is bundled with
+;; Emacs 28.1 and newer.  To keep copilot.el installable on Emacs 27.2
+;; (where current transient releases no longer work), transient is not a
+;; hard dependency: without it, `copilot-menu' signals a `user-error'
+;; explaining what to install, and everything else in copilot.el works
+;; as usual.
+
+;;; Code:
+
+(require 'copilot)
+
+;; The chat commands live in copilot-chat.el, which is part of this
+;; package but only loaded once the menu is opened (see `copilot-menu').
+(defvar copilot-chat-model)
+(defvar copilot-chat-use-agent-mode)
+
+;;
+;; Dynamic descriptions
+;;
+
+(defun copilot-menu--copilot-mode-description ()
+  "Describe `copilot-mode' with its state in the current buffer."
+  (format "Automatic completions [%s]" (if copilot-mode "on" "off")))
+
+(defun copilot-menu--agent-mode-description ()
+  "Describe the agent mode toggle with its current state."
+  (format "Agent mode [%s]" (if copilot-chat-use-agent-mode "on" "off")))
+
+(defun copilot-menu--chat-model-description ()
+  "Describe the chat model selection with the current model."
+  (format "Select chat model (%s)" (or copilot-chat-model "default")))
+
+;;
+;; Extra suffix commands
+;;
+
+(defun copilot-menu-toggle-agent-mode ()
+  "Toggle `copilot-chat-use-agent-mode' and report the new state."
+  (interactive)
+  (require 'copilot-chat)
+  (setq copilot-chat-use-agent-mode (not copilot-chat-use-agent-mode))
+  (message "Copilot Chat: agent mode %s"
+           (if copilot-chat-use-agent-mode "enabled" "disabled")))
+
+(defun copilot-menu-open-log ()
+  "Open the Copilot language server log buffer."
+  (interactive)
+  (let ((buffer (get-buffer "*copilot-language-server-log*")))
+    (if buffer
+        (pop-to-buffer buffer)
+      (user-error "Copilot: No server log buffer yet"))))
+
+;;
+;; The menu itself
+;;
+
+(defconst copilot-menu--definition
+  '(transient-define-prefix copilot-menu ()
+     "Transient menu for the most common Copilot commands."
+     [["Completions"
+       ("t" copilot-mode
+        :description (lambda () (copilot-menu--copilot-mode-description))
+        :transient t)
+       ("c" "Complete at point" copilot-complete)
+       ("p" "Panel completions" copilot-panel-complete)]
+      ["Chat"
+       ("h" "Open chat" copilot-chat)
+       ("r" "Send region" copilot-chat-send-region)
+       ("/" "Slash command" copilot-chat-slash-command)
+       ("f" "Attach file as context" copilot-chat-add-file-reference)
+       ("k" "Clear pending context" copilot-chat-clear-references)
+       ("m" copilot-chat-select-model
+        :description (lambda () (copilot-menu--chat-model-description)))]
+      ["Agent"
+       ("a" copilot-menu-toggle-agent-mode
+        :description (lambda () (copilot-menu--agent-mode-description))
+        :transient t)
+       ("T" "List MCP tools" copilot-chat-list-mcp-tools)]]
+     [["Account"
+       ("i" "Login" copilot-login)
+       ("o" "Logout" copilot-logout)
+       ("u" "Usage quota" copilot-quota)
+       ("R" "Code references" copilot-list-code-references)]
+      ["Server"
+       ("s" "Install server" copilot-install-server)
+       ("S" "Reinstall server" copilot-reinstall-server)
+       ("U" "Uninstall server" copilot-uninstall-server)
+       ("d" "Restart & diagnose" copilot-diagnose)
+       ("l" "Open server log" copilot-menu-open-log)]]
+     (interactive)
+     (require 'copilot-chat)
+     (transient-setup 'copilot-menu))
+  "The `copilot-menu' transient definition, kept as data.
+`transient-define-prefix' is a macro, so a file using it directly cannot
+even be byte-compiled on an Emacs without the `transient' package.
+Storing the definition as data and evaluating it at load time (see
+below) keeps copilot.el compatible with Emacs 27.2, where current
+transient releases are not installable.")
+
+;;;###autoload (autoload 'copilot-menu "copilot-menu" nil t)
+(if (require 'transient nil t)
+    (eval copilot-menu--definition t)
+  (defun copilot-menu ()
+    "Placeholder for the Copilot menu when `transient' is missing."
+    (interactive)
+    (user-error
+     "Copilot: `copilot-menu' requires the `transient' package (bundled with Emacs 28.1 and newer)")))
+
+(provide 'copilot-menu)
+;;; copilot-menu.el ends here

--- a/doc/design.md
+++ b/doc/design.md
@@ -12,7 +12,7 @@ interactive commands.
 
 ## Architecture
 
-The package is split into four files, each with a clear responsibility:
+The package is split into five files, each with a clear responsibility:
 
 | File | Role |
 |---|---|
@@ -20,6 +20,7 @@ The package is split into four files, each with a clear responsibility:
 | `copilot-chat.el` | Chat UI via `conversation/*` JSON-RPC methods |
 | `copilot-nes.el` | Next Edit Suggestions via `textDocument/copilotInlineEdit` |
 | `copilot-balancer.el` | Lisp parentheses post-processor for completions |
+| `copilot-menu.el` | Transient menu (`copilot-menu`) tying the interactive commands together |
 
 `copilot-chat.el` and `copilot-nes.el` depend on the core for the server
 connection and the handler registries, but they are otherwise self-contained

--- a/test/copilot-menu-test.el
+++ b/test/copilot-menu-test.el
@@ -67,7 +67,10 @@ optional description string)."
                          copilot-uninstall-server
                          copilot-diagnose
                          copilot-menu-open-log))
-        (expect commands :to-contain command))))
+        (expect commands :to-contain command))
+      ;; Exactly these, so a future suffix shape the walker doesn't
+      ;; understand cannot silently drop commands from the check.
+      (expect (length commands) :to-equal 20)))
 
   (describe "copilot-menu-toggle-agent-mode"
     (it "flips copilot-chat-use-agent-mode"

--- a/test/copilot-menu-test.el
+++ b/test/copilot-menu-test.el
@@ -1,0 +1,94 @@
+;;; copilot-menu-test.el --- Tests for copilot-menu.el -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Buttercup tests for copilot-menu.el.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'copilot-menu)
+(require 'copilot)
+(require 'copilot-chat)
+
+(defun copilot-menu-test--layout-commands ()
+  "Collect every suffix command from `copilot-menu--definition'.
+Walk the quoted definition rather than transient's internal layout
+representation, which differs across the transient versions bundled
+with the supported Emacsen.  A suffix is a list starting with a key
+string, whose command is the first symbol after the key (skipping an
+optional description string)."
+  (let (commands)
+    (letrec ((walk
+              (lambda (x)
+                (cond
+                 ((vectorp x) (mapc walk x))
+                 ((and (consp x) (stringp (car x)))
+                  (let ((cand (if (stringp (nth 1 x)) (nth 2 x) (nth 1 x))))
+                    (when (and cand (symbolp cand))
+                      (push cand commands))))
+                 ((proper-list-p x) (mapc walk x))))))
+      (funcall walk copilot-menu--definition))
+    (nreverse commands)))
+
+(describe "copilot-menu"
+  (it "is defined as a transient prefix when transient is available"
+    (assume (featurep 'transient) "transient is not available")
+    (expect (fboundp 'copilot-menu) :to-be-truthy)
+    (expect (get 'copilot-menu 'transient--prefix) :to-be-truthy)
+    (expect (get 'copilot-menu 'transient--layout) :to-be-truthy))
+
+  (it "references only commands that exist"
+    (let ((commands (copilot-menu-test--layout-commands)))
+      (expect commands :not :to-be nil)
+      (dolist (command commands)
+        (expect (fboundp command) :to-be-truthy)
+        (expect (commandp command) :to-be-truthy))))
+
+  (it "includes the expected suffix commands"
+    (let ((commands (copilot-menu-test--layout-commands)))
+      (dolist (command '(copilot-mode
+                         copilot-complete
+                         copilot-panel-complete
+                         copilot-chat
+                         copilot-chat-send-region
+                         copilot-chat-slash-command
+                         copilot-chat-add-file-reference
+                         copilot-chat-clear-references
+                         copilot-chat-select-model
+                         copilot-menu-toggle-agent-mode
+                         copilot-chat-list-mcp-tools
+                         copilot-login
+                         copilot-logout
+                         copilot-quota
+                         copilot-list-code-references
+                         copilot-install-server
+                         copilot-reinstall-server
+                         copilot-uninstall-server
+                         copilot-diagnose
+                         copilot-menu-open-log))
+        (expect commands :to-contain command))))
+
+  (describe "copilot-menu-toggle-agent-mode"
+    (it "flips copilot-chat-use-agent-mode"
+      (let ((copilot-chat-use-agent-mode nil))
+        (copilot-menu-toggle-agent-mode)
+        (expect copilot-chat-use-agent-mode :to-be-truthy)
+        (copilot-menu-toggle-agent-mode)
+        (expect copilot-chat-use-agent-mode :to-be nil))))
+
+  (describe "copilot-menu-open-log"
+    (it "signals a user error when there is no log buffer"
+      (when (get-buffer "*copilot-language-server-log*")
+        (kill-buffer "*copilot-language-server-log*"))
+      (expect (copilot-menu-open-log) :to-throw 'user-error))
+
+    (it "pops to the log buffer when it exists"
+      (let ((buffer (get-buffer-create "*copilot-language-server-log*")))
+        (unwind-protect
+            (progn
+              (copilot-menu-open-log)
+              (expect (window-buffer) :to-be buffer))
+          (kill-buffer buffer))))))
+
+;;; copilot-menu-test.el ends here


### PR DESCRIPTION
Adds `M-x copilot-menu`, a magit-style transient collecting the package's most common commands in one discoverable place: completions (toggle/complete/panel), chat (open, send region, slash commands, context, model selection), agent mode (toggle plus MCP tool listing), account/usage (login, logout, quota, code references), and server management (install, reinstall, uninstall, diagnose, log).

The toggles show live state inline (`Automatic completions [on]`, `Agent mode [off]`, `Select chat model (gpt-5)`), reading only variables already in memory, so opening the menu never triggers server requests.

`transient` is a soft dependency: current releases require Emacs 28.1 (where it's bundled anyway), so a hard dependency would break the package's 27.2 floor. The menu definition is stored as data and evaluated only when transient loads; the file byte-compiles fine without it and `copilot-menu` explains what's missing if invoked on such a setup.

New file `copilot-menu.el` with its own test file; 415 specs pass, checkdoc clean, compiles without warnings.