### PR TITLE
Add a region rewrite command with diff preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `copilot-chat-doc`
   - `copilot-chat-optimize`
   - `copilot-chat-write-tests`
+- Add `copilot-chat-rewrite` to rewrite the active region according to a free-form instruction, with the proposed change previewed as a diff and applied only after confirmation. The instruction preamble is customizable via `copilot-chat-rewrite-prompt`, re-indentation of the result can be disabled with `copilot-chat-rewrite-indent`, and a pending rewrite is cancellable with `copilot-chat-stop`.
 - Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt` and a pending generation cancellable with `copilot-chat-stop`.
 - Optionally persist chat sessions across Emacs restarts: with `copilot-chat-save-history` enabled (off by default) the transcript is saved after each turn to a per-workspace file under `copilot-chat-history-directory`, `copilot-chat-restore` brings the saved conversation back with its full context, and `copilot-chat-clear-history` deletes the saved file.
 - Handle the server's `copilot/codingAgentMessage` request, so updates from GitHub's cloud coding agent (e.g. the pull request it opens to continue delegated work) are echoed and recorded in the `*copilot-coding-agent*` buffer instead of being dropped.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ The chat buffer's header line shows at a glance whether Agent or Ask mode is act
 
 Chat sessions can be persisted across Emacs restarts. Set `copilot-chat-save-history` to `t` (it is off by default, since transcripts land on disk in plain text) and the whole session is saved after each completed turn, one file per workspace under `copilot-chat-history-directory` (`~/.emacs.d/copilot-chat-history/` by default). `M-x copilot-chat-restore` brings the saved conversation back: the transcript reappears in the chat buffer, and the next message continues it with the full context (the saved turns are replayed to the server when the new conversation starts). `copilot-chat-clear-history` deletes the current workspace's saved history; `copilot-chat-reset` clears only the live session and leaves the file alone.
 
+`copilot-chat-rewrite` rewrites the active region according to a free-form instruction (e.g. "make it iterative"). The rewritten code is shown as a diff-style preview against the region and applied only after you confirm, so nothing is changed behind your back; the region is tracked with markers, so edits elsewhere in the buffer while the request is in flight are fine, while edits to the region itself drop the rewrite. The instruction preamble can be customized via `copilot-chat-rewrite-prompt`, the applied code is re-indented unless `copilot-chat-rewrite-indent` is set to `nil`, and a pending rewrite can be cancelled with `copilot-chat-stop`. Like `copilot-chat-insert-commit-message`, it runs outside the chat panel and never disturbs an ongoing conversation.
+
 `copilot-chat-insert-commit-message` generates a commit message from the staged changes and inserts it at point. It is meant to be called from a commit message buffer (e.g. Magit's `COMMIT_EDITMSG` or any `git-commit` buffer), but works from any buffer inside a git repository. It runs outside the chat panel, so it never disturbs an ongoing conversation; the instruction sent along with the diff can be customized via `copilot-chat-commit-message-prompt`.
 
 Customization:
@@ -502,6 +504,7 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-chat-doc` | Document the region or defun at point |
 | `copilot-chat-optimize` | Optimize the region or defun at point |
 | `copilot-chat-write-tests` | Write tests for the region or defun at point |
+| `copilot-chat-rewrite` | Rewrite the region per an instruction, with a diff preview and confirmation |
 | `copilot-chat-stop` | Cancel streaming, or reset the conversation if idle |
 | `copilot-chat-reset` | Destroy the current conversation and clear the chat buffer |
 | `copilot-chat-restore` | Restore the saved chat for the current workspace |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -164,6 +164,26 @@ Used by `copilot-chat-insert-commit-message'."
   :group 'copilot-chat
   :package-version '(copilot . "0.8"))
 
+(defcustom copilot-chat-rewrite-prompt
+  "Rewrite the code below according to the instruction that follows it.
+Return ONLY the rewritten code, without markdown code fences and
+without any commentary or explanations."
+  "Instruction prepended to the code sent by `copilot-chat-rewrite'.
+The rewrite instruction read from the minibuffer and the region's code
+\(in a fenced block tagged with the buffer's language) are appended to
+this prompt."
+  :type 'string
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
+(defcustom copilot-chat-rewrite-indent t
+  "When non-nil, re-indent the region rewritten by `copilot-chat-rewrite'.
+`indent-region' runs over the inserted text right after an accepted
+rewrite replaces the region."
+  :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
 (defcustom copilot-chat-save-history nil
   "When non-nil, save the chat transcript to disk after each turn.
 The whole session is written to a per-workspace file under
@@ -2099,6 +2119,127 @@ chat panel and does not disturb an ongoing chat conversation."
                (insert reply)))
            (set-marker pos nil)
            (message "Copilot Chat: Commit message inserted"))))))))
+
+;;
+;; Region rewrite
+;;
+
+(defconst copilot-chat--rewrite-preview-buffer-name
+  "*copilot-chat-rewrite-preview*"
+  "Name of the buffer used to preview a pending region rewrite.")
+
+(defun copilot-chat--rewrite-request (instruction lang code)
+  "Return the chat message asking to rewrite CODE per INSTRUCTION.
+The message starts with `copilot-chat-rewrite-prompt' and carries CODE
+in a fenced block tagged with the language id LANG."
+  (format "%s\n\nInstruction: %s\n\n```%s\n%s\n```"
+          copilot-chat-rewrite-prompt instruction lang code))
+
+(defun copilot-chat--rewrite-confirm (original proposal)
+  "Preview PROPOSAL replacing ORIGINAL and ask whether to apply it.
+Show a diff-style preview (removed region, then proposed replacement)
+in a temporary window and prompt with `y-or-n-p'.  Return the answer;
+the preview buffer is removed afterwards.  The current buffer is
+preserved: tearing down the preview window can leave another buffer
+current (e.g. when the preview reused the sole window), and the caller
+is in the middle of handling an async reply."
+  ;; A fresh buffer per call, so an overlapping confirmation can't erase
+  ;; or kill the preview out from under this prompt.
+  (let ((buf (generate-new-buffer copilot-chat--rewrite-preview-buffer-name))
+        (original-buffer (current-buffer)))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (insert (copilot-chat--diff-lines
+                     original "-" 'copilot-chat-diff-removed-face)
+                    "\n"
+                    (copilot-chat--diff-lines
+                     proposal "+" 'copilot-chat-diff-added-face))
+            (goto-char (point-min))
+            (setq buffer-read-only t))
+          (display-buffer buf '((display-buffer-pop-up-window
+                                 display-buffer-use-some-window)
+                                (window-height . fit-window-to-buffer)))
+          (y-or-n-p "Copilot Chat: Apply this rewrite? "))
+      (when-let* ((win (get-buffer-window buf)))
+        (quit-window nil win))
+      (kill-buffer buf)
+      (when (buffer-live-p original-buffer)
+        (set-buffer original-buffer)))))
+
+(defun copilot-chat--rewrite-apply (buf start end reply)
+  "Replace the region between markers START and END in BUF with REPLY.
+Re-indent the inserted text afterwards unless
+`copilot-chat-rewrite-indent' is nil."
+  (with-current-buffer buf
+    (save-excursion
+      (goto-char start)
+      (delete-region start end)
+      (insert reply)
+      (when copilot-chat-rewrite-indent
+        (indent-region start (point))))))
+
+(defun copilot-chat--rewrite-reply (buf start end original reply error-msg)
+  "Handle the rewrite REPLY for the region ORIGINAL in BUF.
+START and END are markers delimiting the region; ERROR-MSG is the error
+string from the one-shot request, or nil.  Preview the proposal and
+apply it on confirmation; when BUF is gone, the region's text no longer
+matches ORIGINAL, or the reply is empty or errored, report the reason
+and leave the buffer alone.  The markers are cleared either way."
+  (let ((reply (and reply (copilot-chat--strip-code-fences reply))))
+    (cond
+     (error-msg
+      (message "Copilot Chat: Rewrite failed: %s" error-msg))
+     ((or (null reply) (string-empty-p reply))
+      (message "Copilot Chat: Got an empty rewrite"))
+     ((not (buffer-live-p buf))
+      (message "Copilot Chat: Rewrite buffer is gone"))
+     ((not (string= original
+                    (with-current-buffer buf
+                      (buffer-substring-no-properties start end))))
+      (message "Copilot Chat: Region changed since the request; rewrite dropped"))
+     ((buffer-local-value 'buffer-read-only buf)
+      ;; Don't signal inside the jsonrpc process filter; salvage the
+      ;; reply instead.
+      (kill-new reply)
+      (message "Copilot Chat: Buffer is read-only; rewrite copied to kill ring"))
+     ((not (copilot-chat--rewrite-confirm original reply))
+      (message "Copilot Chat: Rewrite discarded"))
+     (t
+      (copilot-chat--rewrite-apply buf start end reply)
+      (message "Copilot Chat: Region rewritten"))))
+  (set-marker start nil)
+  (set-marker end nil))
+
+;;;###autoload
+(defun copilot-chat-rewrite (start end instruction)
+  "Rewrite the region between START and END according to INSTRUCTION.
+The region's code is sent to Copilot with INSTRUCTION (read from the
+minibuffer when called interactively) and the buffer's language.  The
+reply is previewed as a diff against the region and applied only after
+confirmation; the region is tracked with markers, so edits elsewhere in
+the buffer while the request is in flight don't shift the target, while
+edits to the region itself drop the rewrite.  The request runs outside
+the chat panel and does not disturb an ongoing chat conversation; cancel
+it with `copilot-chat-stop'."
+  (interactive
+   (if (use-region-p)
+       (list (region-beginning) (region-end)
+             (read-string "Rewrite instruction: "))
+     (user-error "Copilot Chat: No active region")))
+  (when (string-empty-p (string-trim instruction))
+    (user-error "Copilot Chat: Empty rewrite instruction"))
+  (let* ((buf (current-buffer))
+         (code (buffer-substring-no-properties start end))
+         (request (copilot-chat--rewrite-request
+                   instruction (copilot--get-language-id) code))
+         (beg (copy-marker start))
+         (fin (copy-marker end)))
+    (message "Copilot Chat: Rewriting region...")
+    (copilot-chat--one-shot
+     request
+     (lambda (reply error-msg)
+       (copilot-chat--rewrite-reply buf beg fin code reply error-msg)))))
 
 ;;
 ;; Major mode

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -2131,9 +2131,19 @@ chat panel and does not disturb an ongoing chat conversation."
 (defun copilot-chat--rewrite-request (instruction lang code)
   "Return the chat message asking to rewrite CODE per INSTRUCTION.
 The message starts with `copilot-chat-rewrite-prompt' and carries CODE
-in a fenced block tagged with the language id LANG."
-  (format "%s\n\nInstruction: %s\n\n```%s\n%s\n```"
-          copilot-chat-rewrite-prompt instruction lang code))
+in a fenced block tagged with the language id LANG.  The fence is made
+longer than any backtick run inside CODE, so rewriting markdown that
+contains its own fenced blocks doesn't terminate the fence early."
+  (let ((longest-run 0)
+        (pos 0))
+    (while (string-match "`+" code pos)
+      (setq longest-run (max longest-run
+                             (- (match-end 0) (match-beginning 0))))
+      (setq pos (match-end 0)))
+    (let ((fence (make-string (max 3 (1+ longest-run)) ?`)))
+      (format "%s\n\nInstruction: %s\n\n%s%s\n%s\n%s"
+              copilot-chat-rewrite-prompt instruction fence lang code
+              fence))))
 
 (defun copilot-chat--rewrite-confirm (original proposal)
   "Preview PROPOSAL replacing ORIGINAL and ask whether to apply it.
@@ -2170,14 +2180,29 @@ is in the middle of handling an async reply."
 (defun copilot-chat--rewrite-apply (buf start end reply)
   "Replace the region between markers START and END in BUF with REPLY.
 Re-indent the inserted text afterwards unless
-`copilot-chat-rewrite-indent' is nil."
+`copilot-chat-rewrite-indent' is nil.  Widen first: the buffer may be
+narrowed to a region excluding the target when the reply arrives."
   (with-current-buffer buf
-    (save-excursion
-      (goto-char start)
-      (delete-region start end)
-      (insert reply)
-      (when copilot-chat-rewrite-indent
-        (indent-region start (point))))))
+    (save-restriction
+      (widen)
+      (save-excursion
+        (goto-char start)
+        (delete-region start end)
+        (insert reply)
+        (when copilot-chat-rewrite-indent
+          (indent-region start (point)))))))
+
+(defun copilot-chat--rewrite-region-intact-p (buf start end original)
+  "Return non-nil when ORIGINAL is still the text between START and END in BUF.
+Widen before comparing: the reply arrives asynchronously and the buffer
+may be narrowed to a region that excludes the rewrite target, which
+must not signal `args-out-of-range' in the process filter."
+  (and (buffer-live-p buf)
+       (with-current-buffer buf
+         (save-restriction
+           (widen)
+           (string= original
+                    (buffer-substring-no-properties start end))))))
 
 (defun copilot-chat--rewrite-reply (buf start end original reply error-msg)
   "Handle the rewrite REPLY for the region ORIGINAL in BUF.
@@ -2185,31 +2210,47 @@ START and END are markers delimiting the region; ERROR-MSG is the error
 string from the one-shot request, or nil.  Preview the proposal and
 apply it on confirmation; when BUF is gone, the region's text no longer
 matches ORIGINAL, or the reply is empty or errored, report the reason
-and leave the buffer alone.  The markers are cleared either way."
-  (let ((reply (and reply (copilot-chat--strip-code-fences reply))))
-    (cond
-     (error-msg
-      (message "Copilot Chat: Rewrite failed: %s" error-msg))
-     ((or (null reply) (string-empty-p reply))
-      (message "Copilot Chat: Got an empty rewrite"))
-     ((not (buffer-live-p buf))
-      (message "Copilot Chat: Rewrite buffer is gone"))
-     ((not (string= original
-                    (with-current-buffer buf
-                      (buffer-substring-no-properties start end))))
-      (message "Copilot Chat: Region changed since the request; rewrite dropped"))
-     ((buffer-local-value 'buffer-read-only buf)
-      ;; Don't signal inside the jsonrpc process filter; salvage the
-      ;; reply instead.
-      (kill-new reply)
-      (message "Copilot Chat: Buffer is read-only; rewrite copied to kill ring"))
-     ((not (copilot-chat--rewrite-confirm original reply))
-      (message "Copilot Chat: Rewrite discarded"))
-     (t
-      (copilot-chat--rewrite-apply buf start end reply)
-      (message "Copilot Chat: Region rewritten"))))
-  (set-marker start nil)
-  (set-marker end nil))
+and leave the buffer alone.  The intactness check runs again after the
+confirmation: `y-or-n-p' blocks while timers and process filters keep
+running (auto-revert, other replies), so the region can change between
+the first check and the user's answer.  The markers are cleared either
+way, including on a quit at the prompt."
+  (unwind-protect
+      (let ((reply (and reply (copilot-chat--strip-code-fences reply))))
+        (cond
+         (error-msg
+          (message "Copilot Chat: Rewrite failed: %s" error-msg))
+         ((or (null reply) (string-empty-p reply))
+          (message "Copilot Chat: Got an empty rewrite"))
+         ((not (copilot-chat--rewrite-region-intact-p buf start end original))
+          (message
+           "Copilot Chat: Region changed since the request; rewrite dropped"))
+         ((buffer-local-value 'buffer-read-only buf)
+          ;; Don't signal inside the jsonrpc process filter; salvage the
+          ;; reply instead.
+          (kill-new reply)
+          (message
+           "Copilot Chat: Buffer is read-only; rewrite copied to kill ring"))
+         ((not (copilot-chat--rewrite-confirm original reply))
+          (message "Copilot Chat: Rewrite discarded"))
+         ((not (copilot-chat--rewrite-region-intact-p buf start end original))
+          (message
+           "Copilot Chat: Region changed during confirmation; rewrite dropped"))
+         (t
+          ;; Read-only text properties inside an otherwise writable
+          ;; buffer still make `delete-region' signal; degrade to the
+          ;; kill-ring salvage instead of erroring in the process
+          ;; filter.
+          (condition-case nil
+              (progn
+                (copilot-chat--rewrite-apply buf start end reply)
+                (message "Copilot Chat: Region rewritten"))
+            (text-read-only
+             (kill-new reply)
+             (message
+              "Copilot Chat: Region is read-only; rewrite copied to kill ring"))))))
+    (set-marker start nil)
+    (set-marker end nil)))
 
 ;;;###autoload
 (defun copilot-chat-rewrite (start end instruction)
@@ -2229,6 +2270,8 @@ it with `copilot-chat-stop'."
      (user-error "Copilot Chat: No active region")))
   (when (string-empty-p (string-trim instruction))
     (user-error "Copilot Chat: Empty rewrite instruction"))
+  (when (= start end)
+    (user-error "Copilot Chat: The region is empty"))
   (let* ((buf (current-buffer))
          (code (buffer-substring-no-properties start end))
          (request (copilot-chat--rewrite-request

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2949,6 +2949,208 @@
           (setq buffer-read-only t)
           (funcall reply-fn "feat: x" nil)
           (expect (buffer-string) :to-equal ""))
-        (expect (current-kill 0) :to-equal "feat: x")))))
+        (expect (current-kill 0) :to-equal "feat: x"))))
+
+  (describe "copilot-chat--rewrite-request"
+    (it "composes the prompt, instruction, language tag, and code"
+      (let ((copilot-chat-rewrite-prompt "PROMPT"))
+        (expect (copilot-chat--rewrite-request
+                 "make it iterative" "python" "def f(): pass")
+                :to-equal
+                "PROMPT\n\nInstruction: make it iterative\n\n```python\ndef f(): pass\n```"))))
+
+  (describe "copilot-chat-rewrite"
+    (it "errors without an active region"
+      (spy-on 'copilot-chat--one-shot)
+      (with-temp-buffer
+        (insert "code")
+        (expect (call-interactively #'copilot-chat-rewrite)
+                :to-throw 'user-error))
+      (expect 'copilot-chat--one-shot :not :to-have-been-called))
+
+    (it "errors on a blank instruction"
+      (spy-on 'copilot-chat--one-shot)
+      (with-temp-buffer
+        (insert "code")
+        (expect (copilot-chat-rewrite (point-min) (point-max) "  ")
+                :to-throw 'user-error))
+      (expect 'copilot-chat--one-shot :not :to-have-been-called))
+
+    (it "sends the prompt, instruction, language, and region code"
+      (spy-on 'copilot-chat--one-shot)
+      (spy-on 'copilot--get-language-id :and-return-value "python")
+      (spy-on 'message)
+      (let ((copilot-chat-rewrite-prompt "PROMPT"))
+        (with-temp-buffer
+          (insert "def f(): pass")
+          (copilot-chat-rewrite (point-min) (point-max) "make it iterative")))
+      (expect (car (spy-calls-args-for 'copilot-chat--one-shot 0))
+              :to-equal
+              "PROMPT\n\nInstruction: make it iterative\n\n```python\ndef f(): pass\n```"))
+
+    (it "strips code fences before previewing and applying"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "python")
+        (spy-on 'copilot-chat--rewrite-confirm :and-return-value t)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "```python\nNEW\n```" nil)
+          (expect (buffer-string) :to-equal "NEW"))
+        (expect (cadr (spy-calls-args-for 'copilot-chat--rewrite-confirm 0))
+                :to-equal "NEW")))
+
+    (it "reports a server error without touching the buffer"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn nil "boom")
+          (expect (buffer-string) :to-equal "OLD"))
+        (expect 'copilot-chat--rewrite-confirm :not :to-have-been-called)))
+
+    (it "reports an empty reply without touching the buffer"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "```\n\n```" nil)
+          (expect (buffer-string) :to-equal "OLD"))
+        (expect 'copilot-chat--rewrite-confirm :not :to-have-been-called)))
+
+    (it "does nothing when the buffer is gone by reply time"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm)
+        (spy-on 'message)
+        (let ((buf (generate-new-buffer "rewrite-src")))
+          (with-current-buffer buf
+            (insert "OLD")
+            (copilot-chat-rewrite (point-min) (point-max) "rewrite"))
+          (kill-buffer buf))
+        (funcall reply-fn "NEW" nil)
+        (expect 'copilot-chat--rewrite-confirm :not :to-have-been-called)))
+
+    (it "drops the rewrite when the region changed since the request"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          ;; The user edits inside the region before the reply arrives.
+          (goto-char 2)
+          (insert "X")
+          (funcall reply-fn "NEW" nil)
+          (expect (buffer-string) :to-equal "OXLD"))
+        (expect 'copilot-chat--rewrite-confirm :not :to-have-been-called)))
+
+    (it "leaves the buffer untouched when the preview is declined"
+      (let ((reply-fn nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'y-or-n-p :and-return-value nil)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "NEW" nil)
+          (expect (buffer-string) :to-equal "OLD"))
+        (expect 'y-or-n-p :to-have-been-called)
+        (expect (get-buffer copilot-chat--rewrite-preview-buffer-name)
+                :not :to-be-truthy)))
+
+    (it "replaces exactly the region on accept"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'y-or-n-p :and-return-value t)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "before\nREGION\nafter\n")
+          (copilot-chat-rewrite 8 14 "rewrite")
+          (funcall reply-fn "NEW" nil)
+          (expect (buffer-string) :to-equal "before\nNEW\nafter\n"))
+        (expect (get-buffer copilot-chat--rewrite-preview-buffer-name)
+                :not :to-be-truthy)))
+
+    (it "follows the region when text before it changes in flight"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm :and-return-value t)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "head\nREGION\ntail\n")
+          (copilot-chat-rewrite 6 12 "rewrite")
+          ;; The user edits above the region before the reply arrives.
+          (goto-char (point-min))
+          (insert ";; new line\n")
+          (funcall reply-fn "NEW" nil)
+          (expect (buffer-string) :to-equal ";; new line\nhead\nNEW\ntail\n"))))
+
+    (it "re-indents the inserted text by default"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent t))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm :and-return-value t)
+        (spy-on 'indent-region)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "NEW" nil))
+        (expect 'indent-region :to-have-been-called)))
+
+    (it "skips re-indentation when copilot-chat-rewrite-indent is nil"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm :and-return-value t)
+        (spy-on 'indent-region)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "NEW" nil))
+        (expect 'indent-region :not :to-have-been-called)))))
 
 ;;; copilot-chat-test.el ends here

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2957,7 +2957,15 @@
         (expect (copilot-chat--rewrite-request
                  "make it iterative" "python" "def f(): pass")
                 :to-equal
-                "PROMPT\n\nInstruction: make it iterative\n\n```python\ndef f(): pass\n```"))))
+                "PROMPT\n\nInstruction: make it iterative\n\n```python\ndef f(): pass\n```")))
+
+    (it "outgrows backtick runs inside the code"
+      (let ((copilot-chat-rewrite-prompt "PROMPT"))
+        (expect (copilot-chat--rewrite-request
+                 "tidy" "markdown" "text\n```elisp\n(code)\n```\nmore")
+                :to-equal
+                (concat "PROMPT\n\nInstruction: tidy\n\n"
+                        "````markdown\ntext\n```elisp\n(code)\n```\nmore\n````")))))
 
   (describe "copilot-chat-rewrite"
     (it "errors without an active region"
@@ -2975,6 +2983,104 @@
         (expect (copilot-chat-rewrite (point-min) (point-max) "  ")
                 :to-throw 'user-error))
       (expect 'copilot-chat--one-shot :not :to-have-been-called))
+
+    (it "errors on an empty region"
+      (spy-on 'copilot-chat--one-shot)
+      (with-temp-buffer
+        (insert "code")
+        (expect (copilot-chat-rewrite (point-min) (point-min) "rewrite")
+                :to-throw 'user-error))
+      (expect 'copilot-chat--one-shot :not :to-have-been-called))
+
+    (it "drops the rewrite when the region changes during confirmation"
+      (let ((reply-fn nil)
+            (target nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        ;; Simulate auto-revert firing while y-or-n-p blocks: the
+        ;; confirm hook mutates the buffer, then answers yes.
+        (spy-on 'copilot-chat--rewrite-confirm
+                :and-call-fake
+                (lambda (&rest _)
+                  (with-current-buffer target
+                    (let ((inhibit-read-only t))
+                      (erase-buffer)
+                      (insert "REVERTED")))
+                  t))
+        (spy-on 'message)
+        (with-temp-buffer
+          (setq target (current-buffer))
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "NEW" nil)
+          (expect (buffer-string) :to-equal "REVERTED"))))
+
+    (it "applies even when the buffer is narrowed away from the region"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm :and-return-value t)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD\nrest")
+          (copilot-chat-rewrite (point-min) (+ (point-min) 3) "rewrite")
+          (narrow-to-region (- (point-max) 4) (point-max))
+          (funcall reply-fn "NEW" nil)
+          (widen)
+          (expect (buffer-string) :to-equal "NEW\nrest"))))
+
+    (it "salvages to the kill ring when the region has read-only text"
+      (let ((reply-fn nil)
+            (copilot-chat-rewrite-indent nil))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        (spy-on 'copilot-chat--rewrite-confirm :and-return-value t)
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (let ((inhibit-read-only t))
+            (put-text-property (point-min) (point-max) 'read-only t))
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (funcall reply-fn "NEW" nil)
+          (let ((inhibit-read-only t))
+            (expect (buffer-string) :to-equal "OLD")))
+        (expect (current-kill 0) :to-equal "NEW")))
+
+    (it "clears the markers when the confirmation exits nonlocally"
+      (let ((reply-fn nil)
+            (markers '()))
+        (spy-on 'copilot-chat--one-shot
+                :and-call-fake
+                (lambda (_message callback) (setq reply-fn callback)))
+        (spy-on 'copilot--get-language-id :and-return-value "text")
+        ;; Stands in for C-g at the y-or-n-p prompt: any nonlocal exit
+        ;; must still hit the unwind that clears the markers.
+        (spy-on 'copilot-chat--rewrite-confirm
+                :and-call-fake (lambda (&rest _) (error "Simulated abort")))
+        (spy-on 'copy-marker
+                :and-call-fake
+                (lambda (pos &optional type)
+                  (let ((m (make-marker)))
+                    (set-marker m pos)
+                    (set-marker-insertion-type m type)
+                    (push m markers)
+                    m)))
+        (spy-on 'message)
+        (with-temp-buffer
+          (insert "OLD")
+          (copilot-chat-rewrite (point-min) (point-max) "rewrite")
+          (expect (funcall reply-fn "NEW" nil) :to-throw 'error)
+          ;; The unwind must have cleared both markers despite the abort.
+          (expect (length markers) :to-equal 2)
+          (expect (seq-filter #'marker-position markers) :to-be nil)
+          (expect (buffer-string) :to-equal "OLD"))))
 
     (it "sends the prompt, instruction, language, and region code"
       (spy-on 'copilot-chat--one-shot)


### PR DESCRIPTION
Adds `copilot-chat-rewrite`: select a region, give an instruction ("make it iterative", "add error handling"), and Copilot's proposal is shown as a diff preview and applied only after confirmation. Runs entirely outside the chat panel via the one-shot machinery from #513, so it inherits its cancellation (`copilot-chat-stop`) and cleanup guarantees; the target region is tracked with markers so edits elsewhere in the buffer don't shift it, while edits to the region itself drop the rewrite.

Hardening from the adversarial review (second commit):

- The staleness check runs again after the confirmation prompt: `y-or-n-p` blocks while timers and process filters keep running, so auto-revert could swap the buffer contents mid-prompt and the apply would splice into the wrong place.
- The reply handler widens before comparing or applying, so a buffer narrowed away from the target can't signal `args-out-of-range` inside the jsonrpc process filter.
- Read-only text properties inside a writable buffer degrade to the kill-ring salvage instead of signalling; markers are cleared via `unwind-protect` even on a quit at the prompt.
- The request fence outgrows any backtick run in the region, so rewriting markdown containing fenced blocks composes correctly.

`copilot-chat-rewrite-prompt` and `copilot-chat-rewrite-indent` customize the instruction preamble and the post-apply re-indent. 501 specs pass, checkdoc clean, no new compile warnings.