### PR TITLE
Let users edit a tool's input before it runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Optionally persist chat sessions across Emacs restarts: with `copilot-chat-save-history` enabled (off by default) the transcript is saved after each turn to a per-workspace file under `copilot-chat-history-directory`, `copilot-chat-restore` brings the saved conversation back with its full context, and `copilot-chat-clear-history` deletes the saved file.
 - Handle the server's `copilot/codingAgentMessage` request, so updates from GitHub's cloud coding agent (e.g. the pull request it opens to continue delegated work) are echoed and recorded in the `*copilot-coding-agent*` buffer instead of being dropped.
 - Add `copilot-menu`, a transient (magit-style) menu that gathers the most common Copilot commands (completions, chat, agent mode, account and usage info, and server management) and shows the current state of `copilot-mode`, agent mode, and the selected chat model. Requires the `transient` package (bundled with Emacs 28.1 and newer) but only when the menu itself is used.
+- Add an `edit` choice at the agent-mode tool-confirmation prompt for the tools copilot.el runs itself, letting you tweak the input before it runs: the shell command of `run_in_terminal`, the content of `create_file` (in a temporary buffer), or the URLs of `fetch_web_page`. Server-executed and MCP tools keep the plain yes/no/always prompt, since the server never reads a modified input back.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ If you often flip between a couple of setups (say a quick ask-mode model and a t
 
 At each tool confirmation prompt you can answer `yes`, `no`, or `always`; `always` approves that tool for the rest of the conversation so it stops asking.
 
+For the tools copilot.el runs itself, the prompt also offers `edit`, which lets you change the input before the tool runs: the shell command of `run_in_terminal`, the content of `create_file` (edited in a temporary buffer, confirmed with `C-c C-c` or cancelled with `C-c C-k`), or the URLs of `fetch_web_page`. The tool then runs once with your edited input. Server-executed and MCP tools do not offer `edit`, since the server does not accept a modified input back.
+
 > [!IMPORTANT]
 >
 > Agent mode only works with a model that can call tools. Some chat models (and whatever default the server resolves when `copilot-chat-model` is `nil`) can't, and then Copilot just describes the commands to run instead of running them, so agent mode looks inactive. Pick a tool-capable model with `M-x copilot-chat-select-model`. copilot.el also warns when it starts an agent-mode conversation whose model lacks tool support.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -786,16 +786,25 @@ Return nil for tools that do not write files."
 (defun copilot-chat--ask-tool (msg)
   "Prompt to approve the tool described by MSG.
 Return `allow' (run it once), `always' (run it and skip future prompts
-for this tool this session), or `deny'."
-  (pcase (car (read-multiple-choice
-               (copilot-chat--confirmation-prompt msg)
-               '((?y "yes" "Allow this tool call")
-                 (?n "no" "Decline this tool call")
-                 (?a "always"
-                     "Allow this and future calls to this tool this session"))))
-    (?y 'allow)
-    (?a 'always)
-    (_ 'deny)))
+for this tool this session), `edit' (edit its input, then run it once),
+or `deny'.  The `edit' choice is offered only for tools copilot.el runs
+itself that have a meaningful editable field (see
+`copilot-chat--tool-editable-field')."
+  (let ((choices
+         (append
+          '((?y "yes" "Allow this tool call")
+            (?n "no" "Decline this tool call")
+            (?a "always"
+                "Allow this and future calls to this tool this session"))
+          (when (copilot-chat--tool-editable-field (plist-get msg :name))
+            '((?e "edit"
+                  "Edit this tool's input, then allow it once"))))))
+    (pcase (car (read-multiple-choice
+                 (copilot-chat--confirmation-prompt msg) choices))
+      (?y 'allow)
+      (?a 'always)
+      (?e 'edit)
+      (_ 'deny))))
 
 (defun copilot-chat--confirm-with-preview (msg preview)
   "Show PREVIEW in a temporary window, then prompt to confirm MSG.
@@ -838,6 +847,111 @@ confirmation time."
   (mapcar (lambda (def) (plist-get def :name))
           (copilot-chat--tool-definitions)))
 
+(defconst copilot-chat--tool-editable-fields
+  '(("run_in_terminal" . :command)
+    ("create_file" . :content)
+    ("fetch_web_page" . :urls))
+  "Map from a client tool's name to the input field the user may edit.
+Only the tools copilot.el runs itself appear here, because the server
+never reads a modified input back: editing is possible only for input
+copilot.el consumes when it invokes the tool.  `get_errors' is omitted,
+as its only input is a list of file paths with nothing useful to
+hand-edit.")
+
+(defun copilot-chat--tool-editable-field (name)
+  "Return the editable input field for tool NAME, or nil.
+NAME must be the exact name copilot.el registered (run_in_terminal and
+friends): namespaced server tools, even ones whose base name collides
+with a client tool, are executed by the server and so cannot be edited."
+  (and (member name (copilot-chat--client-tool-names))
+       (cdr (assoc name copilot-chat--tool-editable-fields))))
+
+(defvar copilot-chat--tool-edits nil
+  "Alist of pending user-edited tool inputs, keyed by tool call.
+Populated when the user picks `edit' at a confirmation prompt and
+consumed when the matching `conversation/invokeClientTool' request
+arrives, so the edited input is used in place of the server's.  Kept as
+global state because both the confirmation and the invocation are handled
+in the JSON-RPC dispatcher rather than in the chat buffer.")
+
+(defun copilot-chat--tool-edit-key (msg)
+  "Return the key that ties a stashed edit to its later invocation for MSG.
+Prefer the server's `toolCallId', which is carried on both the
+confirmation and the invocation request; fall back to the tool name,
+which is safe because the server processes tool calls sequentially,
+awaiting each confirmation before invoking."
+  (or (plist-get msg :toolCallId)
+      (copilot-chat--tool-base-name (plist-get msg :name))))
+
+(defun copilot-chat--stash-tool-edit (msg input)
+  "Remember edited INPUT for the tool call described by MSG."
+  (setf (alist-get (copilot-chat--tool-edit-key msg)
+                   copilot-chat--tool-edits nil nil #'equal)
+        input))
+
+(defun copilot-chat--take-tool-edit (msg)
+  "Return and forget any stashed edited input for MSG, or nil when none."
+  (let ((key (copilot-chat--tool-edit-key msg)))
+    (prog1 (alist-get key copilot-chat--tool-edits nil nil #'equal)
+      (setf (alist-get key copilot-chat--tool-edits nil t #'equal) nil))))
+
+(defvar copilot-chat--tool-edit-keymap
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'exit-recursive-edit)
+    (define-key map (kbd "C-c C-k") #'abort-recursive-edit)
+    map)
+  "Keymap active while editing a multi-line tool argument in a buffer.
+Keys it does not bind fall through to the global map, so ordinary text
+editing works as usual.")
+
+(defun copilot-chat--edit-in-buffer (initial description)
+  "Let the user edit INITIAL in a temporary buffer and return the new text.
+DESCRIPTION names the value being edited and appears in the header line.
+Editing runs in a recursive edit, keyed by
+`copilot-chat--tool-edit-keymap'; cancelling signals `quit'."
+  (let ((buf (generate-new-buffer "*copilot-chat-tool-edit*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (insert (or initial ""))
+            (goto-char (point-min))
+            (use-local-map copilot-chat--tool-edit-keymap)
+            (setq header-line-format
+                  (substitute-command-keys
+                   (format "Edit %s, then \\[exit-recursive-edit] to accept \
+or \\[abort-recursive-edit] to cancel"
+                           description))))
+          (pop-to-buffer buf)
+          (recursive-edit)
+          (with-current-buffer buf (buffer-string)))
+      (when-let* ((win (get-buffer-window buf)))
+        (quit-window nil win))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(defun copilot-chat--read-tool-field (field current)
+  "Read a replacement value for tool input FIELD, defaulting to CURRENT.
+Return the value in the shape the field expects: a string for `:command',
+a string for `:content', and a vector of strings for `:urls'."
+  (pcase field
+    (:command (read-string "Copilot Chat: edit command: " current))
+    (:content (copilot-chat--edit-in-buffer current "file content"))
+    (:urls (vconcat (split-string
+                     (read-string "Copilot Chat: edit URLs (space-separated): "
+                                  (mapconcat #'identity (append current nil) " "))
+                     nil t)))))
+
+(defun copilot-chat--read-tool-edit (msg)
+  "Prompt for a new value for MSG's editable field and stash it.
+Read a replacement for the field named by
+`copilot-chat--tool-editable-field', then remember a copy of the tool
+input with that field replaced, keyed so the later invocation picks it
+up.  A cancelled edit signals `quit' and leaves the stash untouched."
+  (let* ((name (plist-get msg :name))
+         (input (plist-get msg :input))
+         (field (copilot-chat--tool-editable-field name))
+         (new (copilot-chat--read-tool-field field (plist-get input field))))
+    (copilot-chat--stash-tool-edit msg (plist-put (copy-sequence input) field new))))
+
 (defun copilot-chat--log-server-tool (msg)
   "Insert a status line for a server-executed tool approved via MSG.
 The server runs its own built-in and MCP tools internally, so for the
@@ -862,6 +976,11 @@ at the prompt remembers the tool for the rest of the conversation."
         (copilot-chat--accept-tool msg)
       (pcase (copilot-chat--confirm-tool msg)
         ('deny (list :result "dismiss"))
+        ('edit
+         ;; Stash the edited input now; the server reads only the result
+         ;; here and sends the input in a separate invocation request.
+         (copilot-chat--read-tool-edit msg)
+         (copilot-chat--accept-tool msg))
         (decision
          (when (eq decision 'always)
            (cl-pushnew (copilot-chat--tool-base-name name)
@@ -1083,7 +1202,9 @@ both are on), and report when no backend is available at all."
   "Handle `conversation/invokeClientTool' request MSG.
 Dispatch to the appropriate tool and return a LanguageModelToolResult."
   (let ((name (plist-get msg :name))
-        (input (plist-get msg :input)))
+        ;; Prefer an input the user edited at confirmation time, if any.
+        (input (or (copilot-chat--take-tool-edit msg)
+                   (plist-get msg :input))))
     (pcase name
       ("run_in_terminal" (copilot-chat--execute-run-in-terminal input))
       ("create_file" (copilot-chat--execute-create-file input))
@@ -1519,8 +1640,10 @@ turnId.  Turns restored by `copilot-chat-restore' are replayed ahead
 of MESSAGE, so the new conversation picks up the saved context."
   (let ((token (format "copilot-chat-%s" (float-time)))
         (restored nil))
-    ;; A fresh conversation starts with a clean slate of session approvals.
+    ;; A fresh conversation starts with a clean slate of session approvals
+    ;; and no leftover tool-input edits.
     (setq copilot-chat--session-approved-tools nil)
+    (setq copilot-chat--tool-edits nil)
     (copilot-chat--maybe-warn-model-lacks-tools)
     (with-current-buffer (get-buffer copilot-chat--buffer-name)
       (setq copilot-chat--work-done-token token)
@@ -1604,6 +1727,9 @@ of MESSAGE, so the new conversation picks up the saved context."
 
 (defun copilot-chat--destroy ()
   "Destroy the current conversation."
+  ;; Pending tool-input edits belong to the conversation being torn down;
+  ;; never let one leak into the next.
+  (setq copilot-chat--tool-edits nil)
   (let ((chat-buf (get-buffer copilot-chat--buffer-name)))
     (when (and chat-buf (buffer-live-p chat-buf))
       (with-current-buffer chat-buf

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -979,8 +979,14 @@ at the prompt remembers the tool for the rest of the conversation."
         ('edit
          ;; Stash the edited input now; the server reads only the result
          ;; here and sends the input in a separate invocation request.
-         (copilot-chat--read-tool-edit msg)
-         (copilot-chat--accept-tool msg))
+         ;; A cancelled edit (C-c C-k or C-g) raises `quit', which the
+         ;; jsonrpc dispatcher does not turn into a reply, so the server
+         ;; would wait forever; treat it as a plain decline instead.
+         (condition-case nil
+             (progn
+               (copilot-chat--read-tool-edit msg)
+               (copilot-chat--accept-tool msg))
+           (quit (list :result "dismiss"))))
         (decision
          (when (eq decision 'always)
            (cl-pushnew (copilot-chat--tool-base-name name)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1871,7 +1871,40 @@
     (it "clears pending edits when the conversation is destroyed"
       (let ((copilot-chat--tool-edits '(("cls_1" . (:command "x")))))
         (copilot-chat--destroy)
-        (expect copilot-chat--tool-edits :to-be nil))))
+        (expect copilot-chat--tool-edits :to-be nil)))
+
+    (it "declines cleanly when the edit is cancelled"
+      (let ((copilot-chat--tool-edits nil))
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'edit)
+        ;; The user aborts the edit (C-c C-k / C-g both raise quit).
+        (spy-on 'copilot-chat--read-tool-field
+                :and-call-fake (lambda (&rest _) (signal 'quit nil)))
+        ;; A quit must not escape the handler (that would leave the
+        ;; server's confirmation request unanswered); it dismisses.
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "run_in_terminal"
+                       :toolCallId "cls_1"
+                       :input (list :command "rm -rf /")))
+                :to-equal '(:result "dismiss"))
+        (expect copilot-chat--tool-edits :to-be nil)))
+
+    (it "edits a fetch_web_page URL list back into a vector"
+      (let ((copilot-chat--tool-edits nil))
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'edit)
+        (spy-on 'read-string :and-return-value "https://a.test https://b.test")
+        (spy-on 'copilot-chat--execute-fetch-web-page
+                :and-return-value (copilot-chat--tool-result "success" "ok"))
+        (copilot-chat--handle-tool-confirmation
+         (list :name "fetch_web_page"
+               :toolCallId "cls_u"
+               :input (list :urls ["https://old.test"])))
+        (copilot-chat--handle-tool-invocation
+         (list :name "fetch_web_page"
+               :toolCallId "cls_u"
+               :input (list :urls ["https://old.test"])))
+        (expect 'copilot-chat--execute-fetch-web-page
+                :to-have-been-called-with
+                (list :urls ["https://a.test" "https://b.test"])))))
 
   ;;
   ;; Tool execution

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1773,6 +1773,107 @@
         (expect (plist-get result :status) :to-equal "error"))))
 
   ;;
+  ;; Editable tool input
+  ;;
+
+  (describe "copilot-chat--tool-editable-field"
+    (it "names the editable field for each editable client tool"
+      (expect (copilot-chat--tool-editable-field "run_in_terminal")
+              :to-equal :command)
+      (expect (copilot-chat--tool-editable-field "create_file")
+              :to-equal :content)
+      (expect (copilot-chat--tool-editable-field "fetch_web_page")
+              :to-equal :urls))
+
+    (it "offers nothing for a client tool with no useful editable input"
+      (expect (copilot-chat--tool-editable-field "get_errors") :to-be nil))
+
+    (it "offers nothing for server and MCP tools"
+      ;; A namespaced server tool is run by the server, never by us.
+      (expect (copilot-chat--tool-editable-field "copilot.read_file") :to-be nil)
+      (expect (copilot-chat--tool-editable-field "copilot.create_file") :to-be nil)
+      (expect (copilot-chat--tool-editable-field "some_mcp_tool") :to-be nil)))
+
+  (describe "the edit choice at the confirmation prompt"
+    (it "is offered for an editable client tool"
+      (let (choices)
+        (spy-on 'read-multiple-choice :and-call-fake
+                (lambda (_prompt cs) (setq choices cs) '(?y "yes" "")))
+        (copilot-chat--ask-tool (list :name "run_in_terminal"
+                                      :input (list :command "ls")))
+        (expect (assq ?e choices) :to-be-truthy)))
+
+    (it "is not offered for a client tool without an editable field"
+      (let (choices)
+        (spy-on 'read-multiple-choice :and-call-fake
+                (lambda (_prompt cs) (setq choices cs) '(?y "yes" "")))
+        (copilot-chat--ask-tool (list :name "get_errors"
+                                      :input (list :filePaths ["foo.el"])))
+        (expect (assq ?e choices) :to-be nil)))
+
+    (it "is not offered for a server tool"
+      (let (choices)
+        (spy-on 'read-multiple-choice :and-call-fake
+                (lambda (_prompt cs) (setq choices cs) '(?y "yes" "")))
+        (copilot-chat--ask-tool (list :name "copilot.read_file"
+                                      :input (list :filePath "/tmp/x.el")))
+        (expect (assq ?e choices) :to-be nil))))
+
+  (describe "editing a tool's input before it runs"
+    (it "stashes the edited input and runs the tool with it"
+      (let ((copilot-chat--tool-edits nil))
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'edit)
+        (spy-on 'copilot-chat--read-tool-field :and-return-value "echo safe")
+        (spy-on 'copilot-chat--execute-run-in-terminal
+                :and-return-value (copilot-chat--tool-result "success" "ok"))
+        ;; Confirming with `edit' accepts the call and stashes the new input.
+        (expect (copilot-chat--handle-tool-confirmation
+                 (list :name "run_in_terminal"
+                       :toolCallId "cls_1"
+                       :input (list :command "rm -rf /")))
+                :to-equal '(:result "accept"))
+        (expect copilot-chat--tool-edits :not :to-be nil)
+        ;; The later invocation runs with the edited command, not the original.
+        (copilot-chat--handle-tool-invocation
+         (list :name "run_in_terminal"
+               :toolCallId "cls_1"
+               :input (list :command "rm -rf /")))
+        (expect 'copilot-chat--execute-run-in-terminal
+                :to-have-been-called-with (list :command "echo safe"))))
+
+    (it "clears the stash once the edited input has been consumed"
+      (let ((copilot-chat--tool-edits nil))
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'edit)
+        (spy-on 'copilot-chat--read-tool-field :and-return-value "echo safe")
+        (spy-on 'copilot-chat--execute-run-in-terminal
+                :and-return-value (copilot-chat--tool-result "success" "ok"))
+        (copilot-chat--handle-tool-confirmation
+         (list :name "run_in_terminal"
+               :toolCallId "cls_1"
+               :input (list :command "danger")))
+        (copilot-chat--handle-tool-invocation
+         (list :name "run_in_terminal"
+               :toolCallId "cls_1"
+               :input (list :command "danger")))
+        (expect copilot-chat--tool-edits :to-be nil)))
+
+    (it "leaves an unedited invocation on the server's input"
+      (let ((copilot-chat--tool-edits nil))
+        (spy-on 'copilot-chat--execute-run-in-terminal
+                :and-return-value (copilot-chat--tool-result "success" "ok"))
+        (copilot-chat--handle-tool-invocation
+         (list :name "run_in_terminal"
+               :toolCallId "cls_9"
+               :input (list :command "ls")))
+        (expect 'copilot-chat--execute-run-in-terminal
+                :to-have-been-called-with (list :command "ls"))))
+
+    (it "clears pending edits when the conversation is destroyed"
+      (let ((copilot-chat--tool-edits '(("cls_1" . (:command "x")))))
+        (copilot-chat--destroy)
+        (expect copilot-chat--tool-edits :to-be nil))))
+
+  ;;
   ;; Tool execution
   ;;
 


### PR DESCRIPTION
In agent mode, the tool-confirmation prompt gains an `edit` choice for the tools copilot.el runs itself (`run_in_terminal`, `create_file`, `fetch_web_page`): pick `edit` to change the command, file content, or URLs before the tool runs, the gptel "yes, but change the command" pattern. Server-executed tools (`insert_edit_into_file`, `replace_string_in_file`, MCP tools) keep yes/no/always, since the confirmation response is accept/dismiss only and copilot.el can't feed a modified input back to the server.

How it works: confirmation and invocation are two separate server requests, so the edited input can't ride the confirmation reply. It's stashed at confirm time, keyed by the `toolCallId` that both requests share (verified in the 1.517.0 bundle, with strict sequential tool execution as a second guarantee), and consumed when the invocation arrives. The stash is cleared on consumption, on reset, and on a new conversation.

The adversarial review caught that cancelling an edit raised `quit`, which slips past jsonrpc's error-only reply wrapper, so the confirmation request went unanswered and the turn hung, and the documented `C-c C-k` cancel was exactly the trigger. The handler now catches that and dismisses cleanly.

544 specs pass, checkdoc clean, no new compile warnings.