### PR TITLE
Add chat presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- Add `copilot-chat-presets`, named bundles of chat settings (model, agent mode, auto-approved tools) that `copilot-chat-apply-preset` switches between in one step. A preset only touches the settings it lists, and the model and agent mode take effect on the next new conversation.
+- Add `copilot-chat-presets`, named bundles of chat settings (model, agent mode, auto-approved tools) that `copilot-chat-apply-preset` switches between in one step. A preset only touches the settings it lists; its model takes effect on your next message and its agent mode on the next new conversation.
 - Show a status header line in the chat buffer with the chat mode (Agent or Ask), the active model, and in agent mode the number of available tools; disable it with `copilot-chat-show-status-header`. ([#509](https://github.com/copilot-emacs/copilot.el/discussions/509))
 - Add one-shot chat task commands that send the active region (or the defun at point) with a canned prompt, with the answer streaming into the regular chat buffer. The prompts are customizable via `copilot-chat-task-prompts`, and `copilot-chat-task` picks a task with completion:
   - `copilot-chat-review`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Add `copilot-chat-presets`, named bundles of chat settings (model, agent mode, auto-approved tools) that `copilot-chat-apply-preset` switches between in one step. A preset only touches the settings it lists, and the model and agent mode take effect on the next new conversation.
 - Show a status header line in the chat buffer with the chat mode (Agent or Ask), the active model, and in agent mode the number of available tools; disable it with `copilot-chat-show-status-header`. ([#509](https://github.com/copilot-emacs/copilot.el/discussions/509))
 - Add one-shot chat task commands that send the active region (or the defun at point) with a canned prompt, with the answer streaming into the regular chat buffer. The prompts are customizable via `copilot-chat-task-prompts`, and `copilot-chat-task` picks a task with completion:
   - `copilot-chat-review`

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Customization:
 - **`copilot-chat-history-directory`** — where saved transcripts live, one file per workspace (default `~/.emacs.d/copilot-chat-history/`)
 - **`copilot-chat-presets`** — named bundles of chat settings you can switch between with `copilot-chat-apply-preset` (default `nil`)
 
-If you often flip between a couple of setups (say a quick ask-mode model and a tool-capable agent-mode one), collect them as presets and switch with `M-x copilot-chat-apply-preset`. A preset is a plist that may set `:model`, `:agent-mode`, and `:auto-approve-tools`; any key you leave out is untouched. Because the model and agent mode are read when a conversation is created, applying a preset takes effect on the next new conversation (an existing one keeps its model until it is reset).
+If you often flip between a couple of setups (say a quick ask-mode model and a tool-capable agent-mode one), collect them as presets and switch with `M-x copilot-chat-apply-preset`. A preset is a plist that may set `:model`, `:agent-mode`, and `:auto-approve-tools`; any key you leave out is untouched. A preset's model takes effect on your next message (the model is sent with every turn, so even the current conversation switches), while agent mode takes effect on the next new conversation, since it is fixed when a conversation is created.
 
 ```elisp
 (setopt copilot-chat-presets

--- a/README.md
+++ b/README.md
@@ -267,6 +267,16 @@ Customization:
 - **`copilot-chat-auto-approve-tools`** — tool names that skip the confirmation prompt (default `'("get_errors")`)
 - **`copilot-chat-save-history`** — save the chat transcript to disk after each turn, for `copilot-chat-restore` (default `nil`)
 - **`copilot-chat-history-directory`** — where saved transcripts live, one file per workspace (default `~/.emacs.d/copilot-chat-history/`)
+- **`copilot-chat-presets`** — named bundles of chat settings you can switch between with `copilot-chat-apply-preset` (default `nil`)
+
+If you often flip between a couple of setups (say a quick ask-mode model and a tool-capable agent-mode one), collect them as presets and switch with `M-x copilot-chat-apply-preset`. A preset is a plist that may set `:model`, `:agent-mode`, and `:auto-approve-tools`; any key you leave out is untouched. Because the model and agent mode are read when a conversation is created, applying a preset takes effect on the next new conversation (an existing one keeps its model until it is reset).
+
+```elisp
+(setopt copilot-chat-presets
+        '(("fast"  . (:model "gpt-4o" :agent-mode nil))
+          ("agent" . (:model "gpt-5-codex" :agent-mode t
+                      :auto-approve-tools ("get_errors" "copilot.read_file")))))
+```
 
 At each tool confirmation prompt you can answer `yes`, `no`, or `always`; `always` approves that tool for the rest of the conversation so it stops asking.
 
@@ -514,6 +524,7 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-chat-restore` | Restore the saved chat for the current workspace |
 | `copilot-chat-clear-history` | Delete the saved chat history for the current workspace |
 | `copilot-chat-insert-commit-message` | Generate a commit message for the staged changes and insert it at point |
+| `copilot-chat-apply-preset` | Switch to a named bundle of chat settings from `copilot-chat-presets` |
 | **Next Edit Suggestions** | |
 | `copilot-nes-mode` | Toggle NES in the current buffer |
 | `copilot-nes-accept` | Accept (or jump to) the current NES suggestion |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -101,9 +101,10 @@ optional:
 A key omitted from a preset leaves the corresponding variable
 untouched, so a preset can change just a single setting.
 
-Because the model and agent mode are read when a conversation is
-created, applying a preset takes effect on the next new conversation;
-an existing conversation keeps its model until it is reset.
+A preset's model takes effect on your next message, including the
+current conversation, since the model is sent with every turn.  Agent
+mode takes effect on the next new conversation, since it is fixed when
+a conversation is created.
 
 Example:
 
@@ -2967,9 +2968,11 @@ left untouched.
 Called interactively, NAME is read with completion from
 `copilot-chat-presets'.
 
-The model and agent mode take effect on the next new conversation; an
-existing conversation keeps its model until it is reset.  See
-`copilot-chat-presets' for the recognized keys and an example."
+The model takes effect on your next message, including the current
+conversation (the model is sent with every turn).  Agent mode takes
+effect on the next new conversation, since it is fixed when a
+conversation is created.  See `copilot-chat-presets' for the recognized
+keys and an example."
   (interactive
    (list (progn
            (unless copilot-chat-presets
@@ -2983,6 +2986,10 @@ existing conversation keeps its model until it is reset.  See
     (unless entry
       (user-error "Copilot Chat: Unknown preset %S" name))
     (let ((preset (cdr entry)))
+      (when (and (plist-member preset :auto-approve-tools)
+                 (not (listp (plist-get preset :auto-approve-tools))))
+        (user-error
+         "Copilot Chat: Preset %S has a non-list `:auto-approve-tools'" name))
       (when (plist-member preset :model)
         (setq copilot-chat-model (plist-get preset :model)
               ;; Forget any cached default so clearing the model later

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -87,6 +87,39 @@ match."
   :group 'copilot-chat
   :package-version '(copilot . "0.6"))
 
+(defcustom copilot-chat-presets nil
+  "Named bundles of Copilot Chat settings you can switch between.
+Each entry maps a preset name (a string) to a plist of settings that
+`copilot-chat-apply-preset' applies in one step.  Recognized keys, all
+optional:
+
+  `:model'              a chat model id string (sets `copilot-chat-model')
+  `:agent-mode'         a boolean (sets `copilot-chat-use-agent-mode')
+  `:auto-approve-tools' a list of tool-name strings
+                        (sets `copilot-chat-auto-approve-tools')
+
+A key omitted from a preset leaves the corresponding variable
+untouched, so a preset can change just a single setting.
+
+Because the model and agent mode are read when a conversation is
+created, applying a preset takes effect on the next new conversation;
+an existing conversation keeps its model until it is reset.
+
+Example:
+
+  \\='((\"fast\"  . (:model \"gpt-4o\" :agent-mode nil))
+    (\"agent\" . (:model \"gpt-5-codex\" :agent-mode t
+               :auto-approve-tools (\"get_errors\" \"copilot.read_file\"))))"
+  :type '(alist :key-type (string :tag "Preset name")
+                :value-type
+                (plist :options
+                       ((:model (string :tag "Model ID"))
+                        (:agent-mode (boolean :tag "Agent mode"))
+                        (:auto-approve-tools
+                         (repeat (string :tag "Tool name"))))))
+  :group 'copilot-chat
+  :package-version '(copilot . "0.8"))
+
 (defcustom copilot-chat-preview-tool-edits t
   "When non-nil, preview file changes before confirming an edit tool.
 For the tools that create or edit files (`create_file',
@@ -2921,6 +2954,60 @@ well; the saved history file on disk, if any, is left untouched (see
           ;; re-resolves from the server.
           copilot-chat--model-resolved nil)
     (message "Copilot Chat: Model set to %s" model-id)))
+
+;;;###autoload
+(defun copilot-chat-apply-preset (name)
+  "Apply the Copilot Chat preset named NAME from `copilot-chat-presets'.
+A preset is a plist of settings; each present key sets its variable
+\(`:model' sets `copilot-chat-model', `:agent-mode' sets
+`copilot-chat-use-agent-mode', `:auto-approve-tools' sets
+`copilot-chat-auto-approve-tools'), and any key the preset omits is
+left untouched.
+
+Called interactively, NAME is read with completion from
+`copilot-chat-presets'.
+
+The model and agent mode take effect on the next new conversation; an
+existing conversation keeps its model until it is reset.  See
+`copilot-chat-presets' for the recognized keys and an example."
+  (interactive
+   (list (progn
+           (unless copilot-chat-presets
+             (user-error "Copilot Chat: `copilot-chat-presets' is empty"))
+           (completing-read "Copilot Chat preset: "
+                            (mapcar #'car copilot-chat-presets) nil t))))
+  (unless copilot-chat-presets
+    (user-error "Copilot Chat: `copilot-chat-presets' is empty"))
+  (let ((entry (assoc name copilot-chat-presets))
+        (changes nil))
+    (unless entry
+      (user-error "Copilot Chat: Unknown preset %S" name))
+    (let ((preset (cdr entry)))
+      (when (plist-member preset :model)
+        (setq copilot-chat-model (plist-get preset :model)
+              ;; Forget any cached default so clearing the model later
+              ;; re-resolves from the server, mirroring
+              ;; `copilot-chat-select-model'.
+              copilot-chat--model-resolved nil)
+        (push (format "model %s" (or copilot-chat-model "default")) changes))
+      (when (plist-member preset :agent-mode)
+        (setq copilot-chat-use-agent-mode (plist-get preset :agent-mode))
+        (push (format "agent mode %s"
+                      (if copilot-chat-use-agent-mode "on" "off"))
+              changes))
+      (when (plist-member preset :auto-approve-tools)
+        (setq copilot-chat-auto-approve-tools
+              (plist-get preset :auto-approve-tools))
+        (push (format "auto-approved tools: %s"
+                      (if copilot-chat-auto-approve-tools
+                          (string-join copilot-chat-auto-approve-tools ", ")
+                        "none"))
+              changes)))
+    (message "Copilot Chat: Applied preset %S%s"
+             name
+             (if changes
+                 (format " (%s)" (string-join (nreverse changes) ", "))
+               ""))))
 
 (provide 'copilot-chat)
 ;;; copilot-chat.el ends here

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -3628,6 +3628,71 @@
           (insert "OLD")
           (copilot-chat-rewrite (point-min) (point-max) "rewrite")
           (funcall reply-fn "NEW" nil))
-        (expect 'indent-region :not :to-have-been-called)))))
+        (expect 'indent-region :not :to-have-been-called))))
+
+  (describe "copilot-chat-apply-preset"
+    (before-each
+      (setq copilot-chat-presets
+            '(("fast" . (:model "gpt-4o" :agent-mode nil))
+              ("agent" . (:model "gpt-5-codex" :agent-mode t
+                          :auto-approve-tools ("get_errors"
+                                               "copilot.read_file")))
+              ("ask-off" . (:agent-mode nil))))
+      (spy-on 'message))
+
+    (it "applies only the keys the preset carries"
+      (let ((copilot-chat-model "old-model")
+            (copilot-chat-use-agent-mode t)
+            (copilot-chat-auto-approve-tools '("keep")))
+        (copilot-chat-apply-preset "ask-off")
+        (expect copilot-chat-use-agent-mode :to-be nil)
+        (expect copilot-chat-model :to-equal "old-model")
+        (expect copilot-chat-auto-approve-tools :to-equal '("keep"))))
+
+    (it "sets every key the preset carries"
+      (let ((copilot-chat-model nil)
+            (copilot-chat-use-agent-mode nil)
+            (copilot-chat-auto-approve-tools nil))
+        (copilot-chat-apply-preset "agent")
+        (expect copilot-chat-model :to-equal "gpt-5-codex")
+        (expect copilot-chat-use-agent-mode :to-be t)
+        (expect copilot-chat-auto-approve-tools
+                :to-equal '("get_errors" "copilot.read_file"))))
+
+    (it "resets the resolved-model cache when it sets the model"
+      (let ((copilot-chat-model nil)
+            (copilot-chat--model-resolved t))
+        (copilot-chat-apply-preset "fast")
+        (expect copilot-chat--model-resolved :to-be nil)))
+
+    (it "leaves the resolved-model cache alone when the model is absent"
+      (let ((copilot-chat-model "kept")
+            (copilot-chat--model-resolved t))
+        (copilot-chat-apply-preset "ask-off")
+        (expect copilot-chat--model-resolved :to-be t)))
+
+    (it "reports the applied preset and what changed"
+      (let ((copilot-chat-model nil)
+            (copilot-chat-use-agent-mode nil))
+        (copilot-chat-apply-preset "fast")
+        (expect 'message :to-have-been-called-with
+                "Copilot Chat: Applied preset %S%s"
+                "fast" " (model gpt-4o, agent mode off)")))
+
+    (it "errors on an unknown preset"
+      (expect (copilot-chat-apply-preset "nope") :to-throw 'user-error))
+
+    (it "errors when no presets are configured"
+      (let ((copilot-chat-presets nil))
+        (expect (copilot-chat-apply-preset "fast") :to-throw 'user-error)))
+
+    (it "reads the preset name with completion when called interactively"
+      (let ((copilot-chat-model nil)
+            (copilot-chat-use-agent-mode t))
+        (spy-on 'completing-read :and-return-value "fast")
+        (call-interactively 'copilot-chat-apply-preset)
+        (expect 'completing-read :to-have-been-called)
+        (expect copilot-chat-model :to-equal "gpt-4o")
+        (expect copilot-chat-use-agent-mode :to-be nil)))))
 
 ;;; copilot-chat-test.el ends here

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -3671,6 +3671,16 @@
         (copilot-chat-apply-preset "ask-off")
         (expect copilot-chat--model-resolved :to-be t)))
 
+    (it "rejects a non-list :auto-approve-tools without mutating anything"
+      (let ((copilot-chat-presets '(("bad" . (:model "m"
+                                              :auto-approve-tools "oops"))))
+            (copilot-chat-model "before")
+            (copilot-chat-auto-approve-tools '("keep")))
+        (expect (copilot-chat-apply-preset "bad") :to-throw 'user-error)
+        ;; Validation happens before any setq, so nothing is half-applied.
+        (expect copilot-chat-model :to-equal "before")
+        (expect copilot-chat-auto-approve-tools :to-equal '("keep"))))
+
     (it "reports the applied preset and what changed"
       (let ((copilot-chat-model nil)
             (copilot-chat-use-agent-mode nil))


### PR DESCRIPTION
Adds `copilot-chat-presets` and `copilot-chat-apply-preset`, the gptel-presets pattern: name a bundle of chat settings (`:model`, `:agent-mode`, `:auto-approve-tools`) and switch to it in one step. A preset only touches the keys it lists (via `plist-member`, so `:agent-mode nil` genuinely turns agent mode off while an omitted key is left alone). Its model takes effect on your next message and its agent mode on the next new conversation.

Example:

```elisp
(setopt copilot-chat-presets
        '(("fast"  . (:model "gpt-4o" :agent-mode nil))
          ("agent" . (:model "gpt-5-codex" :agent-mode t
                      :auto-approve-tools ("get_errors")))))
```

The adversarial review caught that the original docs claimed an existing conversation keeps its model until reset; that has been false since #508 made the model ship on every turn, so the docstring, README, and CHANGELOG now describe the real per-message-vs-per-conversation split. It also flagged a bare-string `:auto-approve-tools` half-applying then erroring, so applying a preset now validates that key up front.

541 specs pass, checkdoc clean, no new compile warnings.