### PR TITLE
Let users pick the chat mode, including InlineAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- Add `copilot-chat-select-mode` to choose the chat mode reported by the server (`Ask`, `Agent`, `InlineAgent`, and any custom project modes) instead of only the agent on/off toggle. `InlineAgent` is an agent-kind mode with a restricted tool set aimed at inline editing; the tool-call confirmation, tool registration, and status header apply to it as they do to `Agent`. The selection takes effect on the next new conversation, and without one the existing `copilot-chat-use-agent-mode` toggle still decides between Agent and Ask.
 - Add `copilot-chat-presets`, named bundles of chat settings (model, agent mode, auto-approved tools) that `copilot-chat-apply-preset` switches between in one step. A preset only touches the settings it lists; its model takes effect on your next message and its agent mode on the next new conversation.
 - Show a status header line in the chat buffer with the chat mode (Agent or Ask), the active model, and in agent mode the number of available tools; disable it with `copilot-chat-show-status-header`. ([#509](https://github.com/copilot-emacs/copilot.el/discussions/509))
 - Add one-shot chat task commands that send the active region (or the defun at point) with a canned prompt, with the answer streaming into the regular chat buffer. The prompts are customizable via `copilot-chat-task-prompts`, and `copilot-chat-task` picks a task with completion:

--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ Key bindings in the `*copilot-chat*` buffer:
 
 Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
 
-The chat buffer's header line shows at a glance whether Agent or Ask mode is active, which model answers, and in agent mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
+The chat buffer's header line shows at a glance which mode is active (Agent, InlineAgent, Ask, or a selected custom mode), which model answers, and for an agent-kind mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
+
+Beyond the `copilot-chat-use-agent-mode` toggle (which flips between plain Agent and Ask), `M-x copilot-chat-select-mode` lets you pick any mode the server reports: the built-in `Ask`, `Agent`, and `InlineAgent`, plus any custom project modes. `InlineAgent` is an agent-kind mode with a restricted tool set aimed at inline editing, so tool-call confirmation, tool registration, and the tool count in the header apply to it just as they do to `Agent`. The choice takes effect on the next new conversation, since the mode is fixed when a conversation is created; until you pick one, `copilot-chat-use-agent-mode` still decides between Agent and Ask.
 
 When a turn finishes and you have looked away from the chat, copilot.el raises a desktop notification so you don't have to keep watching it stream. It fires only if the turn took at least `copilot-chat-notify-after-seconds` (10 by default, `nil` disables it) and the chat buffer is not the one in your selected window. The backend prefers D-Bus, falls back to `osascript` on macOS, and to a plain `message` elsewhere; override it via `copilot-chat-notify-function`.
 
@@ -497,6 +499,7 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-list-code-references` | Show suggestions that matched public code |
 | `copilot-select-completion-model` | Choose which model to use for completions |
 | `copilot-chat-select-model` | Choose which model to use for chat |
+| `copilot-chat-select-mode` | Choose the chat mode (Ask, Agent, InlineAgent, ...) |
 | **Completion** | |
 | `copilot-mode` | Toggle automatic completions in the current buffer |
 | `copilot-complete` | Trigger a completion at point |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -452,13 +452,133 @@ positively reports that the model cannot call tools."
          (supports (plist-get (plist-get model :capabilities) :supports)))
     (not (eq (plist-get supports :tool_calls) :json-false))))
 
+;;
+;; Chat mode selection
+;;
+
+(defvar copilot-chat--mode nil
+  "The chat mode selected with `copilot-chat-select-mode', or nil.
+Holds the mode plist reported by the server (with `:id', `:name',
+`:kind', and `:isBuiltIn').  When nil, the mode falls back to
+`copilot-chat-use-agent-mode' (Agent when non-nil, otherwise Ask).")
+
+(defvar copilot-chat--modes nil
+  "Cached chat modes from `conversation/modes'.
+The set is static per session, so it is fetched once.")
+
+(defun copilot-chat--builtin-modes ()
+  "Return the built-in chat modes as a fallback list of plists.
+Used when the server reports no modes so a selection is still possible."
+  (list (list :id "ask" :name "Ask" :kind "Ask" :isBuiltIn t)
+        (list :id "agent" :name "Agent" :kind "Agent" :isBuiltIn t)
+        (list :id "inline-agent" :name "InlineAgent" :kind "InlineAgent"
+              :isBuiltIn t)))
+
+(defun copilot-chat--available-modes ()
+  "Return the chat modes the server reports, or nil when unavailable.
+Query `conversation/modes' at most once per session and cache a
+successful result.  A successful query that yields no modes falls back
+to the built-in modes.  A failed query returns nil and is not cached, so
+it can be retried once the connection is up."
+  (or copilot-chat--modes
+      (setq copilot-chat--modes
+            (condition-case err
+                (let* ((root (copilot--workspace-root))
+                       (params
+                        (when root
+                          (list :workspaceFolders
+                                (vector (list :uri (copilot--path-to-uri root)
+                                              :name (file-name-nondirectory
+                                                     (directory-file-name
+                                                      root)))))))
+                       (modes (append (copilot--request 'conversation/modes
+                                                        params)
+                                      nil)))
+                  (or modes (copilot-chat--builtin-modes)))
+              (error
+               (copilot--log 'warning "Could not fetch chat modes: %S" err)
+               nil)))))
+
+(defun copilot-chat--effective-mode ()
+  "Return the effective chat mode as a plist.
+The plist has `:kind' (one of \"Ask\", \"Agent\", or \"InlineAgent\") and
+`:custom-id', a string for a non-built-in custom mode and nil otherwise.
+Derived from the mode chosen with `copilot-chat-select-mode', falling
+back to `copilot-chat-use-agent-mode' (Agent when non-nil, otherwise
+Ask) when no mode is selected."
+  (if copilot-chat--mode
+      (list :kind (plist-get copilot-chat--mode :kind)
+            :custom-id (unless (eq (plist-get copilot-chat--mode :isBuiltIn) t)
+                         (plist-get copilot-chat--mode :id)))
+    (list :kind (if copilot-chat-use-agent-mode "Agent" "Ask"))))
+
+(defun copilot-chat--agent-mode-p ()
+  "Return non-nil when the effective chat mode is an agent-kind mode.
+Both \"Agent\" and \"InlineAgent\" are agent-kind: the server maps them
+to the same agent machinery, so tool registration, tool-call
+confirmation, and the tool-support warning apply to both."
+  (and (member (plist-get (copilot-chat--effective-mode) :kind)
+               '("Agent" "InlineAgent"))
+       t))
+
+(defun copilot-chat--effective-mode-name ()
+  "Return a human-readable name for the effective chat mode."
+  (if copilot-chat--mode
+      (plist-get copilot-chat--mode :name)
+    (plist-get (copilot-chat--effective-mode) :kind)))
+
+(defun copilot-chat--mode-create-params ()
+  "Return `conversation/create' params selecting the effective chat mode.
+Return nil for the default Ask mode so behavior is unchanged for users
+who never pick a mode; otherwise send `chatMode', a `customChatModeId'
+for a custom (non-built-in) mode, and `needToolCallConfirmation' for an
+agent-kind mode."
+  (let* ((mode (copilot-chat--effective-mode))
+         (custom-id (plist-get mode :custom-id))
+         (agentp (copilot-chat--agent-mode-p)))
+    (when (or agentp custom-id)
+      (append (list :chatMode (plist-get mode :kind))
+              (when custom-id (list :customChatModeId custom-id))
+              (when agentp (list :needToolCallConfirmation t))))))
+
+;;;###autoload
+(defun copilot-chat-select-mode ()
+  "Interactively select the Copilot Chat mode.
+Modes (such as `Ask', `Agent', and `InlineAgent', plus any custom
+project modes) are fetched from the server.  `Agent' and `InlineAgent'
+are agent-kind modes that let Copilot run tools; `InlineAgent' uses a
+restricted tool set aimed at inline editing.
+
+The selection takes effect on the next new conversation, since the mode
+is fixed when a conversation is created (start one by resetting the chat
+with `copilot-chat-reset' or sending a message in a fresh chat)."
+  (interactive)
+  (let ((modes (copilot-chat--available-modes)))
+    (unless modes
+      (user-error "Copilot Chat: Could not fetch chat modes"))
+    (let* ((choices
+            (mapcar (lambda (m)
+                      (let ((name (plist-get m :name))
+                            (desc (plist-get m :description)))
+                        (cons (if (and desc (not (string-empty-p desc)))
+                                  (format "%s  %s" name desc)
+                                name)
+                              m)))
+                    modes))
+           (choice (completing-read "Chat mode: " choices nil t))
+           (mode (cdr (assoc choice choices))))
+      (setq copilot-chat--mode mode)
+      (message
+       "Copilot Chat: Mode set to %s (takes effect on the next new conversation)"
+       (plist-get mode :name)))))
+
 (defun copilot-chat--maybe-warn-model-lacks-tools ()
   "Warn when agent mode is on but the active model cannot call tools.
 Without tool support the model just tells the user which commands to run
 instead of running them, which reads as agent mode not working.  This is
 best-effort: it stays silent when tool support can't be determined and
 never blocks starting a conversation."
-  (when copilot-chat-use-agent-mode
+  (when (copilot-chat--agent-mode-p)
     (condition-case nil
         (when-let* ((model (copilot-chat--model)))
           (unless (copilot-chat--model-supports-tools-p model)
@@ -1776,9 +1896,7 @@ of MESSAGE, so the new conversation picks up the saved context."
                       (list (list :uri (concat "file://" root)
                                   :name (file-name-nondirectory
                                          (directory-file-name root)))))))
-             (when copilot-chat-use-agent-mode
-               (list :chatMode "Agent"
-                     :needToolCallConfirmation t))
+             (copilot-chat--mode-create-params)
              (copilot-chat--references-param))
             :success-fn (lambda (result)
                           (when-let* ((buf (get-buffer
@@ -1795,7 +1913,7 @@ of MESSAGE, so the new conversation picks up the saved context."
                               (when (eq copilot-chat--restored-turns
                                         restored)
                                 (setq copilot-chat--restored-turns nil))))
-                          (when copilot-chat-use-agent-mode
+                          (when (copilot-chat--agent-mode-p)
                             (copilot-chat--register-tools))
                           (funcall callback result))
             :error-fn (lambda (err)
@@ -2866,19 +2984,20 @@ last reported by the language server (`copilot-chat--mcp-servers')."
 
 (defun copilot-chat--status-header ()
   "Return the status header line for the chat buffer.
-Show the chat mode (Agent or Ask), the active model, and in agent mode
-the number of available tools.  Built from variables already in memory
+Show the effective chat mode (Agent, InlineAgent, Ask, or a selected
+custom mode), the active model, and for an agent-kind mode the number of
+available tools.  Built from variables already in memory
 \(`copilot-chat-model', the cached `copilot-chat--resolved-model' and
 `copilot-chat--mcp-servers') plus a memoized client-tool count, so it
 is cheap enough to evaluate on every redisplay and never contacts the
 server."
   (let ((segments
-         (list (concat "Copilot Chat  "
-                       (if copilot-chat-use-agent-mode "Agent mode" "Ask mode"))
+         (list (format "Copilot Chat  %s mode"
+                       (copilot-chat--effective-mode-name))
                (or copilot-chat-model
                    copilot-chat--resolved-model
                    "default model")
-               (when copilot-chat-use-agent-mode
+               (when (copilot-chat--agent-mode-p)
                  (format "%d tools" (copilot-chat--tool-count))))))
     (propertize (string-join (delq nil segments) "  •  ")
                 'face 'copilot-chat-status-header-face)))
@@ -3082,10 +3201,10 @@ The set is static per session, so it is fetched once.")
 
 (defun copilot-chat--chat-templates ()
   "Return the server's slash-command templates for the chat.
-Filter to the scope matching the current mode (`agent-panel' when
-`copilot-chat-use-agent-mode' is on, otherwise `chat-panel').  The
-server query is made at most once per session and cached; a failed
-query yields no templates rather than an error."
+Filter to the scope matching the effective mode (`agent-panel' for an
+agent-kind mode, otherwise `chat-panel').  The server query is made at
+most once per session and cached; a failed query yields no templates
+rather than an error."
   (unless copilot-chat--templates
     (setq copilot-chat--templates
           (condition-case err
@@ -3102,7 +3221,7 @@ query yields no templates rather than an error."
             (error
              (copilot--log 'warning "Could not fetch chat templates: %S" err)
              'none))))
-  (let ((scope (if copilot-chat-use-agent-mode "agent-panel" "chat-panel")))
+  (let ((scope (if (copilot-chat--agent-mode-p) "agent-panel" "chat-panel")))
     (seq-filter (lambda (tpl)
                   (seq-contains-p (plist-get tpl :scopes) scope))
                 (if (eq copilot-chat--templates 'none) nil

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -523,9 +523,10 @@ confirmation, and the tool-support warning apply to both."
 
 (defun copilot-chat--effective-mode-name ()
   "Return a human-readable name for the effective chat mode."
-  (if copilot-chat--mode
-      (plist-get copilot-chat--mode :name)
-    (plist-get (copilot-chat--effective-mode) :kind)))
+  (let ((name (and copilot-chat--mode (plist-get copilot-chat--mode :name))))
+    (if (and (stringp name) (not (string-empty-p name)))
+        name
+      (plist-get (copilot-chat--effective-mode) :kind))))
 
 (defun copilot-chat--mode-create-params ()
   "Return `conversation/create' params selecting the effective chat mode.

--- a/copilot-menu.el
+++ b/copilot-menu.el
@@ -79,9 +79,13 @@
 ;;
 
 (defun copilot-menu-toggle-agent-mode ()
-  "Toggle `copilot-chat-use-agent-mode' and report the new state."
+  "Toggle `copilot-chat-use-agent-mode' and report the new state.
+Any explicit mode chosen with `copilot-chat-select-mode' is cleared, so
+the toggle actually takes effect (a selected mode otherwise wins over
+the boolean)."
   (interactive)
   (require 'copilot-chat)
+  (setq copilot-chat--mode nil)
   (setq copilot-chat-use-agent-mode (not copilot-chat-use-agent-mode))
   (message "Copilot Chat: agent mode %s"
            (if copilot-chat-use-agent-mode "enabled" "disabled")))

--- a/copilot-menu.el
+++ b/copilot-menu.el
@@ -48,6 +48,7 @@
 ;; package but only loaded once the menu is opened (see `copilot-menu').
 (defvar copilot-chat-model)
 (defvar copilot-chat-use-agent-mode)
+(defvar copilot-chat--mode)
 
 ;;
 ;; Dynamic descriptions
@@ -64,6 +65,14 @@
 (defun copilot-menu--chat-model-description ()
   "Describe the chat model selection with the current model."
   (format "Select chat model (%s)" (or copilot-chat-model "default")))
+
+(defun copilot-menu--chat-mode-description ()
+  "Describe the chat mode selection with the current mode."
+  (format "Select chat mode (%s)"
+          (cond ((and (boundp 'copilot-chat--mode) copilot-chat--mode)
+                 (plist-get copilot-chat--mode :name))
+                (copilot-chat-use-agent-mode "Agent")
+                (t "Ask"))))
 
 ;;
 ;; Extra suffix commands
@@ -110,6 +119,8 @@
        ("a" copilot-menu-toggle-agent-mode
         :description copilot-menu--agent-mode-description
         :transient t)
+       ("M" copilot-chat-select-mode
+        :description copilot-menu--chat-mode-description)
        ("T" "List MCP tools" copilot-chat-list-mcp-tools)]]
      [["Account"
        ("i" "Login" copilot-login)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -2695,6 +2695,32 @@
                       :to-equal "custom-xyz"))
           (kill-buffer buf))))
 
+    (it "sends a custom Ask-kind mode without tool confirmation"
+      (let ((captured-params nil)
+            (copilot-chat--mode
+             (list :id "custom-ask" :name "Docs" :kind "Ask"
+                   :isBuiltIn :json-false))
+            (copilot-chat-use-agent-mode nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              ;; A custom Ask-kind mode ships its id but is not agent-kind,
+              ;; so no tool confirmation is requested.
+              (expect (plist-get captured-params :chatMode) :to-equal "Ask")
+              (expect (plist-get captured-params :customChatModeId)
+                      :to-equal "custom-ask")
+              (expect (plist-member captured-params :needToolCallConfirmation)
+                      :not :to-be-truthy))
+          (kill-buffer buf))))
+
     (it "registers tools for InlineAgent"
       (let ((copilot-chat--mode
              (list :id "inline-agent" :name "InlineAgent"

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -97,6 +97,18 @@
         (expect (substring-no-properties (copilot-chat--status-header))
                 :to-equal "Copilot Chat  Ask mode  •  gpt-4o")))
 
+    (it "shows the selected mode name with a tool count for InlineAgent"
+      (let ((copilot-chat--mode
+             (list :id "inline-agent" :name "InlineAgent"
+                   :kind "InlineAgent" :isBuiltIn t))
+            (copilot-chat-use-agent-mode nil)
+            (copilot-chat-model "gpt-5-codex")
+            (copilot-chat--mcp-servers nil))
+        (expect (substring-no-properties (copilot-chat--status-header))
+                :to-equal
+                (format "Copilot Chat  InlineAgent mode  •  gpt-5-codex  •  %d tools"
+                        (length (copilot-chat--client-tool-names))))))
+
     (it "falls back to the resolved model when no model is customized"
       (let ((copilot-chat-use-agent-mode nil)
             (copilot-chat-model nil)
@@ -2523,6 +2535,188 @@
                                     (lambda (_r) (setq callback-called t)))
               (expect 'copilot-chat--register-tools :to-have-been-called)
               (expect callback-called :to-be-truthy))
+          (kill-buffer buf)))))
+
+  ;;
+  ;; Chat mode selection
+  ;;
+
+  (describe "copilot-chat--effective-mode"
+    (it "falls back to Ask when no mode is selected and agent mode is off"
+      (let ((copilot-chat--mode nil)
+            (copilot-chat-use-agent-mode nil))
+        (expect (plist-get (copilot-chat--effective-mode) :kind)
+                :to-equal "Ask")))
+
+    (it "falls back to Agent when no mode is selected and agent mode is on"
+      (let ((copilot-chat--mode nil)
+            (copilot-chat-use-agent-mode t))
+        (expect (plist-get (copilot-chat--effective-mode) :kind)
+                :to-equal "Agent")))
+
+    (it "uses the selected mode's kind over the boolean"
+      (let ((copilot-chat--mode
+             (list :id "inline-agent" :name "InlineAgent"
+                   :kind "InlineAgent" :isBuiltIn t))
+            (copilot-chat-use-agent-mode nil))
+        (expect (plist-get (copilot-chat--effective-mode) :kind)
+                :to-equal "InlineAgent")))
+
+    (it "reports no custom id for a built-in mode"
+      (let ((copilot-chat--mode
+             (list :id "agent" :name "Agent" :kind "Agent" :isBuiltIn t)))
+        (expect (plist-get (copilot-chat--effective-mode) :custom-id)
+                :to-be nil)))
+
+    (it "reports the id as custom id for a non-built-in mode"
+      (let ((copilot-chat--mode
+             (list :id "custom-xyz" :name "Reviewer" :kind "Agent"
+                   :isBuiltIn :json-false)))
+        (expect (plist-get (copilot-chat--effective-mode) :custom-id)
+                :to-equal "custom-xyz"))))
+
+  (describe "copilot-chat--agent-mode-p"
+    (it "is true for Agent"
+      (let ((copilot-chat--mode
+             (list :name "Agent" :kind "Agent" :isBuiltIn t)))
+        (expect (copilot-chat--agent-mode-p) :to-be-truthy)))
+
+    (it "is true for InlineAgent"
+      (let ((copilot-chat--mode
+             (list :name "InlineAgent" :kind "InlineAgent" :isBuiltIn t)))
+        (expect (copilot-chat--agent-mode-p) :to-be-truthy)))
+
+    (it "is false for Ask"
+      (let ((copilot-chat--mode
+             (list :name "Ask" :kind "Ask" :isBuiltIn t)))
+        (expect (copilot-chat--agent-mode-p) :to-be nil)))
+
+    (it "follows the boolean fallback when no mode is selected"
+      (let ((copilot-chat--mode nil))
+        (let ((copilot-chat-use-agent-mode t))
+          (expect (copilot-chat--agent-mode-p) :to-be-truthy))
+        (let ((copilot-chat-use-agent-mode nil))
+          (expect (copilot-chat--agent-mode-p) :to-be nil)))))
+
+  (describe "copilot-chat--available-modes"
+    (before-each
+      (setq copilot-chat--modes nil)
+      (spy-on 'copilot--workspace-root :and-return-value nil)
+      (spy-on 'copilot--connection-alivep :and-return-value t))
+    (after-each (setq copilot-chat--modes nil))
+
+    (it "fetches and caches the modes, querying the server once"
+      (spy-on 'jsonrpc-request :and-return-value
+              (vector (list :id "ask" :name "Ask" :kind "Ask" :isBuiltIn t)
+                      (list :id "agent" :name "Agent" :kind "Agent"
+                            :isBuiltIn t)))
+      (let ((modes (copilot-chat--available-modes)))
+        (expect (length modes) :to-equal 2)
+        (expect (plist-get (car modes) :kind) :to-equal "Ask"))
+      (copilot-chat--available-modes)
+      (expect 'jsonrpc-request :to-have-been-called-times 1))
+
+    (it "falls back to the built-ins when the server returns none"
+      (spy-on 'jsonrpc-request :and-return-value [])
+      (let ((kinds (mapcar (lambda (m) (plist-get m :kind))
+                           (copilot-chat--available-modes))))
+        (expect kinds :to-equal '("Ask" "Agent" "InlineAgent"))))
+
+    (it "returns nil when the query fails"
+      (spy-on 'copilot--log)
+      (spy-on 'jsonrpc-request :and-throw-error 'error)
+      (expect (copilot-chat--available-modes) :to-be nil)))
+
+  (describe "copilot-chat-select-mode"
+    (before-each (setq copilot-chat--mode nil))
+    (after-each (setq copilot-chat--mode nil))
+
+    (it "stores the chosen mode"
+      (spy-on 'copilot-chat--available-modes :and-return-value
+              (list (list :id "ask" :name "Ask" :kind "Ask" :isBuiltIn t)
+                    (list :id "inline-agent" :name "InlineAgent"
+                          :kind "InlineAgent" :isBuiltIn t
+                          :description "Inline editing")))
+      (spy-on 'completing-read
+              :and-return-value "InlineAgent  Inline editing")
+      (copilot-chat-select-mode)
+      (expect (plist-get copilot-chat--mode :kind) :to-equal "InlineAgent"))
+
+    (it "errors when modes cannot be fetched"
+      (spy-on 'copilot-chat--available-modes :and-return-value nil)
+      (expect (copilot-chat-select-mode) :to-throw 'user-error)))
+
+  (describe "copilot-chat--create (selected mode)"
+    (it "sends the selected mode's kind without a custom id for a built-in"
+      (let ((captured-params nil)
+            (copilot-chat--mode
+             (list :id "inline-agent" :name "InlineAgent"
+                   :kind "InlineAgent" :isBuiltIn t))
+            (copilot-chat-use-agent-mode nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--register-tools)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-get captured-params :chatMode)
+                      :to-equal "InlineAgent")
+              (expect (plist-get captured-params :needToolCallConfirmation)
+                      :to-equal t)
+              (expect (plist-member captured-params :customChatModeId)
+                      :not :to-be-truthy))
+          (kill-buffer buf))))
+
+    (it "sends a custom id for a non-built-in mode"
+      (let ((captured-params nil)
+            (copilot-chat--mode
+             (list :id "custom-xyz" :name "Reviewer" :kind "Agent"
+                   :isBuiltIn :json-false))
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--register-tools)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-get captured-params :chatMode) :to-equal "Agent")
+              (expect (plist-get captured-params :customChatModeId)
+                      :to-equal "custom-xyz"))
+          (kill-buffer buf))))
+
+    (it "registers tools for InlineAgent"
+      (let ((copilot-chat--mode
+             (list :id "inline-agent" :name "InlineAgent"
+                   :kind "InlineAgent" :isBuiltIn t))
+            (copilot-chat-use-agent-mode nil)
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--register-tools)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method _params &rest args)
+                        (let ((success-fn (plist-get args :success-fn)))
+                          (when success-fn
+                            (funcall success-fn
+                                     (list :conversationId "test"
+                                           :turnId "turn-1"))))
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect 'copilot-chat--register-tools :to-have-been-called))
           (kill-buffer buf)))))
 
   (describe "copilot-chat-send-region"

--- a/test/copilot-menu-test.el
+++ b/test/copilot-menu-test.el
@@ -57,6 +57,7 @@ optional description string)."
                          copilot-chat-clear-references
                          copilot-chat-select-model
                          copilot-menu-toggle-agent-mode
+                         copilot-chat-select-mode
                          copilot-chat-list-mcp-tools
                          copilot-login
                          copilot-logout
@@ -70,7 +71,7 @@ optional description string)."
         (expect commands :to-contain command))
       ;; Exactly these, so a future suffix shape the walker doesn't
       ;; understand cannot silently drop commands from the check.
-      (expect (length commands) :to-equal 20)))
+      (expect (length commands) :to-equal 21)))
 
   (describe "copilot-menu-toggle-agent-mode"
     (it "flips copilot-chat-use-agent-mode"

--- a/test/copilot-menu-test.el
+++ b/test/copilot-menu-test.el
@@ -79,7 +79,14 @@ optional description string)."
         (copilot-menu-toggle-agent-mode)
         (expect copilot-chat-use-agent-mode :to-be-truthy)
         (copilot-menu-toggle-agent-mode)
-        (expect copilot-chat-use-agent-mode :to-be nil))))
+        (expect copilot-chat-use-agent-mode :to-be nil)))
+
+    (it "clears an explicit mode selection so the toggle takes effect"
+      (let ((copilot-chat--mode '(:name "InlineAgent" :kind "InlineAgent"))
+            (copilot-chat-use-agent-mode nil))
+        (copilot-menu-toggle-agent-mode)
+        (expect copilot-chat--mode :to-be nil)
+        (expect copilot-chat-use-agent-mode :to-be-truthy))))
 
   (describe "copilot-menu-open-log"
     (it "signals a user error when there is no log buffer"


### PR DESCRIPTION
Adds `copilot-chat-select-mode`, which fetches the language server's available chat modes (`conversation/modes`) and lets you pick one: Ask, Agent, InlineAgent (agent mode with a restricted tool set for inline editing), or any custom project mode. The selection is sent on the next `conversation/create` as `chatMode` plus a `customChatModeId` for non-built-in modes.

Both Agent and InlineAgent are agent-kind, so tool-call confirmation, tool registration, the tool-support warning, and the agent-panel slash-command templates now gate on a `copilot-chat--agent-mode-p` predicate rather than the raw boolean, and InlineAgent gets the full agent machinery. When no mode is selected, everything falls back to the existing `copilot-chat-use-agent-mode` boolean, so nothing changes for current users, and the wire output is byte-identical in that case. The status header and `copilot-menu` show the active mode.

The adversarial review confirmed the mode classification (`isBuiltIn` true → `t` in this codebase's JSON decoding, so built-ins never get a custom id), the empty-vs-failed modes cache handling, and byte-for-byte backward compatibility. Follow-ups folded in: the menu's agent toggle clears an explicit selection so it isn't a no-op, the header falls back to the mode kind when a custom mode has no name, and a custom Ask-kind mode is now tested.

573 specs pass, checkdoc clean, no new compile warnings.