### PR TITLE
Add native Copilot Code Review commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   - `copilot-chat-optimize`
   - `copilot-chat-write-tests`
 - Add `copilot-chat-rewrite` to rewrite the active region according to a free-form instruction, with the proposed change previewed as a diff and applied only after confirmation. The instruction preamble is customizable via `copilot-chat-rewrite-prompt`, re-indentation of the result can be disabled with `copilot-chat-rewrite-indent`, and a pending rewrite is cancellable with `copilot-chat-stop`.
+- Add native Copilot Code Review support (the same reviewer behind GitHub's code review, via the language server's `copilot/codeReview` methods), with the resulting comments rendered in the chat buffer with file, line, and suggested changes:
+  - `copilot-chat-review-changes` reviews the uncommitted changes (staged and unstaged)
+  - `copilot-chat-review-region` reviews the selected code
 - Add `copilot-chat-insert-commit-message` to generate a commit message from the staged changes and insert it at point (handy in a Magit or `git-commit` buffer), with the instruction sent to Copilot customizable via `copilot-chat-commit-message-prompt` and a pending generation cancellable with `copilot-chat-stop`.
 - Optionally persist chat sessions across Emacs restarts: with `copilot-chat-save-history` enabled (off by default) the transcript is saved after each turn to a per-workspace file under `copilot-chat-history-directory`, `copilot-chat-restore` brings the saved conversation back with its full context, and `copilot-chat-clear-history` deletes the saved file.
 - Handle the server's `copilot/codingAgentMessage` request, so updates from GitHub's cloud coding agent (e.g. the pull request it opens to continue delegated work) are echoed and recorded in the `*copilot-coding-agent*` buffer instead of being dropped.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ There are also one-shot task commands that send the active region (or the functi
 
 `copilot-chat-task` prompts for the task with completion and dispatches to the same machinery. The prompts live in `copilot-chat-task-prompts` and can be customized (or extended with your own tasks).
 
+Beyond the prose feedback of `copilot-chat-review`, there is also native Copilot Code Review, the same reviewer behind GitHub's code review. `copilot-chat-review-changes` sends the repository's uncommitted changes (staged and unstaged, like a pre-commit review) to the dedicated review service, and `copilot-chat-review-region` does the same for the selected code. Instead of a streamed chat answer, these return structured review comments, rendered in the chat buffer with file, line, an explanation, and a suggested change when there is one. The review runs outside the chat conversation, so it never disturbs one in progress. Note that Copilot Code Review is a separate entitlement; when a subscription doesn't include it, the server's error ("GitHub Copilot Code Review is not enabled.") is shown in the chat buffer.
+
 Key bindings in the `*copilot-chat*` buffer:
 - **C-c RET** or **C-c C-c** — send a follow-up message
 - **C-c C-k** — cancel streaming, or reset if idle
@@ -505,6 +507,8 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-chat-optimize` | Optimize the region or defun at point |
 | `copilot-chat-write-tests` | Write tests for the region or defun at point |
 | `copilot-chat-rewrite` | Rewrite the region per an instruction, with a diff preview and confirmation |
+| `copilot-chat-review-changes` | Review the uncommitted changes with native Copilot Code Review |
+| `copilot-chat-review-region` | Review the selected code with native Copilot Code Review |
 | `copilot-chat-stop` | Cancel streaming, or reset the conversation if idle |
 | `copilot-chat-reset` | Destroy the current conversation and clear the chat buffer |
 | `copilot-chat-restore` | Restore the saved chat for the current workspace |
@@ -550,6 +554,8 @@ A few commonly tweaked variables:
 | `conversation/create` | Supported | Start a new chat conversation |
 | `conversation/turn` | Supported | Send a follow-up chat message |
 | `conversation/destroy` | Supported | End a chat conversation |
+| `copilot/codeReview/reviewChanges` | Supported | Native code review of the uncommitted changes |
+| `copilot/codeReview/reviewSnippets` | Supported | Native code review of a selection |
 | `textDocument/copilotInlineEdit` | Supported | Next Edit Suggestions (NES) |
 
 ### Client-to-Server Notifications

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -2285,6 +2285,239 @@ it with `copilot-chat-stop'."
        (copilot-chat--rewrite-reply buf beg fin code reply error-msg)))))
 
 ;;
+;; Native code review
+;;
+
+(defconst copilot-chat--review-max-file-bytes 1000000
+  "Largest file, in bytes, included in a native code review request.")
+
+(defun copilot-chat--repo-root ()
+  "Return the root directory of the enclosing git repository.
+Run git in `default-directory' (via `process-file', so remote buffers
+resolve the remote repository) and put any remote prefix back onto the
+path git reports.  Signal a `user-error' outside a repository."
+  (let* ((exit nil)
+         (out (with-temp-buffer
+                (setq exit (process-file "git" nil t nil
+                                         "rev-parse" "--show-toplevel"))
+                (buffer-string))))
+    (unless (eql exit 0)
+      (user-error "Copilot Chat: Not inside a git repository"))
+    (concat (file-remote-p default-directory)
+            (file-name-as-directory (string-trim out)))))
+
+(defun copilot-chat--changed-files ()
+  "Return the repository-relative paths of the files modified since HEAD.
+List the files `git diff HEAD' touches, staged or not.  Deleted files
+are excluded (a review needs the file's new content), and renames are
+reported as a delete plus an add for the same reason.  Signal a
+`user-error' when git fails or when nothing has changed."
+  (let* ((exit nil)
+         (out (with-temp-buffer
+                (setq exit (process-file "git" nil t nil
+                                         "diff" "--name-only" "--no-renames"
+                                         "--diff-filter=d" "-z" "HEAD"))
+                (buffer-string))))
+    (unless (eql exit 0)
+      (user-error
+       "Copilot Chat: git diff failed (%s); not inside a git repository?"
+       exit))
+    (let ((files (seq-remove #'string-empty-p (split-string out "\0"))))
+      (unless files
+        (user-error "Copilot Chat: No uncommitted changes to review"))
+      files)))
+
+(defun copilot-chat--review-file-text (path)
+  "Return the contents of PATH decoded as UTF-8, or nil.
+Return nil when the file is unreadable, larger than
+`copilot-chat--review-max-file-bytes', or binary (contains NUL bytes),
+none of which belong in a review request."
+  (when (and (file-readable-p path)
+             (when-let* ((size (file-attribute-size (file-attributes path))))
+               (<= size copilot-chat--review-max-file-bytes)))
+    (let ((coding-system-for-read 'utf-8))
+      (with-temp-buffer
+        (insert-file-contents path)
+        (goto-char (point-min))
+        (unless (search-forward "\0" nil t)
+          (buffer-string))))))
+
+(defun copilot-chat--review-base-content (path)
+  "Return PATH's content at HEAD, or an empty string.
+PATH is relative to the repository root.  A file that does not exist at
+HEAD (newly added) yields the empty string, which the review request
+uses to mean the whole file is new."
+  (let ((coding-system-for-read 'utf-8))
+    (with-temp-buffer
+      (if (eql 0 (process-file "git" nil t nil "show" (concat "HEAD:" path)))
+          (buffer-string)
+        ""))))
+
+(defun copilot-chat--uncommitted-changes (root)
+  "Return the uncommitted diff under ROOT as review request entries.
+Each element is a plist with the :uri, :path, :baseContent, and
+:headContent fields the `copilot/codeReview/reviewChanges' method
+expects.  Binary and oversized files are skipped."
+  (delq nil
+        (mapcar
+         (lambda (path)
+           (let ((file (expand-file-name path root)))
+             (when-let* ((head (copilot-chat--review-file-text file)))
+               (list :uri (copilot--path-to-uri file)
+                     :path path
+                     :baseContent (copilot-chat--review-base-content path)
+                     :headContent head))))
+         (copilot-chat--changed-files))))
+
+(defun copilot-chat--review-workspace-folders (root)
+  "Return the workspace-folders vector for a review of ROOT."
+  (vector (list :uri (copilot--path-to-uri (directory-file-name root))
+                :name (file-name-nondirectory (directory-file-name root)))))
+
+(defun copilot-chat--review-comment-location (comment root)
+  "Return a \"path:line\" label for review COMMENT.
+The comment's file URI is shortened relative to ROOT when it lies
+inside it.  The server reports zero-based lines; the label shows the
+one-based line the user knows."
+  (let* ((path (copilot--uri-to-path (or (plist-get comment :uri) "")))
+         (start (plist-get (plist-get comment :range) :start))
+         (line (1+ (or (plist-get start :line) 0))))
+    (format "%s:%d"
+            (if (and root (string-prefix-p root path))
+                (file-relative-name path root)
+              path)
+            line)))
+
+(defun copilot-chat--format-review-comment (comment root)
+  "Return review COMMENT rendered as markdown for the chat buffer.
+ROOT is the directory file paths are shortened against."
+  (let ((text (or (plist-get comment :message) ""))
+        (kind (plist-get comment :kind))
+        (suggestion (plist-get comment :suggestion)))
+    (concat (format "**%s**" (copilot-chat--review-comment-location comment root))
+            (when (and (stringp kind) (not (string-empty-p kind)))
+              (format " [%s]" kind))
+            "\n" text "\n"
+            (when (and (stringp suggestion) (not (string-empty-p suggestion)))
+              (format "\nSuggested change:\n\n```\n%s\n```\n" suggestion)))))
+
+(defun copilot-chat--insert-review-results (comments root)
+  "Render the review COMMENTS in the chat buffer.
+COMMENTS is the (possibly empty) list of structured comments a
+`copilot/codeReview' request returned; ROOT is the directory their file
+paths are shortened against."
+  (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (goto-char (point-max))
+        (insert
+         (if comments
+             (mapconcat (lambda (comment)
+                          (copilot-chat--format-review-comment comment root))
+                        comments "\n")
+           "No review comments; the changes look good.\n")
+         "\n"))
+      (copilot-chat--scroll-to-bottom))))
+
+(defun copilot-chat--request-review (method params request root)
+  "Send review METHOD with PARAMS and render its comments when they arrive.
+REQUEST is the transcript line describing what is being reviewed, shown
+in the chat buffer while the review runs; ROOT is the directory used to
+shorten file paths in the rendered comments.  The review runs outside
+the chat conversation, so it neither consumes a chat turn nor disturbs
+one in flight."
+  (let ((chat-buf (get-buffer-create copilot-chat--buffer-name)))
+    (with-current-buffer chat-buf
+      (unless (derived-mode-p 'copilot-chat-mode)
+        (copilot-chat-mode))
+      (copilot-chat--insert-prompt request)
+      (copilot-chat--scroll-to-bottom))
+    (display-buffer chat-buf)
+    (message "Copilot Chat: Requesting code review (this can take a while)...")
+    ;; Issue the request from the chat buffer: the response callback is
+    ;; dropped when the buffer current at request time has been killed,
+    ;; and a review can run long enough for the invoking buffer to be
+    ;; gone by then.
+    (with-current-buffer chat-buf
+      (copilot--async-request
+       method params
+       :success-fn (lambda (result)
+                     (copilot-chat--insert-review-results
+                      (append (plist-get result :comments) nil) root)
+                     (message "Copilot Chat: Code review finished"))
+       :error-fn (lambda (err)
+                   (let ((msg (or (copilot-chat--error-text err)
+                                  (format "%s" err))))
+                     (copilot-chat--insert-error msg)
+                     (message "Copilot Chat: Code review failed: %s" msg)))))))
+
+;;;###autoload
+(defun copilot-chat-review-changes ()
+  "Run Copilot's native code review over the uncommitted diff.
+Collect the working tree's staged and unstaged edits against HEAD and
+send them to the language server's `copilot/codeReview/reviewChanges'
+method, the reviewer behind GitHub's Copilot Code Review.  The comments
+it returns (file, line, message, and a suggested change when there is
+one) are rendered in the chat buffer.
+
+Signal a `user-error' when there is nothing to review; when the account
+has no access to Copilot Code Review, the server's error is shown in
+the chat buffer instead."
+  (interactive)
+  (let* ((root (copilot-chat--repo-root))
+         (changes (copilot-chat--uncommitted-changes root)))
+    (unless changes
+      (user-error
+       "Copilot Chat: Only binary or oversized files changed; nothing to review"))
+    (copilot-chat--request-review
+     'copilot/codeReview/reviewChanges
+     (list :changes (vconcat changes)
+           :workspaceFolders (copilot-chat--review-workspace-folders root))
+     (format "Review the uncommitted changes (%d file%s)"
+             (length changes) (if (= (length changes) 1) "" "s"))
+     root)))
+
+;;;###autoload
+(defun copilot-chat-review-region (start end)
+  "Review the region between START and END with Copilot's native code review.
+Unlike `copilot-chat-review', which asks the chat model for prose
+feedback, this sends the selection (widened to whole lines) to the
+language server's dedicated `copilot/codeReview/reviewSnippets' method
+and renders the structured comments it returns (file, line, message,
+and suggested change) in the chat buffer."
+  (interactive
+   (if (use-region-p)
+       (list (region-beginning) (region-end))
+     (user-error "Copilot Chat: No active region")))
+  (unless buffer-file-name
+    (user-error "Copilot Chat: Buffer is not visiting a file"))
+  (let* ((snip-beg (save-excursion
+                     (goto-char start) (line-beginning-position)))
+         ;; A region ending at the start of a line does not include that
+         ;; line, so back the end up onto the last selected line.
+         (snip-end (save-excursion
+                     (goto-char end)
+                     (when (and (> end start) (bolp)) (forward-line -1))
+                     (line-end-position)))
+         (start-line (line-number-at-pos snip-beg))
+         (end-line (line-number-at-pos snip-end))
+         (path (copilot--get-relative-path))
+         (root (or (copilot--workspace-root)
+                   (file-name-directory buffer-file-name))))
+    (copilot-chat--request-review
+     'copilot/codeReview/reviewSnippets
+     (list :snippets (vector
+                      (list :uri (copilot--path-to-uri buffer-file-name)
+                            :path path
+                            :content (buffer-substring-no-properties
+                                      snip-beg snip-end)
+                            :startLine start-line
+                            :endLine end-line))
+           :workspaceFolders (copilot-chat--review-workspace-folders root))
+     (format "Review %s, lines %d-%d" path start-line end-line)
+     root)))
+
+;;
 ;; Major mode
 ;;
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -2312,10 +2312,18 @@ List the files `git diff HEAD' touches, staged or not.  Deleted files
 are excluded (a review needs the file's new content), and renames are
 reported as a delete plus an add for the same reason.  Signal a
 `user-error' when git fails or when nothing has changed."
+  (unless (eql 0 (process-file "git" nil nil nil
+                               "rev-parse" "--verify" "--quiet" "HEAD"))
+    (user-error
+     "Copilot Chat: The repository has no commits yet, so there is no base to review against"))
   (let* ((exit nil)
          (out (with-temp-buffer
+                ;; --no-relative: with diff.relative set, paths would
+                ;; come back relative to the invoking subdirectory and
+                ;; never resolve against the repository root.
                 (setq exit (process-file "git" nil t nil
                                          "diff" "--name-only" "--no-renames"
+                                         "--no-relative"
                                          "--diff-filter=d" "-z" "HEAD"))
                 (buffer-string))))
     (unless (eql exit 0)
@@ -2332,7 +2340,8 @@ reported as a delete plus an add for the same reason.  Signal a
 Return nil when the file is unreadable, larger than
 `copilot-chat--review-max-file-bytes', or binary (contains NUL bytes),
 none of which belong in a review request."
-  (when (and (file-readable-p path)
+  (when (and (file-regular-p path)
+             (file-readable-p path)
              (when-let* ((size (file-attribute-size (file-attributes path))))
                (<= size copilot-chat--review-max-file-bytes)))
     (let ((coding-system-for-read 'utf-8))
@@ -2399,7 +2408,18 @@ ROOT is the directory file paths are shortened against."
               (format " [%s]" kind))
             "\n" text "\n"
             (when (and (stringp suggestion) (not (string-empty-p suggestion)))
-              (format "\nSuggested change:\n\n```\n%s\n```\n" suggestion)))))
+              ;; The fence must outgrow any backtick run inside the
+              ;; suggestion (e.g. when reviewing markdown), or the
+              ;; block terminates early.
+              (let* ((longest 0)
+                     (pos 0))
+                (while (string-match "`+" suggestion pos)
+                  (setq longest (max longest (- (match-end 0)
+                                                (match-beginning 0))))
+                  (setq pos (match-end 0)))
+                (let ((fence (make-string (max 3 (1+ longest)) ?`)))
+                  (format "\nSuggested change:\n\n%s\n%s\n%s\n"
+                          fence suggestion fence)))))))
 
 (defun copilot-chat--insert-review-results (comments root)
   "Render the review COMMENTS in the chat buffer.
@@ -2430,6 +2450,11 @@ one in flight."
     (with-current-buffer chat-buf
       (unless (derived-mode-p 'copilot-chat-mode)
         (copilot-chat-mode))
+      ;; Reviews and chat replies both append at point-max; letting a
+      ;; review start while an answer streams would splice their output
+      ;; together.
+      (when copilot-chat--streaming-p
+        (user-error "Copilot Chat: A response is currently being streamed"))
       (copilot-chat--insert-prompt request)
       (copilot-chat--scroll-to-bottom))
     (display-buffer chat-buf)
@@ -2441,6 +2466,12 @@ one in flight."
     (with-current-buffer chat-buf
       (copilot--async-request
        method params
+       ;; jsonrpc's 10s default would silently drop most real reviews:
+       ;; the server's own review pipeline allows 120s.
+       :timeout 130
+       :timeout-fn (lambda ()
+                     (copilot-chat--insert-error "Code review timed out")
+                     (message "Copilot Chat: Code review timed out"))
        :success-fn (lambda (result)
                      (copilot-chat--insert-review-results
                       (append (plist-get result :comments) nil) root)
@@ -2499,8 +2530,10 @@ and suggested change) in the chat buffer."
                      (goto-char end)
                      (when (and (> end start) (bolp)) (forward-line -1))
                      (line-end-position)))
-         (start-line (line-number-at-pos snip-beg))
-         (end-line (line-number-at-pos snip-end))
+         ;; Absolute line numbers: under narrowing the default counts
+         ;; from the accessible region's start, not the file's.
+         (start-line (line-number-at-pos snip-beg t))
+         (end-line (line-number-at-pos snip-end t))
          (path (copilot--get-relative-path))
          (root (or (copilot--workspace-root)
                    (file-name-directory buffer-file-name))))

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2940,7 +2940,37 @@
                       "commit" "-q" "-m" "init")
         (write-region "changed\n" nil (expand-file-name "f.txt") nil 'quiet)
         (write-region "loose\n" nil (expand-file-name "untracked.txt") nil 'quiet)
-        (expect (copilot-chat--changed-files) :to-equal '("f.txt")))))
+        (expect (copilot-chat--changed-files) :to-equal '("f.txt"))))
+
+    (it "gives an accurate error in a repository with no commits"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (write-region "hello\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "f.txt")
+        (condition-case err
+            (progn (copilot-chat--changed-files)
+                   (buttercup-fail "expected a user-error"))
+          (user-error
+           (expect (cadr err) :to-match "no commits yet")))))
+
+    (it "returns root-relative paths even with diff.relative set"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (process-file "git" nil nil nil "config" "diff.relative" "true")
+        (make-directory (expand-file-name "src"))
+        (write-region "hello\n" nil (expand-file-name "src/f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" ".")
+        (process-file "git" nil nil nil
+                      "-c" "user.email=t@t" "-c" "user.name=t"
+                      "commit" "-q" "-m" "init")
+        (write-region "changed\n" nil (expand-file-name "src/f.txt") nil 'quiet)
+        (let ((default-directory (expand-file-name "src/" default-directory)))
+          (expect (copilot-chat--changed-files) :to-equal '("src/f.txt"))))))
+
+  (describe "copilot-chat--review-file-text"
+    (it "returns nil for a directory (e.g. a dirty submodule entry)"
+      (let ((dir (make-temp-file "copilot-subdir" t)))
+        (expect (copilot-chat--review-file-text dir) :to-be nil))))
 
   (describe "copilot-chat--uncommitted-changes"
     (it "pairs each change with its base and head content"
@@ -3144,7 +3174,57 @@
           (set-buffer-modified-p nil))
         (let ((snippet (aref (plist-get captured-params :snippets) 0)))
           (expect (plist-get snippet :content) :to-equal "line one\nline two")
-          (expect (plist-get snippet :endLine) :to-equal 2)))))
+          (expect (plist-get snippet :endLine) :to-equal 2))))
+
+    (it "sends absolute line numbers from a narrowed buffer"
+      (let ((captured-params nil))
+        (spy-on 'copilot--workspace-root :and-return-value "/repo/")
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method params &rest _args)
+                  (setq captured-params params)
+                  (cons nil nil)))
+        (with-temp-buffer
+          (insert "line one\nline two\nline three\n")
+          (setq buffer-file-name "/repo/f.el")
+          ;; Narrow to lines 2-3, review line 2: the file line is 2
+          ;; even though it is the narrowed region's first line.
+          (narrow-to-region 10 (point-max))
+          (copilot-chat-review-region 10 18)
+          (set-buffer-modified-p nil))
+        (let ((snippet (aref (plist-get captured-params :snippets) 0)))
+          (expect (plist-get snippet :startLine) :to-equal 2)
+          (expect (plist-get snippet :endLine) :to-equal 2))))
+
+    (it "sends a generous timeout with a timeout handler"
+      (let ((captured-args nil))
+        (spy-on 'copilot--workspace-root :and-return-value "/repo/")
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (setq captured-args args)
+                  (cons nil nil)))
+        (with-temp-buffer
+          (insert "line one\n")
+          (setq buffer-file-name "/repo/f.el")
+          (copilot-chat-review-region (point-min) (point-max))
+          (set-buffer-modified-p nil))
+        ;; jsonrpc's 10s default would drop most real reviews.
+        (expect (plist-get captured-args :timeout) :to-equal 130)
+        (expect (functionp (plist-get captured-args :timeout-fn))
+                :to-be-truthy)))
+
+    (it "refuses to run while a chat response is streaming"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+        (with-current-buffer buf
+          (copilot-chat-mode)
+          (setq copilot-chat--streaming-p t))
+        (with-temp-buffer
+          (insert "line one\n")
+          (setq buffer-file-name "/repo/f.el")
+          (expect (copilot-chat-review-region (point-min) (point-max))
+                  :to-throw 'user-error)
+          (set-buffer-modified-p nil)))))
 
   (describe "copilot-chat--format-review-comment"
     (it "renders location, kind, message, and suggestion"
@@ -3159,7 +3239,17 @@
         (expect rendered :to-match "\\*\\*src/a\\.el:1\\*\\* \\[consistency\\]")
         (expect rendered :to-match "Watch out")
         (expect rendered :to-match "Suggested change:")
-        (expect rendered :to-match "(safer)")))
+        (expect rendered :to-match "```\n(safer)\n```")))
+
+    (it "outgrows backtick runs inside the suggestion"
+      (let ((rendered (copilot-chat--format-review-comment
+                       '(:uri "file:///repo/README.md"
+                         :range (:start (:line 0 :character 0)
+                                 :end (:line 0 :character 1))
+                         :message "Fix the fence"
+                         :suggestion "```elisp\n(code)\n```")
+                       "/repo/")))
+        (expect rendered :to-match "````\n```elisp\n(code)\n```\n````")))
 
     (it "omits the suggestion block when there is none"
       (let ((rendered (copilot-chat--format-review-comment

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2893,6 +2893,287 @@
         (expect copilot-chat--one-shot-requests :not :to-be-truthy)
         (expect results :to-equal '(("" "Cancelled"))))))
 
+  ;;
+  ;; Native code review
+  ;;
+
+  (describe "copilot-chat--changed-files"
+    ;; Real git in temp directories, like the copilot-chat--staged-diff
+    ;; specs: the point is exactly the git plumbing.
+    (it "errors when not inside a git repository"
+      (let ((default-directory (make-temp-file "copilot-no-repo" t)))
+        (expect (copilot-chat--changed-files) :to-throw 'user-error)))
+
+    (it "errors when there are no uncommitted changes"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (write-region "hello\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "f.txt")
+        (process-file "git" nil nil nil
+                      "-c" "user.email=t@t" "-c" "user.name=t"
+                      "commit" "-q" "-m" "init")
+        (expect (copilot-chat--changed-files) :to-throw 'user-error)))
+
+    (it "lists staged and unstaged changes but not deletions"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (dolist (f '("modified.txt" "staged.txt" "deleted.txt"))
+          (write-region "hello\n" nil (expand-file-name f) nil 'quiet))
+        (process-file "git" nil nil nil "add" ".")
+        (process-file "git" nil nil nil
+                      "-c" "user.email=t@t" "-c" "user.name=t"
+                      "commit" "-q" "-m" "init")
+        (write-region "changed\n" nil (expand-file-name "modified.txt") nil 'quiet)
+        (write-region "restaged\n" nil (expand-file-name "staged.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "staged.txt")
+        (delete-file (expand-file-name "deleted.txt"))
+        (expect (sort (copilot-chat--changed-files) #'string<)
+                :to-equal '("modified.txt" "staged.txt"))))
+
+    (it "does not report untracked files"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (write-region "hello\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "f.txt")
+        (process-file "git" nil nil nil
+                      "-c" "user.email=t@t" "-c" "user.name=t"
+                      "commit" "-q" "-m" "init")
+        (write-region "changed\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (write-region "loose\n" nil (expand-file-name "untracked.txt") nil 'quiet)
+        (expect (copilot-chat--changed-files) :to-equal '("f.txt")))))
+
+  (describe "copilot-chat--uncommitted-changes"
+    (it "pairs each change with its base and head content"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (write-region "old\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "f.txt")
+        (process-file "git" nil nil nil
+                      "-c" "user.email=t@t" "-c" "user.name=t"
+                      "commit" "-q" "-m" "init")
+        (write-region "new\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (write-region "added\n" nil (expand-file-name "g.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "g.txt")
+        (let* ((root (copilot-chat--repo-root))
+               (changes (copilot-chat--uncommitted-changes root))
+               (f (seq-find (lambda (c) (equal (plist-get c :path) "f.txt"))
+                            changes))
+               (g (seq-find (lambda (c) (equal (plist-get c :path) "g.txt"))
+                            changes)))
+          (expect (length changes) :to-equal 2)
+          (expect (plist-get f :baseContent) :to-equal "old\n")
+          (expect (plist-get f :headContent) :to-equal "new\n")
+          (expect (plist-get f :uri) :to-match "\\`file://.*/f\\.txt\\'")
+          ;; A newly added file has no base version.
+          (expect (plist-get g :baseContent) :to-equal "")
+          (expect (plist-get g :headContent) :to-equal "added\n"))))
+
+    (it "skips binary files"
+      (let ((default-directory (make-temp-file "copilot-repo" t)))
+        (process-file "git" nil nil nil "init" "-q")
+        (write-region "text\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (process-file "git" nil nil nil "add" "f.txt")
+        (process-file "git" nil nil nil
+                      "-c" "user.email=t@t" "-c" "user.name=t"
+                      "commit" "-q" "-m" "init")
+        (write-region "more text\n" nil (expand-file-name "f.txt") nil 'quiet)
+        (let ((coding-system-for-write 'binary))
+          (write-region (unibyte-string 0 1 2 3) nil
+                        (expand-file-name "blob.bin") nil 'quiet))
+        (process-file "git" nil nil nil "add" "blob.bin")
+        (let* ((root (copilot-chat--repo-root))
+               (changes (copilot-chat--uncommitted-changes root)))
+          (expect (mapcar (lambda (c) (plist-get c :path)) changes)
+                  :to-equal '("f.txt"))))))
+
+  (describe "copilot-chat-review-changes"
+    (before-each
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'display-buffer)
+      (spy-on 'message)
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name)))
+
+    (after-each
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name)))
+
+    (it "sends the changes to copilot/codeReview/reviewChanges"
+      (let ((captured-method nil)
+            (captured-params nil))
+        (spy-on 'copilot-chat--repo-root :and-return-value "/repo/")
+        (spy-on 'copilot-chat--uncommitted-changes :and-return-value
+                '((:uri "file:///repo/a.el" :path "a.el"
+                   :baseContent "old" :headContent "new")))
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured-method method
+                        captured-params params)
+                  (cons nil nil)))
+        (copilot-chat-review-changes)
+        (expect captured-method :to-equal 'copilot/codeReview/reviewChanges)
+        (let ((changes (plist-get captured-params :changes)))
+          (expect (length changes) :to-equal 1)
+          (expect (aref changes 0)
+                  :to-equal '(:uri "file:///repo/a.el" :path "a.el"
+                              :baseContent "old" :headContent "new")))
+        (expect (plist-get captured-params :workspaceFolders)
+                :to-equal (vector '(:uri "file:///repo" :name "repo")))))
+
+    (it "renders the returned comments in the chat buffer"
+      (let ((captured-args nil))
+        (spy-on 'copilot-chat--repo-root :and-return-value "/repo/")
+        (spy-on 'copilot-chat--uncommitted-changes :and-return-value
+                '((:uri "file:///repo/a.el" :path "a.el"
+                   :baseContent "old" :headContent "new")))
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (setq captured-args args)
+                  (cons nil nil)))
+        (copilot-chat-review-changes)
+        (funcall (plist-get captured-args :success-fn)
+                 '(:comments
+                   [(:uri "file:///repo/a.el"
+                     :range (:start (:line 4 :character 0)
+                             :end (:line 4 :character 10))
+                     :message "Something is off here"
+                     :kind "bug"
+                     :severity "medium"
+                     :suggestion "a fixed line")]))
+        (with-current-buffer copilot-chat--buffer-name
+          ;; Zero-based server line 4 is user-visible line 5.
+          (expect (buffer-string) :to-match "a\\.el:5")
+          (expect (buffer-string) :to-match "\\[bug\\]")
+          (expect (buffer-string) :to-match "Something is off here")
+          (expect (buffer-string) :to-match "Suggested change:")
+          (expect (buffer-string) :to-match "a fixed line"))))
+
+    (it "reports a clean review when no comments come back"
+      (let ((captured-args nil))
+        (spy-on 'copilot-chat--repo-root :and-return-value "/repo/")
+        (spy-on 'copilot-chat--uncommitted-changes :and-return-value
+                '((:uri "file:///repo/a.el" :path "a.el"
+                   :baseContent "old" :headContent "new")))
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (setq captured-args args)
+                  (cons nil nil)))
+        (copilot-chat-review-changes)
+        (funcall (plist-get captured-args :success-fn) '(:comments []))
+        (with-current-buffer copilot-chat--buffer-name
+          (expect (buffer-string) :to-match "No review comments"))))
+
+    (it "shows the server's error when the review is unavailable"
+      (let ((captured-args nil))
+        (spy-on 'copilot-chat--repo-root :and-return-value "/repo/")
+        (spy-on 'copilot-chat--uncommitted-changes :and-return-value
+                '((:uri "file:///repo/a.el" :path "a.el"
+                   :baseContent "old" :headContent "new")))
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (setq captured-args args)
+                  (cons nil nil)))
+        (copilot-chat-review-changes)
+        (funcall (plist-get captured-args :error-fn)
+                 '(:code -32603
+                   :message "GitHub Copilot Code Review is not enabled."))
+        (with-current-buffer copilot-chat--buffer-name
+          (expect (buffer-string)
+                  :to-match "GitHub Copilot Code Review is not enabled\\.")))))
+
+  (describe "copilot-chat-review-region"
+    (before-each
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'display-buffer)
+      (spy-on 'message)
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name)))
+
+    (after-each
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name)))
+
+    (it "errors when the buffer visits no file"
+      (with-temp-buffer
+        (insert "code\n")
+        (expect (copilot-chat-review-region (point-min) (point-max))
+                :to-throw 'user-error)))
+
+    (it "sends the selection as a whole-line snippet with one-based lines"
+      (let ((captured-method nil)
+            (captured-params nil))
+        (spy-on 'copilot--workspace-root :and-return-value "/repo/")
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured-method method
+                        captured-params params)
+                  (cons nil nil)))
+        (with-temp-buffer
+          (insert "line one\nline two\nline three\n")
+          (setq buffer-file-name "/repo/src/f.el")
+          ;; Region from the middle of line 1 to the middle of line 2.
+          (copilot-chat-review-region (+ (point-min) 5) 14)
+          (set-buffer-modified-p nil))
+        (expect captured-method :to-equal 'copilot/codeReview/reviewSnippets)
+        (let ((snippet (aref (plist-get captured-params :snippets) 0)))
+          (expect (plist-get snippet :uri) :to-equal "file:///repo/src/f.el")
+          (expect (plist-get snippet :path) :to-equal "src/f.el")
+          (expect (plist-get snippet :content) :to-equal "line one\nline two")
+          (expect (plist-get snippet :startLine) :to-equal 1)
+          (expect (plist-get snippet :endLine) :to-equal 2))))
+
+    (it "does not include the line a region ends at the start of"
+      (let ((captured-params nil))
+        (spy-on 'copilot--workspace-root :and-return-value "/repo/")
+        (spy-on 'jsonrpc--async-request-1
+                :and-call-fake
+                (lambda (_conn _method params &rest _args)
+                  (setq captured-params params)
+                  (cons nil nil)))
+        (with-temp-buffer
+          (insert "line one\nline two\nline three\n")
+          (setq buffer-file-name "/repo/f.el")
+          ;; Region covering lines 1-2 whose end sits at the start of
+          ;; line 3, as a line-wise selection typically does.
+          (copilot-chat-review-region (point-min) 19)
+          (set-buffer-modified-p nil))
+        (let ((snippet (aref (plist-get captured-params :snippets) 0)))
+          (expect (plist-get snippet :content) :to-equal "line one\nline two")
+          (expect (plist-get snippet :endLine) :to-equal 2)))))
+
+  (describe "copilot-chat--format-review-comment"
+    (it "renders location, kind, message, and suggestion"
+      (let ((rendered (copilot-chat--format-review-comment
+                       '(:uri "file:///repo/src/a.el"
+                         :range (:start (:line 0 :character 2)
+                                 :end (:line 1 :character 4))
+                         :message "Watch out"
+                         :kind "consistency"
+                         :suggestion "(safer)")
+                       "/repo/")))
+        (expect rendered :to-match "\\*\\*src/a\\.el:1\\*\\* \\[consistency\\]")
+        (expect rendered :to-match "Watch out")
+        (expect rendered :to-match "Suggested change:")
+        (expect rendered :to-match "(safer)")))
+
+    (it "omits the suggestion block when there is none"
+      (let ((rendered (copilot-chat--format-review-comment
+                       '(:uri "file:///elsewhere/b.el"
+                         :range (:start (:line 9 :character 0)
+                                 :end (:line 9 :character 5))
+                         :message "Hmm"
+                         :kind "bug"
+                         :suggestion nil)
+                       "/repo/")))
+        ;; A file outside the root keeps its full path.
+        (expect rendered :to-match "/elsewhere/b\\.el:10")
+        (expect rendered :not :to-match "Suggested change:"))))
+
   (describe "copilot-chat-insert-commit-message"
     (it "errors before sending when the diff cannot be collected"
       (spy-on 'copilot-chat--staged-diff :and-throw-error 'user-error)


### PR DESCRIPTION
Wires up the language server's native code review, which turned out to live behind two dedicated requests rather than the conversation protocol (established by mining the 1.517.0 bundle): `copilot/codeReview/reviewChanges` takes `{changes: [{uri, path, baseContent, headContent}]}` and `copilot/codeReview/reviewSnippets` takes line-ranged snippets; both return structured `{comments}` with ranges, messages, and suggestions, no streaming involved. The backend is the same `agents/github-code-review` service as GitHub's Copilot Code Review, and the server enforces the entitlement (a clear error is surfaced when the account doesn't have it).

Two commands:

- `copilot-chat-review-changes` reviews the uncommitted diff against HEAD (staged and unstaged, deletions excluded, binary and oversized files skipped, base content from `git show`, all through `process-file` so TRAMP works).
- `copilot-chat-review-region` reviews the selection as a whole-line snippet.

Comments render in the chat buffer as `path:line [kind]` entries with fenced suggestions. The prompt-based `copilot-chat-review` from #514 stays as is, since Code Review is a separate entitlement.

The adversarial review pass caught a would-be dead-on-arrival bug (second commit): jsonrpc's default 10-second request timeout silently dropped any review taking longer, which is most real ones (the server itself allows 120s); the request now runs with a 130s timeout and a visible timeout handler. Also fixed there: dirty submodule entries no longer abort the collection, `--no-relative` protects against `diff.relative`, unborn HEAD gets an accurate error, reviews refuse to interleave with a streaming chat answer, suggestion fences outgrow embedded backticks, and narrowed buffers send absolute line numbers.

503 specs pass, checkdoc clean, no new compile warnings.