### PR TITLE
Add response actions: copy, navigate, regenerate, rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add `copilot-chat-compose` (bound to `C-c C-e` in the chat buffer) to draft a multi-line message in a dedicated writable buffer, sending it with `C-c C-c` (as a new conversation or a follow-up, just like `copilot-chat`) or cancelling with `C-c C-k`.
 - Add `copilot-chat-display` (bound to `C-c C-d` in the chat buffer) to show the existing chat buffer without sending a message.
+- Add commands for acting on a chat response, bound in the `*copilot-chat*` buffer:
+  - `copilot-chat-copy-response` (`C-c C-w`) copies the most recent reply to the kill ring.
+  - `copilot-chat-next-turn` (`C-c C-n`) and `copilot-chat-previous-turn` (`C-c C-p`) move between exchanges.
+  - `copilot-chat-retry` (`C-c C-r`) regenerates the answer to the last request, or with a prefix argument pre-fills it for editing before re-sending.
+  - `copilot-chat-rate-response` (`C-c C-t`), along with `copilot-chat-thumbs-up` and `copilot-chat-thumbs-down`, sends good/bad feedback about the current response to GitHub.
 
 ## 0.8.0 (2026-07-04)
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Key bindings in the `*copilot-chat*` buffer:
 
 Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
 
-`copilot-chat-retry` regenerates the last answer: it deletes the dead turn on the server, trims the exchange from the transcript, and re-sends the request so the buffer shows a single clean exchange rather than two. `copilot-chat-rate-response` (and the `copilot-chat-thumbs-up` / `copilot-chat-thumbs-down` shortcuts) sends good/bad feedback about the current response to GitHub; it is telemetry only and has no local effect.
+`copilot-chat-retry` regenerates the last answer: it deletes the dead turn on the server and re-sends the request. The original exchange stays put until the new answer arrives and then is replaced, so the buffer ends up with a single clean exchange, and a failed regenerate leaves the original untouched. `copilot-chat-rate-response` (and the `copilot-chat-thumbs-up` / `copilot-chat-thumbs-down` shortcuts) sends good/bad feedback about the current response to GitHub; it is telemetry only and has no local effect.
 
 The chat buffer's header line shows at a glance which mode is active (Agent, InlineAgent, Ask, or a selected custom mode), which model answers, and for an agent-kind mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,15 @@ Key bindings in the `*copilot-chat*` buffer:
 - **C-c /** — pick and send a slash command (`/explain`, `/fix`, `/tests`, ...)
 - **C-c C-f** — attach a file as context for the next message
 - **C-c C-d** — display the chat buffer without sending a message
+- **C-c C-w** — copy the most recent response to the kill ring
+- **C-c C-n** / **C-c C-p** — move to the next / previous exchange
+- **C-c C-r** — regenerate the answer to the last request (with a prefix argument, edit it first)
+- **C-c C-t** — rate the current response as good or bad
 - **q** — quit the chat window
 
 Attach extra context for the next message with `copilot-chat-add-file-reference` (`C-c C-f`) or `copilot-chat-add-region-reference`; `copilot-chat-clear-references` drops anything pending.
+
+`copilot-chat-retry` regenerates the last answer: it deletes the dead turn on the server, trims the exchange from the transcript, and re-sends the request so the buffer shows a single clean exchange rather than two. `copilot-chat-rate-response` (and the `copilot-chat-thumbs-up` / `copilot-chat-thumbs-down` shortcuts) sends good/bad feedback about the current response to GitHub; it is telemetry only and has no local effect.
 
 The chat buffer's header line shows at a glance which mode is active (Agent, InlineAgent, Ask, or a selected custom mode), which model answers, and for an agent-kind mode how many tools are available. Set `copilot-chat-show-status-header` to `nil` to hide it; the setting is read when the chat buffer is created, so it takes effect for new chat buffers.
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -2981,6 +2981,162 @@ and suggested change) in the chat buffer."
      root)))
 
 ;;
+;; Acting on a response
+;;
+
+(defconst copilot-chat--prompt-heading-re
+  "^\\(?:You:\\|\\* You\\)$"
+  "Regexp matching a user-prompt heading in either chat frontend.
+The markdown frontend writes `You:' and the org frontend `* You'.")
+
+(defun copilot-chat-copy-response ()
+  "Copy the most recent Copilot reply to the kill ring.
+The reply is taken from the recorded turns, so it is the clean answer
+text without the `You:'/`Copilot:' scaffolding.  Signal a `user-error'
+when the conversation has no answer yet."
+  (interactive)
+  (unless (derived-mode-p 'copilot-chat-mode)
+    (user-error "Copilot Chat: Not in a chat buffer"))
+  (let ((reply (cdr (car (last copilot-chat--turns)))))
+    (unless (and reply (not (string-empty-p reply)))
+      (user-error "Copilot Chat: No response to copy yet"))
+    (kill-new reply)
+    (message "Copilot Chat: Copied last response to kill ring")))
+
+(defun copilot-chat-next-turn ()
+  "Move point to the next exchange in the chat buffer.
+Search forward for the next user prompt (`You:' or `* You', depending on
+`copilot-chat-frontend').  Signal a `user-error' at the last exchange."
+  (interactive)
+  (unless (derived-mode-p 'copilot-chat-mode)
+    (user-error "Copilot Chat: Not in a chat buffer"))
+  (let ((start (point)))
+    ;; Step off the current line so a heading at point is not matched
+    ;; again as the "next" one.
+    (end-of-line)
+    (if (re-search-forward copilot-chat--prompt-heading-re nil t)
+        (goto-char (line-beginning-position))
+      (goto-char start)
+      (user-error "Copilot Chat: No next exchange"))))
+
+(defun copilot-chat-previous-turn ()
+  "Move point to the previous exchange in the chat buffer.
+Search backward for the preceding user prompt (`You:' or `* You',
+depending on `copilot-chat-frontend').  Signal a `user-error' at the
+first exchange."
+  (interactive)
+  (unless (derived-mode-p 'copilot-chat-mode)
+    (user-error "Copilot Chat: Not in a chat buffer"))
+  (let ((start (point)))
+    ;; Search from the line start so a heading at point is not matched as
+    ;; the "previous" one.
+    (beginning-of-line)
+    (if (re-search-backward copilot-chat--prompt-heading-re nil t)
+        (goto-char (line-beginning-position))
+      (goto-char start)
+      (user-error "Copilot Chat: No previous exchange"))))
+
+(defun copilot-chat--delete-turn (turn-id)
+  "Delete TURN-ID from the current conversation on the server.
+Best effort: a nil TURN-ID, a dead connection, or a server error is
+quietly ignored, so a failed delete never blocks re-sending."
+  (when (and turn-id
+             copilot-chat--conversation-id
+             (copilot--connection-alivep))
+    (copilot--async-request
+     'conversation/turnDelete
+     (list :conversationId copilot-chat--conversation-id
+           :turnId turn-id
+           :source "panel")
+     :error-fn (lambda (err)
+                 (copilot--log 'error "turnDelete failed: %S" err)))))
+
+(defun copilot-chat--delete-last-exchange ()
+  "Remove the last rendered You/Copilot exchange from the chat buffer."
+  (let ((inhibit-read-only t))
+    (goto-char (point-max))
+    (when (re-search-backward copilot-chat--prompt-heading-re nil t)
+      (delete-region (line-beginning-position) (point-max)))))
+
+(defun copilot-chat-retry (&optional edit)
+  "Regenerate the answer to the last request.
+Delete the last turn on the server (best effort), drop it from the
+transcript and the chat buffer, and re-send the same request so a fresh
+answer streams into a single clean exchange.
+
+With a prefix argument EDIT, pre-fill the last request in the minibuffer
+for editing before it is re-sent."
+  (interactive "P")
+  (unless (derived-mode-p 'copilot-chat-mode)
+    (user-error "Copilot Chat: Not in a chat buffer"))
+  (when (or copilot-chat--streaming-p copilot-chat--current-request)
+    (user-error "Copilot Chat: A response is currently being streamed"))
+  (unless copilot-chat--turns
+    (user-error "Copilot Chat: No previous request to retry"))
+  (unless copilot-chat--conversation-id
+    (user-error "Copilot Chat: No active conversation"))
+  (let* ((request (car (car (last copilot-chat--turns))))
+         (msg (if edit
+                  (read-string "Copilot Chat (retry): " request)
+                request)))
+    (when (string-empty-p msg)
+      (user-error "Copilot Chat: Empty message"))
+    ;; Delete the dead server turn so the conversation does not accumulate
+    ;; one; this is best effort and must not wedge the retry.
+    (copilot-chat--delete-turn copilot-chat--current-turn-id)
+    ;; Drop the last exchange from the recorded turns and the buffer so the
+    ;; regenerated answer replaces it instead of piling up beneath it.
+    (setq copilot-chat--turns (butlast copilot-chat--turns))
+    (copilot-chat--delete-last-exchange)
+    (copilot-chat--insert-prompt msg)
+    (copilot-chat--send-turn msg)))
+
+(defun copilot-chat--rate (rating)
+  "Send RATING for the current turn to the server as feedback.
+RATING is a positive number for a thumbs-up and a negative number for a
+thumbs-down.  Signal a `user-error' when there is no turn to rate or the
+connection is down."
+  (unless (derived-mode-p 'copilot-chat-mode)
+    (user-error "Copilot Chat: Not in a chat buffer"))
+  (unless copilot-chat--current-turn-id
+    (user-error "Copilot Chat: No response to rate yet"))
+  (unless (copilot--connection-alivep)
+    (user-error "Copilot Chat: Not connected to the Copilot server"))
+  (message "Copilot Chat: %s"
+           (if (> rating 0) "Sent positive feedback" "Sent negative feedback"))
+  ;; Keep the request as the tail form so its id is the return value,
+  ;; matching the other one-way request helpers.
+  (copilot--async-request
+   'conversation/rating
+   (list :turnId copilot-chat--current-turn-id
+         :rating rating
+         :source "panel")
+   :error-fn (lambda (err)
+               (copilot--log 'error "rating failed: %S" err))))
+
+(defun copilot-chat-thumbs-up ()
+  "Send positive feedback about the current Copilot response."
+  (interactive)
+  (copilot-chat--rate 1))
+
+(defun copilot-chat-thumbs-down ()
+  "Send negative feedback about the current Copilot response."
+  (interactive)
+  (copilot-chat--rate -1))
+
+(defun copilot-chat-rate-response (rating)
+  "Rate the current Copilot response as good or bad.
+RATING is the symbol `good' or `bad'; interactively, choose one with
+completion.  The rating is sent to GitHub as feedback telemetry and has
+no local effect."
+  (interactive
+   (list (intern (completing-read "Rate response: " '("good" "bad") nil t))))
+  (pcase rating
+    ('good (copilot-chat--rate 1))
+    ('bad (copilot-chat--rate -1))
+    (_ (user-error "Copilot Chat: Unknown rating `%s'" rating))))
+
+;;
 ;; Major mode
 ;;
 
@@ -2995,6 +3151,11 @@ and suggested change) in the chat buffer."
     (define-key map (kbd "C-c /") #'copilot-chat-slash-command)
     (define-key map (kbd "C-c C-f") #'copilot-chat-add-file-reference)
     (define-key map (kbd "C-c C-d") #'copilot-chat-display)
+    (define-key map (kbd "C-c C-w") #'copilot-chat-copy-response)
+    (define-key map (kbd "C-c C-n") #'copilot-chat-next-turn)
+    (define-key map (kbd "C-c C-p") #'copilot-chat-previous-turn)
+    (define-key map (kbd "C-c C-r") #'copilot-chat-retry)
+    (define-key map (kbd "C-c C-t") #'copilot-chat-rate-response)
     (define-key map (kbd "q") #'quit-window)
     map)
   "Keymap for `copilot-chat-mode'.")

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -323,6 +323,25 @@ faces; the underlying `header-line' face still applies on its own."
 (defvar-local copilot-chat--current-turn-id nil
   "Turn ID currently being streamed.")
 
+(defvar-local copilot-chat--last-request nil
+  "Text of the most recently sent request, kept for `copilot-chat-retry'.
+Unlike `copilot-chat--current-request' this survives turn completion and
+records the last request whether or not its turn succeeded, so retry
+always targets the request the user last sent.")
+
+(defvar-local copilot-chat--last-prompt-start nil
+  "Marker at the start of the last prompt inserted into the chat buffer.
+Lets `copilot-chat-retry' remove exactly the previous exchange by
+position instead of searching buffer text for a prompt heading, which a
+reply could spoof.")
+
+(defvar-local copilot-chat--retry-pending nil
+  "In-flight `copilot-chat-retry' state, or nil.
+A plist with `:start' (a marker at the exchange being regenerated) and
+`:recorded' (whether that exchange is in `copilot-chat--turns').  The old
+exchange is removed only once the replacement turn succeeds, so a failed
+regenerate never destroys the original answer.")
+
 (defvar-local copilot-chat--work-done-token nil
   "Token for routing `$/progress' notifications.")
 
@@ -645,6 +664,8 @@ and cleans up active tokens."
       (with-current-buffer buf
         (copilot-chat--end-streaming)
         (copilot-chat--remove-active-tokens buf)
+        ;; A failed retry keeps the original exchange in place.
+        (copilot-chat--finish-retry nil)
         ;; A failed turn never reaches the end-progress that would
         ;; clear the capture state; without this the busy guards would
         ;; wedge the chat closed for good.
@@ -849,12 +870,17 @@ so it never disrupts the end of a turn."
             (when copilot-chat--current-request
               (let ((reply (apply #'concat
                                   (nreverse copilot-chat--reply-chunks))))
-                (unless (or error-msg (string-empty-p reply))
+                (if (or error-msg (string-empty-p reply))
+                    ;; A failed/empty replacement leaves the original
+                    ;; exchange in place.
+                    (copilot-chat--finish-retry nil)
                   (setq copilot-chat--turns
                         (append copilot-chat--turns
                                 (list (cons copilot-chat--current-request
                                             reply))))
-                  (copilot-chat--save-history)))
+                  (copilot-chat--save-history)
+                  ;; The replacement landed; trim the exchange it replaced.
+                  (copilot-chat--finish-retry t)))
               (setq copilot-chat--current-request nil
                     copilot-chat--reply-chunks nil)))
           (copilot-chat--scroll-to-bottom)
@@ -1900,6 +1926,7 @@ of MESSAGE, so the new conversation picks up the saved context."
     (with-current-buffer (get-buffer copilot-chat--buffer-name)
       (setq copilot-chat--work-done-token token)
       (setq copilot-chat--current-request message
+            copilot-chat--last-request message
             copilot-chat--reply-chunks nil)
       (setq restored copilot-chat--restored-turns)
       (push (cons token (current-buffer)) copilot-chat--active-buffers))
@@ -1951,6 +1978,7 @@ of MESSAGE, so the new conversation picks up the saved context."
     (with-current-buffer chat-buf
       (setq copilot-chat--work-done-token token)
       (setq copilot-chat--current-request message
+            copilot-chat--last-request message
             copilot-chat--reply-chunks nil)
       (push (cons token chat-buf) copilot-chat--active-buffers)
       (let ((conv-id copilot-chat--conversation-id)
@@ -2145,6 +2173,11 @@ the `You:'/`Copilot:' scaffolding, the org frontend writes `* You' and
 `** Copilot' headings."
   (let ((inhibit-read-only t))
     (goto-char (point-max))
+    ;; Mark where this prompt starts so `copilot-chat-retry' can excise
+    ;; exactly this exchange later without matching buffer text.
+    (unless (markerp copilot-chat--last-prompt-start)
+      (setq copilot-chat--last-prompt-start (make-marker)))
+    (set-marker copilot-chat--last-prompt-start (point))
     (pcase copilot-chat-frontend
       ('org (copilot-chat--insert-prompt-org message))
       (_ (copilot-chat--insert-prompt-markdown message)))))
@@ -3051,18 +3084,39 @@ quietly ignored, so a failed delete never blocks re-sending."
      :error-fn (lambda (err)
                  (copilot--log 'error "turnDelete failed: %S" err)))))
 
-(defun copilot-chat--delete-last-exchange ()
-  "Remove the last rendered You/Copilot exchange from the chat buffer."
-  (let ((inhibit-read-only t))
-    (goto-char (point-max))
-    (when (re-search-backward copilot-chat--prompt-heading-re nil t)
-      (delete-region (line-beginning-position) (point-max)))))
+(defun copilot-chat--finish-retry (success)
+  "Resolve a pending `copilot-chat-retry' after its replacement turn ended.
+When SUCCESS, excise the exchange that was being regenerated from the
+buffer and, if it was a recorded turn, from `copilot-chat--turns',
+leaving only the fresh answer.  Otherwise leave the original exchange
+untouched, so a failed regenerate never loses it.  A no-op when no retry
+is pending."
+  (when copilot-chat--retry-pending
+    (let ((start (plist-get copilot-chat--retry-pending :start))
+          (recorded (plist-get copilot-chat--retry-pending :recorded)))
+      (when success
+        (let ((old (marker-position start))
+              (new (and (markerp copilot-chat--last-prompt-start)
+                        (marker-position copilot-chat--last-prompt-start))))
+          (when (and old new (< old new))
+            (let ((inhibit-read-only t))
+              (delete-region old new))))
+        (when recorded
+          ;; The new pair was just appended, so the turns now end with
+          ;; the OLD pair followed by the NEW one; drop the OLD.
+          (setq copilot-chat--turns
+                (append (butlast copilot-chat--turns 2)
+                        (last copilot-chat--turns)))
+          (copilot-chat--save-history)))
+      (when (markerp start) (set-marker start nil))
+      (setq copilot-chat--retry-pending nil))))
 
 (defun copilot-chat-retry (&optional edit)
   "Regenerate the answer to the last request.
-Delete the last turn on the server (best effort), drop it from the
-transcript and the chat buffer, and re-send the same request so a fresh
-answer streams into a single clean exchange.
+Re-send the last request so a fresh answer streams in; the previous
+exchange is replaced only once the new answer arrives, so a failed
+regenerate leaves the original in place.  The dead turn is also removed
+on the server (best effort).
 
 With a prefix argument EDIT, pre-fill the last request in the minibuffer
 for editing before it is re-sent."
@@ -3071,23 +3125,27 @@ for editing before it is re-sent."
     (user-error "Copilot Chat: Not in a chat buffer"))
   (when (or copilot-chat--streaming-p copilot-chat--current-request)
     (user-error "Copilot Chat: A response is currently being streamed"))
-  (unless copilot-chat--turns
+  (unless copilot-chat--last-request
     (user-error "Copilot Chat: No previous request to retry"))
   (unless copilot-chat--conversation-id
     (user-error "Copilot Chat: No active conversation"))
-  (let* ((request (car (car (last copilot-chat--turns))))
-         (msg (if edit
-                  (read-string "Copilot Chat (retry): " request)
-                request)))
+  (let ((msg (if edit
+                 (read-string "Copilot Chat (retry): " copilot-chat--last-request)
+               copilot-chat--last-request)))
     (when (string-empty-p msg)
       (user-error "Copilot Chat: Empty message"))
-    ;; Delete the dead server turn so the conversation does not accumulate
-    ;; one; this is best effort and must not wedge the retry.
+    ;; Remove the dead server turn (best effort) so the conversation does
+    ;; not accumulate one; it must never wedge the retry.
     (copilot-chat--delete-turn copilot-chat--current-turn-id)
-    ;; Drop the last exchange from the recorded turns and the buffer so the
-    ;; regenerated answer replaces it instead of piling up beneath it.
-    (setq copilot-chat--turns (butlast copilot-chat--turns))
-    (copilot-chat--delete-last-exchange)
+    ;; Remember the exchange to replace and whether it is a recorded turn,
+    ;; then send.  `copilot-chat--finish-retry' trims the old exchange only
+    ;; after the replacement succeeds.
+    (setq copilot-chat--retry-pending
+          (list :start (copy-marker (or copilot-chat--last-prompt-start
+                                        (point-max)))
+                :recorded (and copilot-chat--turns
+                               (equal (car (car (last copilot-chat--turns)))
+                                      copilot-chat--last-request))))
     (copilot-chat--insert-prompt msg)
     (copilot-chat--send-turn msg)))
 
@@ -3558,6 +3616,8 @@ only when there is nothing to cancel at all, reset the conversation."
         (copilot-chat--end-streaming)
         (copilot-chat--insert-error "Cancelled")
         (copilot-chat--remove-active-tokens chat-buf)
+        ;; A cancelled retry keeps the original exchange in place.
+        (copilot-chat--finish-retry nil)
         ;; The cancelled turn's end will never arrive; drop its capture
         ;; state so the busy guards don't wedge the chat closed.
         (setq copilot-chat--current-request nil
@@ -3576,9 +3636,11 @@ well; the saved history file on disk, if any, is left untouched (see
   (copilot-chat--destroy)
   (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
     (with-current-buffer buf
+      (copilot-chat--finish-retry nil)
       (setq copilot-chat--turns nil
             copilot-chat--restored-turns nil
             copilot-chat--current-request nil
+            copilot-chat--last-request nil
             copilot-chat--reply-chunks nil
             copilot-chat--turn-start-time nil
             copilot-chat--session-root nil)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -4372,6 +4372,209 @@
         (call-interactively 'copilot-chat-apply-preset)
         (expect 'completing-read :to-have-been-called)
         (expect copilot-chat-model :to-equal "gpt-4o")
-        (expect copilot-chat-use-agent-mode :to-be nil)))))
+        (expect copilot-chat-use-agent-mode :to-be nil))))
+
+  ;;
+  ;; Acting on a response
+  ;;
+
+  (describe "copilot-chat-copy-response"
+    (it "copies the last reply to the kill ring"
+      (let ((buf (get-buffer-create "*copilot-chat-test-copy*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--turns '(("q1" . "a1") ("q2" . "a2"))))
+              (spy-on 'message)
+              (with-current-buffer buf (copilot-chat-copy-response))
+              (expect (current-kill 0) :to-equal "a2"))
+          (kill-buffer buf))))
+
+    (it "errors when there is no response yet"
+      (let ((buf (get-buffer-create "*copilot-chat-test-copy-empty*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf (copilot-chat-mode))
+              (expect (with-current-buffer buf (copilot-chat-copy-response))
+                      :to-throw 'user-error))
+          (kill-buffer buf)))))
+
+  (describe "turn navigation"
+    (it "moves between exchanges and errors at the ends (markdown)"
+      (let ((copilot-chat-frontend 'markdown)
+            (buf (get-buffer-create "*copilot-chat-test-nav-md*")))
+        (unwind-protect
+            (with-current-buffer buf
+              (copilot-chat-mode)
+              (let ((inhibit-read-only t))
+                (insert "You:\nq1\n\nCopilot:\na1\n\n"
+                        "You:\nq2\n\nCopilot:\na2\n\n"))
+              (goto-char (point-min))
+              (copilot-chat-next-turn)
+              (expect (line-number-at-pos) :to-equal 7)
+              (copilot-chat-previous-turn)
+              (expect (line-number-at-pos) :to-equal 1)
+              (expect (copilot-chat-previous-turn) :to-throw 'user-error)
+              (copilot-chat-next-turn)
+              (expect (copilot-chat-next-turn) :to-throw 'user-error))
+          (kill-buffer buf))))
+
+    (it "moves between exchanges and errors at the ends (org)"
+      (let ((copilot-chat-frontend 'org)
+            (buf (get-buffer-create "*copilot-chat-test-nav-org*")))
+        (unwind-protect
+            (with-current-buffer buf
+              (copilot-chat-mode)
+              (let ((inhibit-read-only t))
+                (insert "* You\nq1\n\n** Copilot\na1\n\n"
+                        "* You\nq2\n\n** Copilot\na2\n\n"))
+              (goto-char (point-min))
+              (copilot-chat-next-turn)
+              (expect (line-number-at-pos) :to-equal 7)
+              (copilot-chat-previous-turn)
+              (expect (line-number-at-pos) :to-equal 1)
+              (expect (copilot-chat-previous-turn) :to-throw 'user-error)
+              (copilot-chat-next-turn)
+              (expect (copilot-chat-next-turn) :to-throw 'user-error))
+          (kill-buffer buf)))))
+
+  (describe "copilot-chat-retry"
+    (it "deletes the last turn, trims the exchange, and resends"
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry*"))
+            (captured nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"
+                      copilot-chat--current-turn-id "turn-1"
+                      copilot-chat--turns '(("q1" . "a1") ("q2" . "a2")))
+                (let ((inhibit-read-only t))
+                  (insert "You:\nq1\n\nCopilot:\na1\n\n"
+                          "You:\nq2\n\nCopilot:\na2\n\n")))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--send-turn)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn method params &rest _args)
+                        (push (cons method params) captured)
+                        (cons nil nil)))
+              (with-current-buffer buf (copilot-chat-retry))
+              ;; The dead server turn was deleted, correlated by id.
+              (let ((del (assq 'conversation/turnDelete captured)))
+                (expect del :to-be-truthy)
+                (expect (plist-get (cdr del) :conversationId) :to-equal "conv-1")
+                (expect (plist-get (cdr del) :turnId) :to-equal "turn-1"))
+              ;; The last exchange is gone from the recorded turns...
+              (with-current-buffer buf
+                (expect copilot-chat--turns :to-equal '(("q1" . "a1")))
+                ;; ...and the stale answer is gone from the buffer, with a
+                ;; single fresh prompt re-rendered for the request.
+                (expect (buffer-string) :not :to-match "a2")
+                (expect (buffer-string) :to-match "You:\nq1"))
+              ;; The request was re-sent verbatim.
+              (expect 'copilot-chat--send-turn :to-have-been-called-with "q2"))
+          (kill-buffer buf))))
+
+    (it "pre-fills the request for editing with a prefix argument"
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry-edit*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"
+                      copilot-chat--current-turn-id "turn-1"
+                      copilot-chat--turns '(("q2" . "a2")))
+                (let ((inhibit-read-only t))
+                  (insert "You:\nq2\n\nCopilot:\na2\n\n")))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--send-turn)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-return-value (cons nil nil))
+              (spy-on 'read-string :and-return-value "q2 edited")
+              (with-current-buffer buf (copilot-chat-retry t))
+              (expect 'read-string
+                      :to-have-been-called-with "Copilot Chat (retry): " "q2")
+              (expect 'copilot-chat--send-turn
+                      :to-have-been-called-with "q2 edited"))
+          (kill-buffer buf))))
+
+    (it "refuses to retry while a response is streaming"
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry-busy*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"
+                      copilot-chat--turns '(("q1" . "a1"))
+                      copilot-chat--streaming-p t))
+              (expect (with-current-buffer buf (copilot-chat-retry))
+                      :to-throw 'user-error))
+          (kill-buffer buf))))
+
+    (it "refuses to retry with no prior turn"
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry-none*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"))
+              (expect (with-current-buffer buf (copilot-chat-retry))
+                      :to-throw 'user-error))
+          (kill-buffer buf)))))
+
+  (describe "copilot-chat-rate-response"
+    (it "sends a positive rating for the current turn"
+      (let ((buf (get-buffer-create "*copilot-chat-test-rate-up*"))
+            (captured nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--current-turn-id "turn-9"))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'message)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn method params &rest _args)
+                        (push (cons method params) captured)
+                        (cons nil nil)))
+              (with-current-buffer buf (copilot-chat-thumbs-up))
+              (let ((r (assq 'conversation/rating captured)))
+                (expect r :to-be-truthy)
+                (expect (plist-get (cdr r) :turnId) :to-equal "turn-9")
+                (expect (plist-get (cdr r) :rating) :to-equal 1)))
+          (kill-buffer buf))))
+
+    (it "sends a negative rating for the current turn"
+      (let ((buf (get-buffer-create "*copilot-chat-test-rate-down*"))
+            (captured nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--current-turn-id "turn-9"))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'message)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn method params &rest _args)
+                        (push (cons method params) captured)
+                        (cons nil nil)))
+              (with-current-buffer buf (copilot-chat-thumbs-down))
+              (let ((r (assq 'conversation/rating captured)))
+                (expect r :to-be-truthy)
+                (expect (plist-get (cdr r) :rating) :to-equal -1)))
+          (kill-buffer buf))))
+
+    (it "errors when there is no turn to rate"
+      (let ((buf (get-buffer-create "*copilot-chat-test-rate-none*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf (copilot-chat-mode))
+              (expect (with-current-buffer buf (copilot-chat-thumbs-up))
+                      :to-throw 'user-error))
+          (kill-buffer buf))))))
 
 ;;; copilot-chat-test.el ends here

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -4440,19 +4440,33 @@
           (kill-buffer buf)))))
 
   (describe "copilot-chat-retry"
-    (it "deletes the last turn, trims the exchange, and resends"
+    ;; Set up a chat buffer with two rendered exchanges and the state
+    ;; retry reads; point `copilot-chat--last-prompt-start' at the last
+    ;; `You:' so retry knows the exchange boundary.
+    (defun copilot-chat-test--setup-retry (buf)
+      (with-current-buffer buf
+        (copilot-chat-mode)
+        (setq copilot-chat--conversation-id "conv-1"
+              copilot-chat--current-turn-id "turn-2"
+              copilot-chat--last-request "q2"
+              copilot-chat--turns '(("q1" . "a1") ("q2" . "a2")))
+        (let ((inhibit-read-only t))
+          (insert "You:\nq1\n\nCopilot:\na1\n\n")
+          (setq copilot-chat--last-prompt-start (copy-marker (point)))
+          (insert "You:\nq2\n\nCopilot:\na2\n\n"))))
+
+    (it "resends the last request and deletes the dead server turn"
       (let ((buf (get-buffer-create "*copilot-chat-test-retry*"))
             (captured nil))
         (unwind-protect
             (progn
+              (copilot-chat-test--setup-retry buf)
+              ;; The last prompt marker must reflect the last `You:'.
               (with-current-buffer buf
-                (copilot-chat-mode)
-                (setq copilot-chat--conversation-id "conv-1"
-                      copilot-chat--current-turn-id "turn-1"
-                      copilot-chat--turns '(("q1" . "a1") ("q2" . "a2")))
-                (let ((inhibit-read-only t))
-                  (insert "You:\nq1\n\nCopilot:\na1\n\n"
-                          "You:\nq2\n\nCopilot:\na2\n\n")))
+                (goto-char (point-min))
+                (search-forward "You:\nq2")
+                (set-marker copilot-chat--last-prompt-start
+                            (match-beginning 0)))
               (spy-on 'copilot--connection-alivep :and-return-value t)
               (spy-on 'copilot-chat--send-turn)
               (spy-on 'jsonrpc--async-request-1
@@ -4465,16 +4479,101 @@
               (let ((del (assq 'conversation/turnDelete captured)))
                 (expect del :to-be-truthy)
                 (expect (plist-get (cdr del) :conversationId) :to-equal "conv-1")
-                (expect (plist-get (cdr del) :turnId) :to-equal "turn-1"))
-              ;; The last exchange is gone from the recorded turns...
+                (expect (plist-get (cdr del) :turnId) :to-equal "turn-2"))
+              (expect 'copilot-chat--send-turn :to-have-been-called-with "q2")
               (with-current-buffer buf
-                (expect copilot-chat--turns :to-equal '(("q1" . "a1")))
-                ;; ...and the stale answer is gone from the buffer, with a
-                ;; single fresh prompt re-rendered for the request.
-                (expect (buffer-string) :not :to-match "a2")
-                (expect (buffer-string) :to-match "You:\nq1"))
-              ;; The request was re-sent verbatim.
-              (expect 'copilot-chat--send-turn :to-have-been-called-with "q2"))
+                ;; Nothing is trimmed yet: the original stays until the
+                ;; replacement lands, so a failed retry can't lose it.
+                (expect copilot-chat--turns
+                        :to-equal '(("q1" . "a1") ("q2" . "a2")))
+                (expect (buffer-string) :to-match "a2")
+                (expect copilot-chat--retry-pending :to-be-truthy)))
+          (kill-buffer buf))))
+
+    (it "trims the replaced exchange once the new answer succeeds"
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry-ok*")))
+        (unwind-protect
+            (progn
+              (copilot-chat-test--setup-retry buf)
+              (with-current-buffer buf
+                (goto-char (point-min))
+                (search-forward "You:\nq2")
+                (set-marker copilot-chat--last-prompt-start
+                            (match-beginning 0)))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--send-turn)
+              (spy-on 'jsonrpc--async-request-1 :and-return-value (cons nil nil))
+              (with-current-buffer buf
+                (copilot-chat-retry)
+                ;; Simulate the replacement turn completing: a fresh prompt
+                ;; was rendered by retry and its answer streamed in.
+                (let ((inhibit-read-only t)) (goto-char (point-max)) (insert "a2new\n\n"))
+                (setq copilot-chat--turns
+                      (append copilot-chat--turns '(("q2" . "a2new"))))
+                (copilot-chat--finish-retry t)
+                ;; The stale exchange is gone from both the turns and the
+                ;; buffer, leaving one clean q2 exchange.
+                (expect copilot-chat--turns
+                        :to-equal '(("q1" . "a1") ("q2" . "a2new")))
+                (expect (buffer-string) :not :to-match "a2\n")
+                (expect (buffer-string) :to-match "a2new")
+                (expect copilot-chat--retry-pending :to-be nil)))
+          (kill-buffer buf))))
+
+    (it "keeps the original exchange when the retry fails"
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry-fail*")))
+        (unwind-protect
+            (progn
+              (copilot-chat-test--setup-retry buf)
+              (with-current-buffer buf
+                (goto-char (point-min))
+                (search-forward "You:\nq2")
+                (set-marker copilot-chat--last-prompt-start
+                            (match-beginning 0)))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--send-turn)
+              (spy-on 'jsonrpc--async-request-1 :and-return-value (cons nil nil))
+              (with-current-buffer buf
+                (copilot-chat-retry)
+                ;; The replacement fails.
+                (copilot-chat--finish-retry nil)
+                ;; The original answer is still present, nothing lost.
+                (expect copilot-chat--turns
+                        :to-equal '(("q1" . "a1") ("q2" . "a2")))
+                (expect (buffer-string) :to-match "a2")
+                (expect copilot-chat--retry-pending :to-be nil)))
+          (kill-buffer buf))))
+
+    (it "retries the last request even when its turn errored"
+      ;; Errored turns are not recorded in `copilot-chat--turns', so
+      ;; reading the request from there would resend the WRONG (older)
+      ;; request; `copilot-chat--last-request' has the real last one.
+      (let ((buf (get-buffer-create "*copilot-chat-test-retry-errored*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"
+                      copilot-chat--current-turn-id "turn-2"
+                      copilot-chat--last-request "q2-failed"
+                      ;; Only the earlier successful turn is recorded.
+                      copilot-chat--turns '(("q1" . "a1")))
+                (let ((inhibit-read-only t))
+                  (insert "You:\nq1\n\nCopilot:\na1\n\n")
+                  (setq copilot-chat--last-prompt-start (copy-marker (point)))
+                  (insert "You:\nq2-failed\n\nCopilot:\n[Error]\n\n")))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'copilot-chat--send-turn)
+              (spy-on 'jsonrpc--async-request-1 :and-return-value (cons nil nil))
+              (with-current-buffer buf (copilot-chat-retry))
+              ;; Resends the failed request, not the older recorded one.
+              (expect 'copilot-chat--send-turn
+                      :to-have-been-called-with "q2-failed")
+              ;; The recorded turn is not the one being retried, so it is
+              ;; not marked for removal.
+              (with-current-buffer buf
+                (expect (plist-get copilot-chat--retry-pending :recorded)
+                        :to-be nil)))
           (kill-buffer buf))))
 
     (it "pre-fills the request for editing with a prefix argument"
@@ -4485,6 +4584,7 @@
                 (copilot-chat-mode)
                 (setq copilot-chat--conversation-id "conv-1"
                       copilot-chat--current-turn-id "turn-1"
+                      copilot-chat--last-request "q2"
                       copilot-chat--turns '(("q2" . "a2")))
                 (let ((inhibit-read-only t))
                   (insert "You:\nq2\n\nCopilot:\na2\n\n")))


### PR DESCRIPTION
Adds commands for acting on a chat response, bound in the chat buffer:

- `copilot-chat-copy-response` (`C-c C-w`) copies the last answer to the kill ring.
- `copilot-chat-next-turn` / `copilot-chat-previous-turn` (`C-c C-n` / `C-c C-p`) jump between exchanges, in both the markdown and org frontends.
- `copilot-chat-retry` (`C-c C-r`) regenerates the answer to the last request (prefix arg edits it first), using the server's `conversation/turnDelete` to drop the dead turn.
- `copilot-chat-rate-response` / `copilot-chat-thumbs-up` / `copilot-chat-thumbs-down` (`C-c C-t`) send good/bad feedback via `conversation/rating` (telemetry only).

The adversarial review found two blocking bugs in the first cut of retry, now fixed:

- It located the exchange to delete by searching the buffer for a `You:`/`* You` heading, so a reply that contained such a line (a coding assistant showing a dialogue, or an org bullet) truncated the transcript at the wrong point. Retry now tracks the last prompt's start with a marker and removes exactly that exchange, no text search.
- It read the request to resend from the recorded turns, but errored turns aren't recorded, so retrying after a failed turn resent an older request and desynced the log. Retry now reads the last request from a dedicated variable that survives an errored turn.

It also made retry non-destructive: the original exchange is kept until the replacement answer succeeds, so a failed or cancelled regenerate no longer loses the original. Regression tests cover all three.

603 specs pass, checkdoc clean, no new compile warnings.