### PR TITLE
Add opt-in chat session persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `copilot-chat-optimize`
   - `copilot-chat-write-tests`
 - Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt` and a pending generation cancellable with `copilot-chat-stop`.
+- Optionally persist chat sessions across Emacs restarts: with `copilot-chat-save-history` enabled (off by default) the transcript is saved after each turn to a per-workspace file under `copilot-chat-history-directory`, `copilot-chat-restore` brings the saved conversation back with its full context, and `copilot-chat-clear-history` deletes the saved file.
 - Add `copilot-menu`, a transient (magit-style) menu that gathers the most common Copilot commands (completions, chat, agent mode, account and usage info, and server management) and shows the current state of `copilot-mode`, agent mode, and the selected chat model. Requires the `transient` package (bundled with Emacs 28.1 and newer) but only when the menu itself is used.
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Attach extra context for the next message with `copilot-chat-add-file-reference`
 
 The chat buffer's header line shows at a glance whether Agent or Ask mode is active, which model answers, and in agent mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
 
+Chat sessions can be persisted across Emacs restarts. Set `copilot-chat-save-history` to `t` (it is off by default, since transcripts land on disk in plain text) and the whole session is saved after each completed turn, one file per workspace under `copilot-chat-history-directory` (`~/.emacs.d/copilot-chat-history/` by default). `M-x copilot-chat-restore` brings the saved conversation back: the transcript reappears in the chat buffer, and the next message continues it with the full context (the saved turns are replayed to the server when the new conversation starts). `copilot-chat-clear-history` deletes the current workspace's saved history; `copilot-chat-reset` clears only the live session and leaves the file alone.
+
 `copilot-chat-insert-commit-message` generates a commit message from the staged changes and inserts it at point. It is meant to be called from a commit message buffer (e.g. Magit's `COMMIT_EDITMSG` or any `git-commit` buffer), but works from any buffer inside a git repository. It runs outside the chat panel, so it never disturbs an ongoing conversation; the instruction sent along with the diff can be customized via `copilot-chat-commit-message-prompt`.
 
 Customization:
@@ -259,6 +261,8 @@ Customization:
 - **`copilot-chat-terminal-timeout`** — seconds before an agent-mode `run_in_terminal` command is killed (default `30`, `nil` to disable)
 - **`copilot-chat-ripgrep-program`** — ripgrep executable used for agent-mode workspace search (default `"rg"`)
 - **`copilot-chat-auto-approve-tools`** — tool names that skip the confirmation prompt (default `'("get_errors")`)
+- **`copilot-chat-save-history`** — save the chat transcript to disk after each turn, for `copilot-chat-restore` (default `nil`)
+- **`copilot-chat-history-directory`** — where saved transcripts live, one file per workspace (default `~/.emacs.d/copilot-chat-history/`)
 
 At each tool confirmation prompt you can answer `yes`, `no`, or `always`; `always` approves that tool for the rest of the conversation so it stops asking.
 
@@ -479,6 +483,8 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-chat-write-tests` | Write tests for the region or defun at point |
 | `copilot-chat-stop` | Cancel streaming, or reset the conversation if idle |
 | `copilot-chat-reset` | Destroy the current conversation and clear the chat buffer |
+| `copilot-chat-restore` | Restore the saved chat for the current workspace |
+| `copilot-chat-clear-history` | Delete the saved chat history for the current workspace |
 | `copilot-chat-insert-commit-message` | Generate a commit message for the staged changes and insert it at point |
 | **Next Edit Suggestions** | |
 | `copilot-nes-mode` | Toggle NES in the current buffer |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -164,6 +164,28 @@ Used by `copilot-chat-insert-commit-message'."
   :group 'copilot-chat
   :package-version '(copilot . "0.8"))
 
+(defcustom copilot-chat-save-history nil
+  "When non-nil, save the chat transcript to disk after each turn.
+The whole session is written to a per-workspace file under
+`copilot-chat-history-directory' every time a turn completes, and
+`copilot-chat-restore' brings a saved conversation back, context
+included.  Transcripts land on disk in plain text, so this is off
+by default."
+  :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
+(defcustom copilot-chat-history-directory
+  (locate-user-emacs-file "copilot-chat-history")
+  "Directory where saved chat transcripts are stored.
+Each workspace gets one file, named after the SHA-1 of its root
+directory (or \"global\" outside any workspace), with the `.eld'
+extension.  The directory is created on demand when the first
+transcript is saved."
+  :type 'directory
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
 (defface copilot-chat-error-face
   '((t :inherit error))
   "Face for error messages in the chat buffer."
@@ -228,6 +250,26 @@ A list of plists like (:type \"file\" :uri URI), sent as the turn's
 
 (defvar-local copilot-chat--request-id nil
   "ID of the in-flight async request, used for cancellation.")
+
+(defvar-local copilot-chat--turns nil
+  "Completed turns of this chat session, oldest first.
+A list of (REQUEST . RESPONSE) string pairs, extended when a turn's
+final progress notification arrives.  Used for saving the session to
+disk and for seeding a restored conversation.")
+
+(defvar-local copilot-chat--current-request nil
+  "Request text of the turn currently being answered, or nil.
+Paired with the accumulated reply and appended to
+`copilot-chat--turns' when the turn ends.")
+
+(defvar-local copilot-chat--reply-chunks nil
+  "Reply chunks streamed for the current turn, most recent first.")
+
+(defvar-local copilot-chat--restored-turns nil
+  "Turns restored by `copilot-chat-restore', pending replay.
+When non-nil, the next `conversation/create' replays them (requests
+and responses) ahead of the new message so the server reconstructs the
+saved context.  Cleared once a conversation is created from them.")
 
 ;;
 ;; Global state
@@ -460,6 +502,8 @@ buffer."
           (force-mode-line-update))
          ((equal kind "report")
           (when-let* ((reply (copilot-chat--extract-reply value)))
+            (when copilot-chat--current-request
+              (push reply copilot-chat--reply-chunks))
             (let ((inhibit-read-only t))
               (goto-char (point-max))
               (insert reply))
@@ -487,6 +531,19 @@ buffer."
                 (insert (propertize
                          (format "Follow-up: %s\n\n" copilot-chat--follow-up)
                          'face 'copilot-chat-follow-up-face)))))
+          ;; Record the completed turn in the session log; one-shot
+          ;; (function-sink) requests never set a current request, so
+          ;; they are never captured here.
+          (when copilot-chat--current-request
+            (setq copilot-chat--turns
+                  (append copilot-chat--turns
+                          (list (cons copilot-chat--current-request
+                                      (apply #'concat
+                                             (nreverse
+                                              copilot-chat--reply-chunks))))))
+            (setq copilot-chat--current-request nil
+                  copilot-chat--reply-chunks nil)
+            (copilot-chat--save-history))
           (copilot-chat--scroll-to-bottom)
           (setq copilot-chat--active-buffers
                 (assoc-delete-all token copilot-chat--active-buffers))))))))
@@ -1339,23 +1396,26 @@ Servers are configured via `copilot-mcp-servers'."
 
 (defun copilot-chat--create (message callback)
   "Create a new conversation with MESSAGE.
-CALLBACK is called with the response containing conversationId and turnId."
-  (let ((token (format "copilot-chat-%s" (float-time))))
+CALLBACK is called with the response containing conversationId and
+turnId.  Turns restored by `copilot-chat-restore' are replayed ahead
+of MESSAGE, so the new conversation picks up the saved context."
+  (let ((token (format "copilot-chat-%s" (float-time)))
+        (restored nil))
     ;; A fresh conversation starts with a clean slate of session approvals.
     (setq copilot-chat--session-approved-tools nil)
     (copilot-chat--maybe-warn-model-lacks-tools)
     (with-current-buffer (get-buffer copilot-chat--buffer-name)
       (setq copilot-chat--work-done-token token)
+      (setq copilot-chat--current-request message
+            copilot-chat--reply-chunks nil)
+      (setq restored copilot-chat--restored-turns)
       (push (cons token (current-buffer)) copilot-chat--active-buffers))
     (let ((req-id
            (copilot--async-request
             'conversation/create
             (append
              (list :workDoneToken token
-                   :turns (vector
-                           (list :request message
-                                 :response ""
-                                 :turnId ""))
+                   :turns (copilot-chat--turns-param restored message)
                    :capabilities (list :skills (vector "current-editor")
                                        :allSkills t)
                    :source "panel")
@@ -1374,7 +1434,11 @@ CALLBACK is called with the response containing conversationId and turnId."
                           (when-let* ((buf (get-buffer
                                             copilot-chat--buffer-name)))
                             (with-current-buffer buf
-                              (copilot-chat--consume-references)))
+                              (copilot-chat--consume-references)
+                              ;; The restored turns are now part of the
+                              ;; server-side conversation; replaying them
+                              ;; again would duplicate the context.
+                              (setq copilot-chat--restored-turns nil)))
                           (when copilot-chat-use-agent-mode
                             (copilot-chat--register-tools))
                           (funcall callback result))
@@ -1389,6 +1453,8 @@ CALLBACK is called with the response containing conversationId and turnId."
         (chat-buf (get-buffer copilot-chat--buffer-name)))
     (with-current-buffer chat-buf
       (setq copilot-chat--work-done-token token)
+      (setq copilot-chat--current-request message
+            copilot-chat--reply-chunks nil)
       (push (cons token chat-buf) copilot-chat--active-buffers)
       (let ((conv-id copilot-chat--conversation-id)
             (doc (copilot-chat--generate-context-doc)))
@@ -1724,6 +1790,137 @@ The context points at the current file with the region's range."
     (with-current-buffer buf
       (copilot-chat--consume-references)))
   (message "Copilot Chat: Cleared pending context"))
+
+;;
+;; Session persistence
+;;
+
+(defun copilot-chat--history-root ()
+  "Return the workspace root the chat session belongs to, or nil.
+The chat buffer visits no file, so `copilot--workspace-root' returns
+nil there; fall back to the root of the live source buffer in that
+case."
+  (or (copilot--workspace-root)
+      (when (buffer-live-p copilot-chat--source-buffer)
+        (with-current-buffer copilot-chat--source-buffer
+          (copilot--workspace-root)))))
+
+(defun copilot-chat--history-file ()
+  "Return the chat history file for the current workspace.
+One file per workspace root, named after the root's SHA-1 (or
+\"global\" outside any workspace), under
+`copilot-chat-history-directory'."
+  (let ((root (copilot-chat--history-root)))
+    (expand-file-name (concat (if root (sha1 root) "global") ".eld")
+                      copilot-chat-history-directory)))
+
+(defun copilot-chat--save-history ()
+  "Save this session's turn log to the workspace history file.
+A no-op unless `copilot-chat-save-history' is enabled and there is
+something to save.  Never signals: chat must keep flowing even when
+the transcript cannot be written, so any error is only logged."
+  (when (and copilot-chat-save-history copilot-chat--turns)
+    (condition-case err
+        (let ((print-length nil)
+              (print-level nil))
+          (make-directory copilot-chat-history-directory t)
+          (write-region
+           (prin1-to-string
+            (list :version 1
+                  :timestamp (format-time-string "%FT%T%z")
+                  :workspace (copilot-chat--history-root)
+                  :turns copilot-chat--turns))
+           nil (copilot-chat--history-file) nil 'silent))
+      (error
+       (copilot--log 'error "Could not save chat history: %S" err)))))
+
+(defun copilot-chat--valid-history-p (data)
+  "Return non-nil when DATA is a well-formed saved chat history."
+  (and (proper-list-p data)
+       (eql (plist-get data :version) 1)
+       (let ((turns (plist-get data :turns)))
+         (and (proper-list-p turns)
+              turns
+              (seq-every-p (lambda (turn)
+                             (and (consp turn)
+                                  (stringp (car turn))
+                                  (stringp (cdr turn))))
+                           turns)))))
+
+(defun copilot-chat--read-history ()
+  "Read the saved chat history for the current workspace.
+Return its plist.  Signal a `user-error' when there is no history
+file, or when the file does not contain a well-formed history."
+  (let ((file (copilot-chat--history-file)))
+    (unless (file-exists-p file)
+      (user-error "Copilot Chat: No saved chat history for this workspace"))
+    (let ((data (condition-case nil
+                    (with-temp-buffer
+                      (insert-file-contents file)
+                      (read (current-buffer)))
+                  (error nil))))
+      (unless (copilot-chat--valid-history-p data)
+        (user-error "Copilot Chat: History file %s is corrupt" file))
+      data)))
+
+(defun copilot-chat--turns-param (restored message)
+  "Return the turn vector for a new conversation asking MESSAGE.
+RESTORED is a list of saved (REQUEST . RESPONSE) pairs replayed, with
+their responses, ahead of MESSAGE so the server reconstructs their
+context; the final turn is the one it answers."
+  (vconcat
+   (mapcar (lambda (turn)
+             (list :request (car turn) :response (cdr turn)))
+           restored)
+   (vector (list :request message :response "" :turnId ""))))
+
+;;;###autoload
+(defun copilot-chat-restore ()
+  "Restore the saved chat transcript for the current workspace.
+Render the saved conversation in the chat buffer without contacting
+the server; the next message starts a new conversation that replays
+the saved turns first, so Copilot answers with the full context.
+Signal a `user-error' when there is no saved history."
+  (interactive)
+  (let* ((data (copilot-chat--read-history))
+         (turns (plist-get data :turns))
+         (chat-buf (get-buffer-create copilot-chat--buffer-name)))
+    (with-current-buffer chat-buf
+      (unless (derived-mode-p 'copilot-chat-mode)
+        (copilot-chat-mode))
+      (when copilot-chat--streaming-p
+        (user-error "Copilot Chat: A response is currently being streamed"))
+      ;; Drop any live conversation: the next message must start a new
+      ;; one seeded with the restored turns.
+      (copilot-chat--destroy)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (dolist (turn turns)
+          (copilot-chat--insert-prompt (car turn))
+          (goto-char (point-max))
+          (insert (cdr turn) "\n\n")))
+      (setq copilot-chat--turns turns)
+      (setq copilot-chat--restored-turns turns)
+      (setq copilot-chat--current-request nil
+            copilot-chat--reply-chunks nil))
+    (display-buffer chat-buf)
+    (message
+     "Copilot Chat: Restored %d turn%s; the next message continues the conversation"
+     (length turns) (if (= (length turns) 1) "" "s"))))
+
+;;;###autoload
+(defun copilot-chat-clear-history ()
+  "Delete the saved chat history file for the current workspace.
+The conversation in the chat buffer is left alone; this only removes
+the file `copilot-chat-restore' would read."
+  (interactive)
+  (let ((file (copilot-chat--history-file)))
+    (unless (file-exists-p file)
+      (user-error "Copilot Chat: No saved chat history for this workspace"))
+    (when (yes-or-no-p
+           "Delete the saved Copilot Chat history for this workspace? ")
+      (delete-file file)
+      (message "Copilot Chat: Saved chat history deleted"))))
 
 ;;
 ;; Commit message generation
@@ -2136,11 +2333,18 @@ only when there is nothing to cancel at all, reset the conversation."
 
 ;;;###autoload
 (defun copilot-chat-reset ()
-  "Destroy the current conversation and clear the chat buffer."
+  "Destroy the current conversation and clear the chat buffer.
+The session's turn log and any pending restored turns are cleared as
+well; the saved history file on disk, if any, is left untouched (see
+`copilot-chat-clear-history')."
   (interactive)
   (copilot-chat--destroy)
   (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
     (with-current-buffer buf
+      (setq copilot-chat--turns nil
+            copilot-chat--restored-turns nil
+            copilot-chat--current-request nil
+            copilot-chat--reply-chunks nil)
       (let ((inhibit-read-only t))
         (erase-buffer)))))
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -271,6 +271,15 @@ When non-nil, the next `conversation/create' replays them (requests
 and responses) ahead of the new message so the server reconstructs the
 saved context.  Cleared once a conversation is created from them.")
 
+(defvar-local copilot-chat--session-root nil
+  "History root this chat session is pinned to, once resolved.
+Either a workspace root string or the symbol `global'.  Resolved at
+most once per session (at restore time or on the first save) and
+reused for every later save, so that saving and restoring can never
+silently target two different history files: the save runs in the chat
+buffer while a restore may be invoked from a project buffer, and the
+two would otherwise each resolve their own root.")
+
 ;;
 ;; Global state
 ;;
@@ -415,7 +424,12 @@ and cleans up active tokens."
     (when (buffer-live-p buf)
       (with-current-buffer buf
         (copilot-chat--end-streaming)
-        (copilot-chat--remove-active-tokens buf))))
+        (copilot-chat--remove-active-tokens buf)
+        ;; A failed turn never reaches the end-progress that would
+        ;; clear the capture state; without this the busy guards would
+        ;; wedge the chat closed for good.
+        (setq copilot-chat--current-request nil
+              copilot-chat--reply-chunks nil))))
   (copilot-chat--insert-error (format "%s" err)))
 
 ;;
@@ -530,20 +544,24 @@ buffer."
                          (not (string-empty-p copilot-chat--follow-up)))
                 (insert (propertize
                          (format "Follow-up: %s\n\n" copilot-chat--follow-up)
-                         'face 'copilot-chat-follow-up-face)))))
-          ;; Record the completed turn in the session log; one-shot
-          ;; (function-sink) requests never set a current request, so
-          ;; they are never captured here.
-          (when copilot-chat--current-request
-            (setq copilot-chat--turns
-                  (append copilot-chat--turns
-                          (list (cons copilot-chat--current-request
-                                      (apply #'concat
-                                             (nreverse
-                                              copilot-chat--reply-chunks))))))
-            (setq copilot-chat--current-request nil
-                  copilot-chat--reply-chunks nil)
-            (copilot-chat--save-history))
+                         'face 'copilot-chat-follow-up-face))))
+            ;; Record the completed turn in the session log; one-shot
+            ;; (function-sink) requests never set a current request, so
+            ;; they are never captured here.  An errored or empty turn
+            ;; is dropped rather than recorded: replaying a question
+            ;; with a blank answer to the server (and re-rendering it on
+            ;; restore) helps nobody.
+            (when copilot-chat--current-request
+              (let ((reply (apply #'concat
+                                  (nreverse copilot-chat--reply-chunks))))
+                (unless (or error-msg (string-empty-p reply))
+                  (setq copilot-chat--turns
+                        (append copilot-chat--turns
+                                (list (cons copilot-chat--current-request
+                                            reply))))
+                  (copilot-chat--save-history)))
+              (setq copilot-chat--current-request nil
+                    copilot-chat--reply-chunks nil)))
           (copilot-chat--scroll-to-bottom)
           (setq copilot-chat--active-buffers
                 (assoc-delete-all token copilot-chat--active-buffers))))))))
@@ -1437,8 +1455,14 @@ of MESSAGE, so the new conversation picks up the saved context."
                               (copilot-chat--consume-references)
                               ;; The restored turns are now part of the
                               ;; server-side conversation; replaying them
-                              ;; again would duplicate the context.
-                              (setq copilot-chat--restored-turns nil)))
+                              ;; again would duplicate the context.  Only
+                              ;; clear the exact set this create sent: a
+                              ;; restore run in the meantime must not
+                              ;; have its freshly stashed turns dropped
+                              ;; by a stale response.
+                              (when (eq copilot-chat--restored-turns
+                                        restored)
+                                (setq copilot-chat--restored-turns nil))))
                           (when copilot-chat-use-agent-mode
                             (copilot-chat--register-tools))
                           (funcall callback result))
@@ -1805,32 +1829,47 @@ case."
         (with-current-buffer copilot-chat--source-buffer
           (copilot--workspace-root)))))
 
-(defun copilot-chat--history-file ()
-  "Return the chat history file for the current workspace.
+(defun copilot-chat--ensure-session-root ()
+  "Return the history root this session is pinned to, resolving once.
+Return a workspace root string, or nil for the global history.  The
+first call resolves via `copilot-chat--history-root' and pins the
+result in `copilot-chat--session-root'; later calls (and saves after a
+restore, which pins the root itself) reuse it."
+  (unless copilot-chat--session-root
+    (setq copilot-chat--session-root
+          (or (copilot-chat--history-root) 'global)))
+  (unless (eq copilot-chat--session-root 'global)
+    copilot-chat--session-root))
+
+(defun copilot-chat--history-file (root)
+  "Return the chat history file for the workspace ROOT.
 One file per workspace root, named after the root's SHA-1 (or
-\"global\" outside any workspace), under
-`copilot-chat-history-directory'."
-  (let ((root (copilot-chat--history-root)))
-    (expand-file-name (concat (if root (sha1 root) "global") ".eld")
-                      copilot-chat-history-directory)))
+\"global\" when ROOT is nil), under `copilot-chat-history-directory'."
+  (expand-file-name (concat (if root (sha1 root) "global") ".eld")
+                    copilot-chat-history-directory))
 
 (defun copilot-chat--save-history ()
   "Save this session's turn log to the workspace history file.
 A no-op unless `copilot-chat-save-history' is enabled and there is
-something to save.  Never signals: chat must keep flowing even when
-the transcript cannot be written, so any error is only logged."
+something to save.  The transcript is private data, so the directory
+and file are created unreadable to other users.  Never signals: chat
+must keep flowing even when the transcript cannot be written, so any
+error is only logged."
   (when (and copilot-chat-save-history copilot-chat--turns)
     (condition-case err
         (let ((print-length nil)
-              (print-level nil))
-          (make-directory copilot-chat-history-directory t)
-          (write-region
-           (prin1-to-string
-            (list :version 1
-                  :timestamp (format-time-string "%FT%T%z")
-                  :workspace (copilot-chat--history-root)
-                  :turns copilot-chat--turns))
-           nil (copilot-chat--history-file) nil 'silent))
+              (print-level nil)
+              (root (copilot-chat--ensure-session-root)))
+          (with-file-modes #o700
+            (make-directory copilot-chat-history-directory t))
+          (with-file-modes #o600
+            (write-region
+             (prin1-to-string
+              (list :version 1
+                    :timestamp (format-time-string "%FT%T%z")
+                    :workspace root
+                    :turns copilot-chat--turns))
+             nil (copilot-chat--history-file root) nil 'silent)))
       (error
        (copilot--log 'error "Could not save chat history: %S" err)))))
 
@@ -1847,11 +1886,15 @@ the transcript cannot be written, so any error is only logged."
                                   (stringp (cdr turn))))
                            turns)))))
 
-(defun copilot-chat--read-history ()
-  "Read the saved chat history for the current workspace.
-Return its plist.  Signal a `user-error' when there is no history
-file, or when the file does not contain a well-formed history."
-  (let ((file (copilot-chat--history-file)))
+(defun copilot-chat--read-history (root)
+  "Read the saved chat history for the workspace ROOT.
+Return its plist, with every turn's text stripped of text properties:
+`read' happily reconstructs propertized strings, and a tampered (or
+merely synced) history file must not be able to inject `keymap',
+`display', or `read-only' properties into the chat buffer.  Signal a
+`user-error' when there is no history file, or when the file does not
+contain a well-formed history."
+  (let ((file (copilot-chat--history-file root)))
     (unless (file-exists-p file)
       (user-error "Copilot Chat: No saved chat history for this workspace"))
     (let ((data (condition-case nil
@@ -1861,7 +1904,11 @@ file, or when the file does not contain a well-formed history."
                   (error nil))))
       (unless (copilot-chat--valid-history-p data)
         (user-error "Copilot Chat: History file %s is corrupt" file))
-      data)))
+      (plist-put data :turns
+                 (mapcar (lambda (turn)
+                           (cons (substring-no-properties (car turn))
+                                 (substring-no-properties (cdr turn))))
+                         (plist-get data :turns))))))
 
 (defun copilot-chat--turns-param (restored message)
   "Return the turn vector for a new conversation asking MESSAGE.
@@ -1882,13 +1929,17 @@ the server; the next message starts a new conversation that replays
 the saved turns first, so Copilot answers with the full context.
 Signal a `user-error' when there is no saved history."
   (interactive)
-  (let* ((data (copilot-chat--read-history))
+  ;; Resolve the root in the invoking buffer, where the user's notion
+  ;; of "this workspace" lives, and pin it on the chat session below so
+  ;; later saves target the very same file.
+  (let* ((root (copilot-chat--history-root))
+         (data (copilot-chat--read-history root))
          (turns (plist-get data :turns))
          (chat-buf (get-buffer-create copilot-chat--buffer-name)))
     (with-current-buffer chat-buf
       (unless (derived-mode-p 'copilot-chat-mode)
         (copilot-chat-mode))
-      (when copilot-chat--streaming-p
+      (when (or copilot-chat--streaming-p copilot-chat--current-request)
         (user-error "Copilot Chat: A response is currently being streamed"))
       ;; Drop any live conversation: the next message must start a new
       ;; one seeded with the restored turns.
@@ -1901,6 +1952,7 @@ Signal a `user-error' when there is no saved history."
           (insert (cdr turn) "\n\n")))
       (setq copilot-chat--turns turns)
       (setq copilot-chat--restored-turns turns)
+      (setq copilot-chat--session-root (or root 'global))
       (setq copilot-chat--current-request nil
             copilot-chat--reply-chunks nil))
     (display-buffer chat-buf)
@@ -1914,7 +1966,7 @@ Signal a `user-error' when there is no saved history."
 The conversation in the chat buffer is left alone; this only removes
 the file `copilot-chat-restore' would read."
   (interactive)
-  (let ((file (copilot-chat--history-file)))
+  (let ((file (copilot-chat--history-file (copilot-chat--history-root))))
     (unless (file-exists-p file)
       (user-error "Copilot Chat: No saved chat history for this workspace"))
     (when (yes-or-no-p
@@ -2121,6 +2173,12 @@ Otherwise, create a new conversation."
     (with-current-buffer chat-buf
       (unless (derived-mode-p 'copilot-chat-mode)
         (copilot-chat-mode))
+      ;; Refuse to start a turn while one is in flight: with a single
+      ;; set of per-buffer capture slots, an interleaved turn would
+      ;; pair the previous request with the next response in the
+      ;; session log (and lose the new turn's answer entirely).
+      (when (or copilot-chat--streaming-p copilot-chat--current-request)
+        (user-error "Copilot Chat: A response is currently being streamed"))
       (setq copilot-chat--source-buffer source-buf))
     (display-buffer chat-buf)
     (with-current-buffer chat-buf
@@ -2327,7 +2385,11 @@ only when there is nothing to cancel at all, reset the conversation."
                           (list :id copilot-chat--request-id)))
         (copilot-chat--end-streaming)
         (copilot-chat--insert-error "Cancelled")
-        (copilot-chat--remove-active-tokens chat-buf)))
+        (copilot-chat--remove-active-tokens chat-buf)
+        ;; The cancelled turn's end will never arrive; drop its capture
+        ;; state so the busy guards don't wedge the chat closed.
+        (setq copilot-chat--current-request nil
+              copilot-chat--reply-chunks nil)))
      ((copilot-chat--cancel-one-shots))
      (t (copilot-chat-reset)))))
 
@@ -2344,7 +2406,8 @@ well; the saved history file on disk, if any, is left untouched (see
       (setq copilot-chat--turns nil
             copilot-chat--restored-turns nil
             copilot-chat--current-request nil
-            copilot-chat--reply-chunks nil)
+            copilot-chat--reply-chunks nil
+            copilot-chat--session-root nil)
       (let ((inhibit-read-only t))
         (erase-buffer)))))
 

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -874,6 +874,311 @@
           (kill-buffer buf)))))
 
   ;;
+  ;; Session persistence
+  ;;
+
+  (describe "chat session persistence"
+    :var (history-dir)
+    (before-each
+      (setq history-dir (make-temp-file "copilot-chat-history" t)))
+    (after-each
+      (delete-directory history-dir t))
+
+    (describe "turn capture"
+      (it "records a completed turn when the end notification arrives"
+        (let ((buf (get-buffer-create "*copilot-chat-test-capture*")))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "hi there"))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "report" :reply "Hello ")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "report" :reply "world")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "end"))))
+                (with-current-buffer buf
+                  (expect copilot-chat--turns
+                          :to-equal '(("hi there" . "Hello world")))
+                  (expect copilot-chat--current-request :to-be nil)
+                  (expect copilot-chat--reply-chunks :to-be nil)))
+            (kill-buffer buf))))
+
+      (it "appends turns in chronological order"
+        (let ((buf (get-buffer-create "*copilot-chat-test-capture-order*")))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--turns '(("first q" . "first a"))
+                        copilot-chat--current-request "second q"))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "report" :reply "second a")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "end"))))
+                (with-current-buffer buf
+                  (expect copilot-chat--turns
+                          :to-equal '(("first q" . "first a")
+                                      ("second q" . "second a")))))
+            (kill-buffer buf))))
+
+      (it "records nothing when no request is pending"
+        (let ((buf (get-buffer-create "*copilot-chat-test-no-capture*")))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "report" :reply "stray")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "end"))))
+                (with-current-buffer buf
+                  (expect copilot-chat--turns :to-be nil)))
+            (kill-buffer buf)))))
+
+    (describe "saving"
+      (it "is disabled by default and writes no file"
+        (expect (default-value 'copilot-chat-save-history) :to-be nil)
+        (let ((buf (get-buffer-create "*copilot-chat-test-no-save*")))
+          (unwind-protect
+              (let ((copilot-chat-history-directory history-dir))
+                (spy-on 'copilot--workspace-root
+                        :and-return-value "/tmp/project/")
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "q"))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "report" :reply "a")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "end"))))
+                (expect (directory-files history-dir nil "\\.eld\\'")
+                        :to-be nil))
+            (kill-buffer buf))))
+
+      (it "saves the session after a completed turn and round-trips"
+        (let ((buf (get-buffer-create "*copilot-chat-test-save*")))
+          (unwind-protect
+              (let ((copilot-chat-save-history t)
+                    (copilot-chat-history-directory history-dir))
+                (spy-on 'copilot--workspace-root
+                        :and-return-value "/tmp/project/")
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "what is Emacs?"))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "report" :reply "An editor.")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "end"))))
+                (let* ((file (expand-file-name
+                              (concat (sha1 "/tmp/project/") ".eld")
+                              history-dir))
+                       (data (with-temp-buffer
+                               (insert-file-contents file)
+                               (read (current-buffer)))))
+                  (expect (plist-get data :version) :to-equal 1)
+                  (expect (plist-get data :workspace)
+                          :to-equal "/tmp/project/")
+                  (expect (plist-get data :turns)
+                          :to-equal '(("what is Emacs?" . "An editor.")))))
+            (kill-buffer buf))))
+
+      (it "names the file \"global\" outside any workspace"
+        (spy-on 'copilot--workspace-root :and-return-value nil)
+        (let ((copilot-chat-history-directory history-dir))
+          (with-temp-buffer
+            (expect (file-name-nondirectory (copilot-chat--history-file))
+                    :to-equal "global.eld"))))
+
+      (it "logs a save failure instead of signalling"
+        (spy-on 'copilot--workspace-root :and-return-value "/tmp/project/")
+        (spy-on 'write-region :and-throw-error 'error)
+        (spy-on 'copilot--log)
+        (let ((copilot-chat-save-history t)
+              (copilot-chat-history-directory history-dir))
+          (with-temp-buffer
+            (setq-local copilot-chat--turns '(("q" . "a")))
+            (copilot-chat--save-history)))
+        (expect 'copilot--log :to-have-been-called)))
+
+    (describe "copilot-chat-restore"
+      (before-each
+        (spy-on 'copilot--workspace-root :and-return-value "/tmp/project/")
+        (spy-on 'display-buffer)
+        (spy-on 'copilot--connection-alivep :and-return-value nil)
+        (spy-on 'jsonrpc--async-request-1)
+        (spy-on 'message)
+        (when (get-buffer copilot-chat--buffer-name)
+          (kill-buffer copilot-chat--buffer-name)))
+
+      (it "renders the transcript and stashes the turns without a server"
+        (let ((copilot-chat-history-directory history-dir))
+          (with-temp-file (expand-file-name
+                           (concat (sha1 "/tmp/project/") ".eld") history-dir)
+            (prin1 '(:version 1
+                     :timestamp "2026-07-04T00:00:00+0000"
+                     :workspace "/tmp/project/"
+                     :turns (("first q" . "first a")
+                             ("second q" . "second a")))
+                   (current-buffer)))
+          (copilot-chat-restore)
+          (unwind-protect
+              (with-current-buffer copilot-chat--buffer-name
+                (expect (buffer-string) :to-match "You:")
+                (expect (buffer-string) :to-match "first q")
+                (expect (buffer-string) :to-match "first a")
+                (expect (buffer-string) :to-match "Copilot:")
+                (expect (buffer-string) :to-match "second a")
+                (expect copilot-chat--turns
+                        :to-equal '(("first q" . "first a")
+                                    ("second q" . "second a")))
+                (expect copilot-chat--restored-turns
+                        :to-equal copilot-chat--turns)
+                (expect 'jsonrpc--async-request-1
+                        :not :to-have-been-called))
+            (kill-buffer copilot-chat--buffer-name))))
+
+      (it "errors when there is no saved history"
+        (let ((copilot-chat-history-directory history-dir))
+          (expect (copilot-chat-restore) :to-throw 'user-error)))
+
+      (it "rejects a garbage history file with a user-error"
+        (let ((copilot-chat-history-directory history-dir))
+          (with-temp-file (expand-file-name
+                           (concat (sha1 "/tmp/project/") ".eld") history-dir)
+            (insert "((((not even elisp"))
+          (expect (copilot-chat-restore) :to-throw 'user-error)))
+
+      (it "rejects a well-formed file with the wrong shape"
+        (let ((copilot-chat-history-directory history-dir))
+          (with-temp-file (expand-file-name
+                           (concat (sha1 "/tmp/project/") ".eld") history-dir)
+            (prin1 '(:version 99 :turns "nope") (current-buffer)))
+          (expect (copilot-chat-restore) :to-throw 'user-error))))
+
+    (describe "creating a conversation from restored turns"
+      (it "replays the restored turns ahead of the new message"
+        (let ((captured-params nil)
+              (captured-args nil)
+              (buf (get-buffer-create copilot-chat--buffer-name)))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--restored-turns
+                        '(("old q" . "old a") ("older q" . "older a"))))
+                (spy-on 'copilot--connection-alivep :and-return-value t)
+                (spy-on 'jsonrpc--async-request-1
+                        :and-call-fake
+                        (lambda (_conn _method params &rest args)
+                          (setq captured-params params
+                                captured-args args)
+                          (cons nil nil)))
+                (copilot-chat--create "new q" #'ignore)
+                (let ((turns (plist-get captured-params :turns)))
+                  (expect (length turns) :to-equal 3)
+                  (expect (aref turns 0)
+                          :to-equal '(:request "old q" :response "old a"))
+                  (expect (aref turns 1)
+                          :to-equal '(:request "older q" :response "older a"))
+                  (expect (aref turns 2)
+                          :to-equal '(:request "new q" :response "" :turnId "")))
+                ;; A successful create clears the pending restored turns.
+                (funcall (plist-get captured-args :success-fn)
+                         '(:conversationId "c1" :turnId "t1"))
+                (expect (buffer-local-value 'copilot-chat--restored-turns buf)
+                        :to-be nil))
+            (kill-buffer buf))))
+
+      (it "sends only the new turn when nothing was restored"
+        (let ((captured-params nil)
+              (buf (get-buffer-create copilot-chat--buffer-name)))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode))
+                (spy-on 'copilot--connection-alivep :and-return-value t)
+                (spy-on 'jsonrpc--async-request-1
+                        :and-call-fake
+                        (lambda (_conn _method params &rest _args)
+                          (setq captured-params params)
+                          (cons nil nil)))
+                (copilot-chat--create "hello" #'ignore)
+                (let ((turns (plist-get captured-params :turns)))
+                  (expect (length turns) :to-equal 1)
+                  (expect (aref turns 0)
+                          :to-equal '(:request "hello"
+                                      :response "" :turnId ""))))
+            (kill-buffer buf)))))
+
+    (describe "housekeeping"
+      (it "copilot-chat-reset clears the persistence state"
+        (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--turns '(("q" . "a"))
+                        copilot-chat--restored-turns '(("q" . "a"))
+                        copilot-chat--current-request "pending"
+                        copilot-chat--reply-chunks '("x")))
+                (spy-on 'copilot--connection-alivep :and-return-value nil)
+                (copilot-chat-reset)
+                (with-current-buffer buf
+                  (expect copilot-chat--turns :to-be nil)
+                  (expect copilot-chat--restored-turns :to-be nil)
+                  (expect copilot-chat--current-request :to-be nil)
+                  (expect copilot-chat--reply-chunks :to-be nil)))
+            (kill-buffer buf))))
+
+      (it "copilot-chat-reset does not delete the history file"
+        (spy-on 'copilot--connection-alivep :and-return-value nil)
+        (let* ((copilot-chat-history-directory history-dir)
+               (file (expand-file-name "global.eld" history-dir)))
+          (with-temp-file file
+            (prin1 '(:version 1 :turns (("q" . "a"))) (current-buffer)))
+          (copilot-chat-reset)
+          (expect (file-exists-p file) :to-be-truthy)))
+
+      (it "copilot-chat-clear-history deletes the file after confirmation"
+        (spy-on 'copilot--workspace-root :and-return-value "/tmp/project/")
+        (spy-on 'yes-or-no-p :and-return-value t)
+        (spy-on 'message)
+        (let* ((copilot-chat-history-directory history-dir)
+               (file (expand-file-name (concat (sha1 "/tmp/project/") ".eld")
+                                       history-dir)))
+          (with-temp-file file
+            (prin1 '(:version 1 :turns (("q" . "a"))) (current-buffer)))
+          (copilot-chat-clear-history)
+          (expect (file-exists-p file) :not :to-be-truthy)))
+
+      (it "copilot-chat-clear-history keeps the file when declined"
+        (spy-on 'copilot--workspace-root :and-return-value "/tmp/project/")
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (let* ((copilot-chat-history-directory history-dir)
+               (file (expand-file-name (concat (sha1 "/tmp/project/") ".eld")
+                                       history-dir)))
+          (with-temp-file file
+            (prin1 '(:version 1 :turns (("q" . "a"))) (current-buffer)))
+          (copilot-chat-clear-history)
+          (expect (file-exists-p file) :to-be-truthy)))
+
+      (it "copilot-chat-clear-history errors when there is no file"
+        (spy-on 'copilot--workspace-root :and-return-value "/tmp/project/")
+        (let ((copilot-chat-history-directory history-dir))
+          (expect (copilot-chat-clear-history) :to-throw 'user-error)))))
+
+  ;;
   ;; Default model resolution
   ;;
 

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -942,6 +942,140 @@
                    (list :token "tok" :value (list :kind "end"))))
                 (with-current-buffer buf
                   (expect copilot-chat--turns :to-be nil)))
+            (kill-buffer buf))))
+
+      (it "drops an errored turn instead of recording it"
+        (let ((buf (get-buffer-create "*copilot-chat-test-err-capture*")))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "bad q"))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "report" :reply "partial")))
+                  (copilot-chat--handle-progress
+                   (list :token "tok"
+                         :value (list :kind "end"
+                                      :result (list :error "boom")))))
+                (with-current-buffer buf
+                  (expect copilot-chat--turns :to-be nil)
+                  (expect copilot-chat--current-request :to-be nil)
+                  (expect copilot-chat--reply-chunks :to-be nil)))
+            (kill-buffer buf))))
+
+      (it "drops a turn whose reply is empty"
+        (let ((buf (get-buffer-create "*copilot-chat-test-empty-capture*")))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "silent q"))
+                (let ((copilot-chat--active-buffers (list (cons "tok" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "tok" :value (list :kind "end"))))
+                (with-current-buffer buf
+                  (expect copilot-chat--turns :to-be nil)))
+            (kill-buffer buf)))))
+
+    (describe "review hardening"
+      (it "refuses a new message while a turn is in flight"
+        (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+          (unwind-protect
+              (progn
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "pending"))
+                (expect (copilot-chat "hello") :to-throw 'user-error))
+            (kill-buffer buf))))
+
+      (it "refuses to restore while a turn is in flight"
+        (let ((copilot-chat-history-directory history-dir)
+              (buf (get-buffer-create copilot-chat--buffer-name)))
+          (unwind-protect
+              (progn
+                (with-file-modes #o600
+                  (write-region "(:version 1 :turns ((\"q\" . \"a\")))"
+                                nil (expand-file-name "global.eld" history-dir)
+                                nil 'silent))
+                (spy-on 'copilot--workspace-root :and-return-value nil)
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--current-request "pending"))
+                (expect (copilot-chat-restore) :to-throw 'user-error))
+            (kill-buffer buf))))
+
+      (it "strips text properties read from a history file"
+        (let ((copilot-chat-history-directory history-dir))
+          (write-region
+           "(:version 1 :turns ((\"q\" . #(\"pwned\" 0 5 (keymap t)))))"
+           nil (expand-file-name "global.eld" history-dir) nil 'silent)
+          (let* ((data (copilot-chat--read-history nil))
+                 (turn (car (plist-get data :turns))))
+            (expect (text-properties-at 0 (cdr turn)) :to-be nil))))
+
+      (it "pins the restored root so later saves target the same file"
+        (let ((copilot-chat-history-directory history-dir)
+              (copilot-chat-save-history t)
+              (project-file (expand-file-name (concat (sha1 "/proj/") ".eld")
+                                              history-dir)))
+          (unwind-protect
+              (progn
+                (write-region "(:version 1 :turns ((\"q\" . \"a\")))"
+                              nil project-file nil 'silent)
+                (spy-on 'copilot--workspace-root :and-return-value "/proj/")
+                (spy-on 'display-buffer)
+                (copilot-chat-restore)
+                ;; The workspace can no longer be resolved (e.g. saves
+                ;; run in the chat buffer after restart); the pinned
+                ;; root must still direct them to the same file.
+                (spy-on 'copilot--workspace-root :and-return-value nil)
+                (with-current-buffer copilot-chat--buffer-name
+                  (setq copilot-chat--turns '(("q2" . "a2")))
+                  (copilot-chat--save-history))
+                (expect (file-exists-p
+                         (expand-file-name "global.eld" history-dir))
+                        :to-be nil)
+                (with-temp-buffer
+                  (insert-file-contents project-file)
+                  (expect (buffer-string) :to-match "q2")))
+            (when (get-buffer copilot-chat--buffer-name)
+              (kill-buffer copilot-chat--buffer-name)))))
+
+      (it "saves the history file readable only by its owner"
+        (assume (not (eq system-type 'windows-nt)) "POSIX file modes only")
+        (let ((copilot-chat-history-directory
+               (expand-file-name "fresh" history-dir))
+              (copilot-chat-save-history t)
+              (buf (get-buffer-create "*copilot-chat-test-modes*")))
+          (unwind-protect
+              (progn
+                (spy-on 'copilot--workspace-root :and-return-value nil)
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--turns '(("q" . "a")))
+                  (copilot-chat--save-history))
+                (expect (file-modes
+                         (expand-file-name "global.eld"
+                                           copilot-chat-history-directory))
+                        :to-equal #o600))
+            (kill-buffer buf))))
+
+      (it "clears the capture state when cancelling a streaming turn"
+        (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+          (unwind-protect
+              (progn
+                (spy-on 'copilot--connection-alivep :and-return-value nil)
+                (with-current-buffer buf
+                  (copilot-chat-mode)
+                  (setq copilot-chat--streaming-p t
+                        copilot-chat--current-request "q"
+                        copilot-chat--reply-chunks '("x")))
+                (copilot-chat-stop)
+                (with-current-buffer buf
+                  (expect copilot-chat--current-request :to-be nil)
+                  (expect copilot-chat--reply-chunks :to-be nil)))
             (kill-buffer buf)))))
 
     (describe "saving"
@@ -994,11 +1128,9 @@
             (kill-buffer buf))))
 
       (it "names the file \"global\" outside any workspace"
-        (spy-on 'copilot--workspace-root :and-return-value nil)
         (let ((copilot-chat-history-directory history-dir))
-          (with-temp-buffer
-            (expect (file-name-nondirectory (copilot-chat--history-file))
-                    :to-equal "global.eld"))))
+          (expect (file-name-nondirectory (copilot-chat--history-file nil))
+                  :to-equal "global.eld")))
 
       (it "logs a save failure instead of signalling"
         (spy-on 'copilot--workspace-root :and-return-value "/tmp/project/")


### PR DESCRIPTION
Adds chat session persistence: with `copilot-chat-save-history` enabled (off by default, since transcripts land on disk), every completed turn saves the session to a per-workspace file under `copilot-chat-history-directory`. `M-x copilot-chat-restore` renders the saved transcript and the next message continues the conversation with full context; `copilot-chat-clear-history` deletes the file.

How restore works: the language server's `conversation/create` accepts a `turns` array of `{request, response}` pairs (verified against the 1.517.0 bundle), and replaying saved turns with their responses rebuilds the conversation server-side. Restore is deliberately lazy: it renders the transcript and stashes the turns without contacting the server, and the next `conversation/create` sends the history plus the new message. No unknown protocol semantics involved.

Hardening from the adversarial review pass (second commit):

- `copilot-chat` now refuses to send while a turn is in flight, matching `copilot-chat-send`. Previously an interleaved turn would corrupt the log (one request paired with another's response) and lose an answer.
- History read from disk is stripped of text properties; `read` reconstructs propertized strings, so a tampered or synced file could otherwise inject a `keymap` property that runs code on a keypress.
- The history root is pinned per session at restore/first-save, so save and restore can never silently target two different files.
- Errored and empty turns are not recorded; capture state is cleared on request errors and cancellation; history files are written `600` in a `700` directory.

481 specs pass (32 new), checkdoc clean, no new compile warnings.