### PR TITLE
Add a compose buffer and a display command for chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## main (unreleased)
 
+### New Features
+
+- Add `copilot-chat-compose` (bound to `C-c C-e` in the chat buffer) to draft a multi-line message in a dedicated writable buffer, sending it with `C-c C-c` (as a new conversation or a follow-up, just like `copilot-chat`) or cancelling with `C-c C-k`.
+- Add `copilot-chat-display` (bound to `C-c C-d` in the chat buffer) to show the existing chat buffer without sending a message.
+
 ## 0.8.0 (2026-07-04)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ M-x copilot-chat
 M-x copilot-chat-send-region
 ```
 
+For anything longer than a quick question, `copilot-chat-compose` (`C-c C-e` in the chat buffer) pops a dedicated writable buffer where you can draft a multi-line, multi-paragraph message with the usual editing and yank commands, then send it with `C-c C-c` or cancel with `C-c C-k`. It sends the same way `copilot-chat` does: as a new conversation when none exists yet, or as a follow-up turn otherwise. `copilot-chat-display` (`C-c C-d`) just shows the existing chat buffer without sending anything.
+
 There are also one-shot task commands that send the active region (or the function at point when no region is active) with a canned prompt, so you don't have to type anything; the answer streams into the chat buffer as usual:
 
 - `copilot-chat-review` — review the code for bugs, risks, and improvements
@@ -241,11 +243,13 @@ Beyond the prose feedback of `copilot-chat-review`, there is also native Copilot
 
 Key bindings in the `*copilot-chat*` buffer:
 - **C-c RET** or **C-c C-c** — send a follow-up message
+- **C-c C-e** — compose a multi-line message in a dedicated buffer
 - **C-c C-k** — cancel streaming, or reset if idle
 - **C-c C-i** — insert the code block at point into the source buffer
 - **C-c M-w** — copy the code block at point to the kill ring
 - **C-c /** — pick and send a slash command (`/explain`, `/fix`, `/tests`, ...)
 - **C-c C-f** — attach a file as context for the next message
+- **C-c C-d** — display the chat buffer without sending a message
 - **q** — quit the chat window
 
 Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
@@ -286,7 +290,7 @@ If you often flip between a couple of setups (say a quick ask-mode model and a t
 
 At each tool confirmation prompt you can answer `yes`, `no`, or `always`; `always` approves that tool for the rest of the conversation so it stops asking.
 
-For the tools copilot.el runs itself, the prompt also offers `edit`, which lets you change the input before the tool runs: the shell command of `run_in_terminal`, the content of `create_file` (edited in a temporary buffer, confirmed with `C-c C-c` or cancelled with `C-c C-k`), or the URLs of `fetch_web_page`. The tool then runs once with your edited input. Server-executed and MCP tools do not offer `edit`, since the server does not accept a modified input back.
+For the tools copilot.el runs itself, the prompt also offers `edit`, which lets you change the input before the tool runs: the shell command of `run_in_terminal`, the content of `create_file`, or the URLs of `fetch_web_page`. Each opens in a temporary buffer, confirmed with `C-c C-c` or cancelled with `C-c C-k`. The tool then runs once with your edited input. Server-executed and MCP tools do not offer `edit`, since the server does not accept a modified input back.
 
 > [!IMPORTANT]
 >
@@ -519,6 +523,8 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-previous-completion` | Cycle to the previous completion |
 | **Chat** | |
 | `copilot-chat` | Open Copilot Chat and send a message |
+| `copilot-chat-compose` | Draft a multi-line message in a dedicated buffer and send it |
+| `copilot-chat-display` | Display the chat buffer without sending a message |
 | `copilot-chat-send` | Send a follow-up message in the current chat |
 | `copilot-chat-send-region` | Send the selected region as context with an optional prompt |
 | `copilot-chat-task` | Pick a one-shot task and run it on the region or defun at point |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -1143,16 +1143,18 @@ awaiting each confirmation before invoking."
     (define-key map (kbd "C-c C-c") #'exit-recursive-edit)
     (define-key map (kbd "C-c C-k") #'abort-recursive-edit)
     map)
-  "Keymap active while editing a multi-line tool argument in a buffer.
-Keys it does not bind fall through to the global map, so ordinary text
-editing works as usual.")
+  "Keymap active while editing multi-line text in a temporary buffer.
+Used for tool-argument edits and for `copilot-chat-compose'.  Keys it
+does not bind fall through to the global map, so ordinary text editing
+works as usual.")
 
-(defun copilot-chat--edit-in-buffer (initial description)
+(defun copilot-chat--edit-in-buffer (initial description &optional buffer-name)
   "Let the user edit INITIAL in a temporary buffer and return the new text.
 DESCRIPTION names the value being edited and appears in the header line.
-Editing runs in a recursive edit, keyed by
+BUFFER-NAME, when given, names the scratch buffer; it defaults to a
+tool-edit buffer.  Editing runs in a recursive edit, keyed by
 `copilot-chat--tool-edit-keymap'; cancelling signals `quit'."
-  (let ((buf (generate-new-buffer "*copilot-chat-tool-edit*")))
+  (let ((buf (generate-new-buffer (or buffer-name "*copilot-chat-tool-edit*"))))
     (unwind-protect
         (progn
           (with-current-buffer buf
@@ -1176,11 +1178,12 @@ or \\[abort-recursive-edit] to cancel"
 Return the value in the shape the field expects: a string for `:command',
 a string for `:content', and a vector of strings for `:urls'."
   (pcase field
-    (:command (read-string "Copilot Chat: edit command: " current))
+    (:command (copilot-chat--edit-in-buffer current "command"))
     (:content (copilot-chat--edit-in-buffer current "file content"))
     (:urls (vconcat (split-string
-                     (read-string "Copilot Chat: edit URLs (space-separated): "
-                                  (mapconcat #'identity (append current nil) " "))
+                     (copilot-chat--edit-in-buffer
+                      (mapconcat #'identity (append current nil) "\n")
+                      "URLs (one per line or space-separated)")
                      nil t)))))
 
 (defun copilot-chat--read-tool-edit (msg)
@@ -2985,11 +2988,13 @@ and suggested change) in the chat buffer."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c RET") #'copilot-chat-send)
     (define-key map (kbd "C-c C-c") #'copilot-chat-send)
+    (define-key map (kbd "C-c C-e") #'copilot-chat-compose)
     (define-key map (kbd "C-c C-k") #'copilot-chat-stop)
     (define-key map (kbd "C-c C-i") #'copilot-chat-insert-code-block)
     (define-key map (kbd "C-c M-w") #'copilot-chat-copy-code-block)
     (define-key map (kbd "C-c /") #'copilot-chat-slash-command)
     (define-key map (kbd "C-c C-f") #'copilot-chat-add-file-reference)
+    (define-key map (kbd "C-c C-d") #'copilot-chat-display)
     (define-key map (kbd "q") #'quit-window)
     map)
   "Keymap for `copilot-chat-mode'.")
@@ -3187,6 +3192,39 @@ When called interactively, prompt for the message."
                      (plist-get result :conversationId))
                (setq copilot-chat--current-turn-id
                      (plist-get result :turnId))))))))))
+
+;;;###autoload
+(defun copilot-chat-compose ()
+  "Draft a Copilot Chat message in a dedicated compose buffer.
+Pop a writable buffer where you can compose a multi-line message with
+the usual editing and yank commands.
+\\<copilot-chat--tool-edit-keymap>Send it with \\[exit-recursive-edit],
+or cancel with \\[abort-recursive-edit].  The message is routed through
+`copilot-chat', so it starts a new conversation when none exists yet and
+is sent as a follow-up turn otherwise.  Empty or whitespace-only input
+is not sent."
+  (interactive)
+  (let ((message (condition-case nil
+                     (copilot-chat--edit-in-buffer "" "message"
+                                                   "*copilot-chat-compose*")
+                   ;; C-c C-k (or C-g) aborts the recursive edit; treat
+                   ;; that as a clean cancel rather than an empty send.
+                   (quit :cancelled))))
+    (unless (eq message :cancelled)
+      (when (string-blank-p message)
+        (user-error "Copilot Chat: Empty message"))
+      (copilot-chat message))))
+
+;;;###autoload
+(defun copilot-chat-display ()
+  "Display the existing Copilot Chat buffer without sending a message.
+Signal a `user-error' when no chat buffer exists yet, since there is
+nothing to show; start a conversation with `copilot-chat' first."
+  (interactive)
+  (let ((chat-buf (get-buffer copilot-chat--buffer-name)))
+    (unless chat-buf
+      (user-error "Copilot Chat: No active chat buffer"))
+    (display-buffer chat-buf)))
 
 ;;;###autoload
 (defun copilot-chat-send-region (start end &optional prompt)

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -3204,11 +3204,17 @@ or cancel with \\[abort-recursive-edit].  The message is routed through
 is sent as a follow-up turn otherwise.  Empty or whitespace-only input
 is not sent."
   (interactive)
+  ;; Check the busy state up front, so a long draft isn't composed and
+  ;; then thrown away by the send-time guard in `copilot-chat'.
+  (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
+    (when (or (buffer-local-value 'copilot-chat--streaming-p buf)
+              (buffer-local-value 'copilot-chat--current-request buf))
+      (user-error "Copilot Chat: A response is currently being streamed")))
   (let ((message (condition-case nil
                      (copilot-chat--edit-in-buffer "" "message"
                                                    "*copilot-chat-compose*")
-                   ;; C-c C-k (or C-g) aborts the recursive edit; treat
-                   ;; that as a clean cancel rather than an empty send.
+                   ;; C-c C-k aborts the recursive edit; treat that as a
+                   ;; clean cancel rather than an empty send.
                    (quit :cancelled))))
     (unless (eq message :cancelled)
       (when (string-blank-p message)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -917,6 +917,59 @@
         (kill-buffer copilot-chat--buffer-name))
       (expect (copilot-chat-send "hello") :to-throw 'user-error)))
 
+  (describe "copilot-chat-compose"
+    (before-each
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name))
+      (spy-on 'copilot-chat--create)
+      (spy-on 'copilot-chat--send-turn)
+      (spy-on 'display-buffer))
+
+    (it "sends the composed multi-line message as a new conversation"
+      (spy-on 'copilot-chat--edit-in-buffer
+              :and-return-value "first line\n\nsecond paragraph")
+      (copilot-chat-compose)
+      (expect 'copilot-chat--create :to-have-been-called)
+      (expect (car (spy-calls-args-for 'copilot-chat--create 0))
+              :to-equal "first line\n\nsecond paragraph"))
+
+    (it "sends the composed message as a follow-up turn when a conversation exists"
+      (spy-on 'copilot-chat--edit-in-buffer :and-return-value "follow-up text")
+      (with-current-buffer (get-buffer-create copilot-chat--buffer-name)
+        (copilot-chat-mode)
+        (setq copilot-chat--conversation-id "conv-1"))
+      (copilot-chat-compose)
+      (expect 'copilot-chat--send-turn
+              :to-have-been-called-with "follow-up text")
+      (expect 'copilot-chat--create :not :to-have-been-called))
+
+    (it "does not send whitespace-only input"
+      (spy-on 'copilot-chat--edit-in-buffer :and-return-value "   \n\t ")
+      (expect (copilot-chat-compose) :to-throw 'user-error)
+      (expect 'copilot-chat--create :not :to-have-been-called)
+      (expect 'copilot-chat--send-turn :not :to-have-been-called))
+
+    (it "does not send when the compose buffer is cancelled"
+      (spy-on 'copilot-chat--edit-in-buffer
+              :and-call-fake (lambda (&rest _) (signal 'quit nil)))
+      (copilot-chat-compose)
+      (expect 'copilot-chat--create :not :to-have-been-called)
+      (expect 'copilot-chat--send-turn :not :to-have-been-called)))
+
+  (describe "copilot-chat-display"
+    (it "errors when no chat buffer exists"
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name))
+      (expect (copilot-chat-display) :to-throw 'user-error))
+
+    (it "displays the existing chat buffer"
+      (get-buffer-create copilot-chat--buffer-name)
+      (spy-on 'display-buffer)
+      (copilot-chat-display)
+      (expect 'display-buffer
+              :to-have-been-called-with
+              (get-buffer copilot-chat--buffer-name))))
+
   ;;
   ;; Conversation creation params
   ;;
@@ -2126,10 +2179,31 @@
                 :to-equal '(:result "dismiss"))
         (expect copilot-chat--tool-edits :to-be nil)))
 
+    (it "edits a shell command through the compose buffer"
+      (let ((copilot-chat--tool-edits nil))
+        (spy-on 'copilot-chat--ask-tool :and-return-value 'edit)
+        ;; The compose helper stands in for the recursive-edit buffer.
+        (spy-on 'copilot-chat--edit-in-buffer :and-return-value "echo safe")
+        (spy-on 'copilot-chat--execute-run-in-terminal
+                :and-return-value (copilot-chat--tool-result "success" "ok"))
+        (copilot-chat--handle-tool-confirmation
+         (list :name "run_in_terminal"
+               :toolCallId "cls_c"
+               :input (list :command "rm -rf /")))
+        (copilot-chat--handle-tool-invocation
+         (list :name "run_in_terminal"
+               :toolCallId "cls_c"
+               :input (list :command "rm -rf /")))
+        (expect 'copilot-chat--execute-run-in-terminal
+                :to-have-been-called-with (list :command "echo safe"))))
+
     (it "edits a fetch_web_page URL list back into a vector"
       (let ((copilot-chat--tool-edits nil))
         (spy-on 'copilot-chat--ask-tool :and-return-value 'edit)
-        (spy-on 'read-string :and-return-value "https://a.test https://b.test")
+        ;; The compose helper returns whitespace/newline-separated URLs,
+        ;; which the field reader splits back into a vector.
+        (spy-on 'copilot-chat--edit-in-buffer
+                :and-return-value "https://a.test\nhttps://b.test")
         (spy-on 'copilot-chat--execute-fetch-web-page
                 :and-return-value (copilot-chat--tool-result "success" "ok"))
         (copilot-chat--handle-tool-confirmation

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -954,7 +954,22 @@
               :and-call-fake (lambda (&rest _) (signal 'quit nil)))
       (copilot-chat-compose)
       (expect 'copilot-chat--create :not :to-have-been-called)
-      (expect 'copilot-chat--send-turn :not :to-have-been-called)))
+      (expect 'copilot-chat--send-turn :not :to-have-been-called))
+
+    (it "refuses to compose while a response is streaming"
+      ;; The busy check runs before the compose buffer opens, so a long
+      ;; draft is not composed only to be discarded by the send guard.
+      (spy-on 'copilot-chat--edit-in-buffer)
+      (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t))
+              (expect (copilot-chat-compose) :to-throw 'user-error)
+              (expect 'copilot-chat--edit-in-buffer
+                      :not :to-have-been-called))
+          (kill-buffer buf)))))
 
   (describe "copilot-chat-display"
     (it "errors when no chat buffer exists"


### PR DESCRIPTION
Two chat input improvements, the top papercut from the UX audit:

- `copilot-chat-compose` (`C-c C-e`) opens a writable buffer to draft a multi-line message with normal editing and yank, sent with `C-c C-c` and cancelled with `C-c C-k`. It routes through `copilot-chat`, so all the send dispatch (new conversation vs follow-up, busy checks, context attach) is reused, not forked. The quick one-line `copilot-chat`/`copilot-chat-send` path is unchanged.
- `copilot-chat-display` (`C-c C-d`) reveals the existing chat buffer without demanding a message.

The existing `copilot-chat--edit-in-buffer` helper (already used for tool-argument editing) was generalized to back all three, and the agent-mode tool-argument edits for `run_in_terminal` commands and `fetch_web_page` URLs now use the same multi-line buffer instead of a cramped one-line minibuffer.

From the adversarial review: composing while a response streams checked the busy state only after the compose buffer was torn down, discarding the draft; the guard now runs up front.

597 specs pass, checkdoc clean, no new compile warnings.