### PR TITLE
Show a streaming indicator and keep scrollback sticky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - `copilot-chat-next-turn` (`C-c C-n`) and `copilot-chat-previous-turn` (`C-c C-p`) move between exchanges.
   - `copilot-chat-retry` (`C-c C-r`) regenerates the answer to the last request, or with a prefix argument pre-fills it for editing before re-sending.
   - `copilot-chat-rate-response` (`C-c C-t`), along with `copilot-chat-thumbs-up` and `copilot-chat-thumbs-down`, sends good/bad feedback about the current response to GitHub.
+- Show an animated thinking indicator under the `Copilot:` label while a reply is being prepared, so the gap before the first streamed chunk no longer looks dead; it disappears the moment the reply starts (or the turn ends, is cancelled, or errors) and is disabled with `copilot-chat-show-thinking-indicator`.
+- Keep manual scrollback sticky while a reply streams: a chat window is only auto-scrolled to follow new output when it is already at the bottom, so scrolling up to re-read an earlier part of a long response no longer fights the stream.
 
 ## 0.8.0 (2026-07-04)
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The chat buffer's header line shows at a glance which mode is active (Agent, Inl
 
 Beyond the `copilot-chat-use-agent-mode` toggle (which flips between plain Agent and Ask), `M-x copilot-chat-select-mode` lets you pick any mode the server reports: the built-in `Ask`, `Agent`, and `InlineAgent`, plus any custom project modes. `InlineAgent` is an agent-kind mode with a restricted tool set aimed at inline editing, so tool-call confirmation, tool registration, and the tool count in the header apply to it just as they do to `Agent`. The choice takes effect on the next new conversation, since the mode is fixed when a conversation is created; until you pick one, `copilot-chat-use-agent-mode` still decides between Agent and Ask.
 
+While a reply is being prepared, a small animated indicator is shown under the `Copilot:` label so the wait before the first streamed chunk no longer looks dead; it disappears as soon as the reply starts (or the turn ends, is cancelled, or errors). Set `copilot-chat-show-thinking-indicator` to `nil` to turn it off. While a reply streams the chat window follows the new output only when it is already at the bottom, so you can scroll up to re-read an earlier part of a long response without the stream yanking you back down.
+
 When a turn finishes and you have looked away from the chat, copilot.el raises a desktop notification so you don't have to keep watching it stream. It fires only if the turn took at least `copilot-chat-notify-after-seconds` (10 by default, `nil` disables it) and the chat buffer is not the one in your selected window. The backend prefers D-Bus, falls back to `osascript` on macOS, and to a plain `message` elsewhere; override it via `copilot-chat-notify-function`.
 
 Chat sessions can be persisted across Emacs restarts. Set `copilot-chat-save-history` to `t` (it is off by default, since transcripts land on disk in plain text) and the whole session is saved after each completed turn, one file per workspace under `copilot-chat-history-directory` (`~/.emacs.d/copilot-chat-history/` by default). `M-x copilot-chat-restore` brings the saved conversation back: the transcript reappears in the chat buffer, and the next message continues it with the full context (the saved turns are replayed to the server when the new conversation starts). `copilot-chat-clear-history` deletes the current workspace's saved history; `copilot-chat-reset` clears only the live session and leaves the file alone.
@@ -282,6 +284,7 @@ Customization:
 - **`copilot-chat-save-history`** — save the chat transcript to disk after each turn, for `copilot-chat-restore` (default `nil`)
 - **`copilot-chat-history-directory`** — where saved transcripts live, one file per workspace (default `~/.emacs.d/copilot-chat-history/`)
 - **`copilot-chat-presets`** — named bundles of chat settings you can switch between with `copilot-chat-apply-preset` (default `nil`)
+- **`copilot-chat-show-thinking-indicator`** — animate a thinking indicator while a reply is being prepared (default `t`)
 - **`copilot-chat-notify-after-seconds`** — notify when a turn finishes and you have looked away, but only if it ran at least this long (default `10`, `nil` disables)
 - **`copilot-chat-notify-function`** — function called with a title and body to raise the notification (default `copilot-chat--notify`)
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -169,6 +169,19 @@ for new chat buffers."
   :group 'copilot-chat
   :package-version '(copilot . "0.8"))
 
+(defcustom copilot-chat-show-thinking-indicator t
+  "When non-nil, animate a thinking indicator while a reply streams.
+Between sending a message and the arrival of the first reply chunk the
+chat buffer would otherwise show a bare `Copilot:' label with no sign
+that anything is happening.  With this enabled a small animated spinner
+is shown at the end of the buffer for that gap and removed as soon as the
+first chunk arrives (or the turn ends, is cancelled, or errors).  It is
+only shown for the chat buffer's streamed replies, never for one-shot
+requests such as commit-message generation."
+  :type 'boolean
+  :group 'copilot-chat
+  :package-version '(copilot . "0.9"))
+
 (defcustom copilot-chat-frontend 'markdown
   "Markup used to render the Copilot Chat buffer.
 With the default `markdown' value the buffer is highlighted as
@@ -303,6 +316,11 @@ faces; the underlying `header-line' face still applies on its own."
   "Face for tool invocation lines in the chat buffer."
   :group 'copilot-chat)
 
+(defface copilot-chat-thinking-face
+  '((t :inherit shadow :slant italic))
+  "Face for the streaming thinking indicator in the chat buffer."
+  :group 'copilot-chat)
+
 (defface copilot-chat-diff-added-face
   '((t :inherit diff-added))
   "Face for added lines in a tool edit preview."
@@ -382,6 +400,21 @@ Paired with the accumulated reply and appended to
   "`float-time' when the current streamed turn began, or nil.
 Set at the progress `begin' notification and read at `end' to decide
 whether the turn ran long enough to warrant a desktop notification.")
+
+(defvar-local copilot-chat--thinking-overlay nil
+  "Overlay carrying the streaming thinking indicator, or nil.
+The indicator rides on the overlay's `after-string', so it never becomes
+real buffer text and cannot be swallowed by streamed output; removing it
+is just deleting the overlay.")
+
+(defvar-local copilot-chat--thinking-timer nil
+  "Timer animating the thinking indicator, or nil.
+Always cancelled by `copilot-chat--stop-thinking-indicator', which runs
+on the first reply chunk and on every end, cancel, and error path, so no
+timer is ever left running.")
+
+(defvar-local copilot-chat--thinking-frame 0
+  "Index of the thinking indicator's current spinner frame.")
 
 (defvar-local copilot-chat--restored-turns nil
   "Turns restored by `copilot-chat-restore', pending replay.
@@ -648,8 +681,73 @@ Return nil when no model can be resolved, letting the server pick."
         (cl-remove-if (lambda (entry) (eq (cdr entry) buf))
                       copilot-chat--active-buffers)))
 
+;;
+;; Streaming thinking indicator
+;;
+
+(defconst copilot-chat--thinking-frames ["|" "/" "-" "\\"]
+  "Spinner frames cycled by the streaming thinking indicator.")
+
+(defconst copilot-chat--thinking-interval 0.15
+  "Seconds between thinking-indicator animation frames.")
+
+(defun copilot-chat--thinking-string ()
+  "Return the display string for the current thinking-indicator frame."
+  (propertize
+   (format "%s Thinking..."
+           (aref copilot-chat--thinking-frames
+                 (mod copilot-chat--thinking-frame
+                      (length copilot-chat--thinking-frames))))
+   'face 'copilot-chat-thinking-face))
+
+(defun copilot-chat--thinking-tick (buffer timer)
+  "Advance the thinking-indicator animation in BUFFER, driven by TIMER.
+When BUFFER is dead or its indicator overlay is gone, cancel TIMER so a
+killed or finished chat buffer can never leave the animation running."
+  (if (and (buffer-live-p buffer)
+           (buffer-local-value 'copilot-chat--thinking-overlay buffer))
+      (with-current-buffer buffer
+        (setq copilot-chat--thinking-frame (1+ copilot-chat--thinking-frame))
+        (overlay-put copilot-chat--thinking-overlay
+                     'after-string (copilot-chat--thinking-string)))
+    (cancel-timer timer)))
+
+(defun copilot-chat--start-thinking-indicator ()
+  "Show an animated thinking indicator at the end of the chat buffer.
+Does nothing when `copilot-chat-show-thinking-indicator' is nil.  The
+indicator lives on an overlay's `after-string', so streamed text is never
+eaten, and it is removed by `copilot-chat--stop-thinking-indicator'."
+  (when copilot-chat-show-thinking-indicator
+    ;; Never stack two indicators; clear any leftover first.
+    (copilot-chat--stop-thinking-indicator)
+    (setq copilot-chat--thinking-frame 0)
+    (let ((ov (make-overlay (point-max) (point-max) nil t t)))
+      (overlay-put ov 'after-string (copilot-chat--thinking-string))
+      (setq copilot-chat--thinking-overlay ov))
+    (let* ((buffer (current-buffer))
+           ;; Create the timer, then point it at itself so a tick fired
+           ;; after the buffer is killed can cancel the exact timer.
+           (timer (run-with-timer copilot-chat--thinking-interval
+                                  copilot-chat--thinking-interval
+                                  #'ignore)))
+      (timer-set-function timer #'copilot-chat--thinking-tick
+                          (list buffer timer))
+      (setq copilot-chat--thinking-timer timer))))
+
+(defun copilot-chat--stop-thinking-indicator ()
+  "Remove the streaming thinking indicator and stop its animation.
+Idempotent and safe to call from the report, end, cancel, and error
+paths: it leaves no timer running and no indicator behind."
+  (when (timerp copilot-chat--thinking-timer)
+    (cancel-timer copilot-chat--thinking-timer))
+  (setq copilot-chat--thinking-timer nil)
+  (when (overlayp copilot-chat--thinking-overlay)
+    (delete-overlay copilot-chat--thinking-overlay))
+  (setq copilot-chat--thinking-overlay nil))
+
 (defun copilot-chat--end-streaming ()
   "Reset streaming state in the current chat buffer."
+  (copilot-chat--stop-thinking-indicator)
   (setq copilot-chat--streaming-p nil)
   (setq copilot-chat--request-id nil)
   (force-mode-line-update))
@@ -829,65 +927,73 @@ so it never disrupts the end of a turn."
          ((equal kind "begin")
           (setq copilot-chat--streaming-p t)
           (setq copilot-chat--turn-start-time (float-time))
+          (copilot-chat--start-thinking-indicator)
           (force-mode-line-update))
          ((equal kind "report")
+          ;; The first chunk means the reply is flowing; drop the
+          ;; thinking indicator even if this report carries no text.
+          (copilot-chat--stop-thinking-indicator)
           (when-let* ((reply (copilot-chat--extract-reply value)))
             (when copilot-chat--current-request
               (push reply copilot-chat--reply-chunks))
-            (let ((inhibit-read-only t))
+            ;; Decide which windows are following the stream before the
+            ;; insert; a window scrolled up to re-read is left alone.
+            (let ((windows (copilot-chat--following-windows (current-buffer)))
+                  (inhibit-read-only t))
               (goto-char (point-max))
-              (insert reply))
-            (copilot-chat--scroll-to-bottom)))
+              (insert reply)
+              (copilot-chat--scroll-windows windows))))
          ((equal kind "end")
-          (copilot-chat--end-streaming)
-          (let* ((result (plist-get value :result))
-                 ;; The server normally sends an object here, but
-                 ;; guard against any other shape.
-                 (result (and (listp result) result))
-                 (error-msg (copilot-chat--error-text
-                             (plist-get result :error))))
-            ;; Reset the follow-up every turn so a stale one from a
-            ;; previous turn is never re-inserted.
-            (setq copilot-chat--follow-up (plist-get result :followUp))
-            (let ((inhibit-read-only t))
-              (goto-char (point-max))
-              (insert "\n\n")
-              ;; Surface a turn-level error the server reports at the
-              ;; end, which would otherwise leave only an empty reply.
-              (when error-msg
-                (insert (copilot-chat--format-error error-msg)))
-              (when (and (stringp copilot-chat--follow-up)
-                         (not (string-empty-p copilot-chat--follow-up)))
-                (insert (propertize
-                         (format "Follow-up: %s\n\n" copilot-chat--follow-up)
-                         'face 'copilot-chat-follow-up-face))))
-            ;; Record the completed turn in the session log; one-shot
-            ;; (function-sink) requests never set a current request, so
-            ;; they are never captured here.  An errored or empty turn
-            ;; is dropped rather than recorded: replaying a question
-            ;; with a blank answer to the server (and re-rendering it on
-            ;; restore) helps nobody.
-            (when copilot-chat--current-request
-              (let ((reply (apply #'concat
-                                  (nreverse copilot-chat--reply-chunks))))
-                (if (or error-msg (string-empty-p reply))
-                    ;; A failed/empty replacement leaves the original
-                    ;; exchange in place.
-                    (copilot-chat--finish-retry nil)
-                  (setq copilot-chat--turns
-                        (append copilot-chat--turns
-                                (list (cons copilot-chat--current-request
-                                            reply))))
-                  (copilot-chat--save-history)
-                  ;; The replacement landed; trim the exchange it replaced.
-                  (copilot-chat--finish-retry t)))
-              (setq copilot-chat--current-request nil
-                    copilot-chat--reply-chunks nil)))
-          (copilot-chat--scroll-to-bottom)
-          (copilot-chat--maybe-notify-turn-end chat-buf)
-          (setq copilot-chat--turn-start-time nil)
-          (setq copilot-chat--active-buffers
-                (assoc-delete-all token copilot-chat--active-buffers))))))))
+          (let ((windows (copilot-chat--following-windows (current-buffer))))
+            (copilot-chat--end-streaming)
+            (let* ((result (plist-get value :result))
+                   ;; The server normally sends an object here, but
+                   ;; guard against any other shape.
+                   (result (and (listp result) result))
+                   (error-msg (copilot-chat--error-text
+                               (plist-get result :error))))
+              ;; Reset the follow-up every turn so a stale one from a
+              ;; previous turn is never re-inserted.
+              (setq copilot-chat--follow-up (plist-get result :followUp))
+              (let ((inhibit-read-only t))
+                (goto-char (point-max))
+                (insert "\n\n")
+                ;; Surface a turn-level error the server reports at the
+                ;; end, which would otherwise leave only an empty reply.
+                (when error-msg
+                  (insert (copilot-chat--format-error error-msg)))
+                (when (and (stringp copilot-chat--follow-up)
+                           (not (string-empty-p copilot-chat--follow-up)))
+                  (insert (propertize
+                           (format "Follow-up: %s\n\n" copilot-chat--follow-up)
+                           'face 'copilot-chat-follow-up-face))))
+              ;; Record the completed turn in the session log; one-shot
+              ;; (function-sink) requests never set a current request, so
+              ;; they are never captured here.  An errored or empty turn
+              ;; is dropped rather than recorded: replaying a question
+              ;; with a blank answer to the server (and re-rendering it on
+              ;; restore) helps nobody.
+              (when copilot-chat--current-request
+                (let ((reply (apply #'concat
+                                    (nreverse copilot-chat--reply-chunks))))
+                  (if (or error-msg (string-empty-p reply))
+                      ;; A failed/empty replacement leaves the original
+                      ;; exchange in place.
+                      (copilot-chat--finish-retry nil)
+                    (setq copilot-chat--turns
+                          (append copilot-chat--turns
+                                  (list (cons copilot-chat--current-request
+                                              reply))))
+                    (copilot-chat--save-history)
+                    ;; The replacement landed; trim the exchange it replaced.
+                    (copilot-chat--finish-retry t)))
+                (setq copilot-chat--current-request nil
+                      copilot-chat--reply-chunks nil)))
+            (copilot-chat--scroll-windows windows)
+            (copilot-chat--maybe-notify-turn-end chat-buf)
+            (setq copilot-chat--turn-start-time nil)
+            (setq copilot-chat--active-buffers
+                  (assoc-delete-all token copilot-chat--active-buffers)))))))))
 
 (copilot-on-notification '$/progress #'copilot-chat--handle-progress)
 
@@ -2142,12 +2248,42 @@ the conversation is destroyed.  Cancellable with `copilot-chat-stop'."
 ;; UI helpers
 ;;
 
+(defun copilot-chat--following-windows (buffer)
+  "Return the windows showing BUFFER whose point is following the stream.
+A window counts as following when its point sits within a couple of lines
+of `point-max'.  Call this before an insertion: the pre-insert position
+is what should decide whether the window keeps up with new output, so a
+window scrolled up to re-read earlier text stays put while one already at
+the bottom follows along.  A buffer can be shown in several windows, so
+every window across all frames is considered."
+  (let (following)
+    (with-current-buffer buffer
+      (let ((threshold (save-excursion
+                         (goto-char (point-max))
+                         (forward-line -2)
+                         (point))))
+        (dolist (win (get-buffer-window-list buffer nil t))
+          (when (>= (window-point win) threshold)
+            (push win following)))))
+    following))
+
+(defun copilot-chat--scroll-windows (windows)
+  "Scroll each live window in WINDOWS to show the end of its buffer.
+Used with the list from `copilot-chat--following-windows' so only the
+windows that were already following the stream keep up with new output."
+  (dolist (win windows)
+    (when (window-live-p win)
+      (with-selected-window win
+        (goto-char (point-max))
+        (recenter -1)))))
+
 (defun copilot-chat--scroll-to-bottom ()
-  "Scroll chat window to show the latest output."
-  (when-let* ((win (get-buffer-window copilot-chat--buffer-name)))
-    (with-selected-window win
-      (goto-char (point-max))
-      (recenter -1))))
+  "Scroll the chat windows that are following the stream to the latest output.
+Only windows whose point is still at (or within a line or two of) the end
+of the buffer are scrolled; a window scrolled up to re-read earlier
+output is left in place so it does not fight the stream."
+  (when-let* ((buf (get-buffer copilot-chat--buffer-name)))
+    (copilot-chat--scroll-windows (copilot-chat--following-windows buf))))
 
 (defun copilot-chat--insert-prompt-markdown (message)
   "Insert the markdown prompt scaffolding for MESSAGE at point.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -940,8 +940,13 @@ so it never disrupts the end of a turn."
             ;; insert; a window scrolled up to re-read is left alone.
             (let ((windows (copilot-chat--following-windows (current-buffer)))
                   (inhibit-read-only t))
-              (goto-char (point-max))
-              (insert reply)
+              ;; `save-excursion' keeps buffer point (and thus a
+              ;; scrolled-up selected window's point) from being dragged
+              ;; to `point-max'; only the snapshotted following windows
+              ;; are scrolled.
+              (save-excursion
+                (goto-char (point-max))
+                (insert reply))
               (copilot-chat--scroll-windows windows))))
          ((equal kind "end")
           (let ((windows (copilot-chat--following-windows (current-buffer))))
@@ -956,17 +961,18 @@ so it never disrupts the end of a turn."
               ;; previous turn is never re-inserted.
               (setq copilot-chat--follow-up (plist-get result :followUp))
               (let ((inhibit-read-only t))
-                (goto-char (point-max))
-                (insert "\n\n")
-                ;; Surface a turn-level error the server reports at the
-                ;; end, which would otherwise leave only an empty reply.
-                (when error-msg
-                  (insert (copilot-chat--format-error error-msg)))
-                (when (and (stringp copilot-chat--follow-up)
-                           (not (string-empty-p copilot-chat--follow-up)))
-                  (insert (propertize
-                           (format "Follow-up: %s\n\n" copilot-chat--follow-up)
-                           'face 'copilot-chat-follow-up-face))))
+                (save-excursion
+                  (goto-char (point-max))
+                  (insert "\n\n")
+                  ;; Surface a turn-level error the server reports at the
+                  ;; end, which would otherwise leave only an empty reply.
+                  (when error-msg
+                    (insert (copilot-chat--format-error error-msg)))
+                  (when (and (stringp copilot-chat--follow-up)
+                             (not (string-empty-p copilot-chat--follow-up)))
+                    (insert (propertize
+                             (format "Follow-up: %s\n\n" copilot-chat--follow-up)
+                             'face 'copilot-chat-follow-up-face)))))
               ;; Record the completed turn in the session log; one-shot
               ;; (function-sink) requests never set a current request, so
               ;; they are never captured here.  An errored or empty turn

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -665,7 +665,29 @@
                 (expect (window-point win) :to-equal 3)))
           (delete-other-windows)
           (kill-buffer buf)
-          (kill-buffer other)))))
+          (kill-buffer other))))
+
+    (it "leaves the SELECTED window scrolled up untouched"
+      ;; The common case: the user is reading the chat in the selected
+      ;; window, scrolled up.  A bare `goto-char' would move buffer point
+      ;; (which is the selected window's point) to the bottom.
+      (let ((buf (get-buffer-create "*copilot-chat-test-sticky-selected*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t)
+                (let ((inhibit-read-only t))
+                  (insert "You:\nhi\n\nCopilot:\nline\nline\nline\n")))
+              (set-window-buffer (selected-window) buf)
+              (set-window-point (selected-window) 3)
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "report" :reply "streamed line\n"))))
+              (expect (window-point (selected-window)) :to-equal 3))
+          (kill-buffer buf)))))
 
   ;;
   ;; Turn-end desktop notification

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -477,6 +477,197 @@
           (kill-buffer buf)))))
 
   ;;
+  ;; Streaming thinking indicator
+  ;;
+
+  (describe "streaming thinking indicator"
+    (it "shows an overlay indicator and schedules a timer on begin"
+      (let ((buf (get-buffer-create "*copilot-chat-test-thinking-begin*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p nil))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "begin")))
+                (with-current-buffer buf
+                  (expect (overlayp copilot-chat--thinking-overlay)
+                          :to-be-truthy)
+                  (expect (timerp copilot-chat--thinking-timer)
+                          :to-be-truthy)
+                  ;; It rides on the overlay's after-string, so it never
+                  ;; becomes real buffer text that streamed output could eat.
+                  (expect (buffer-string) :not :to-match "Thinking")
+                  (expect (overlay-get copilot-chat--thinking-overlay
+                                       'after-string)
+                          :to-match "Thinking")
+                  ;; Never leave a live timer running behind the spec.
+                  (copilot-chat--stop-thinking-indicator))))
+          (kill-buffer buf))))
+
+    (it "removes the indicator on the first reply chunk"
+      (let ((buf (get-buffer-create "*copilot-chat-test-thinking-report*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p nil))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "begin")))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "report" :reply "Hi")))
+                (with-current-buffer buf
+                  (expect copilot-chat--thinking-overlay :to-be nil)
+                  (expect copilot-chat--thinking-timer :to-be nil)
+                  (expect (buffer-string) :to-match "Hi"))))
+          (kill-buffer buf))))
+
+    (it "removes the indicator when a turn ends with no reply"
+      (let ((buf (get-buffer-create "*copilot-chat-test-thinking-end*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p nil))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "begin")))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "end")))
+                (with-current-buffer buf
+                  (expect copilot-chat--thinking-overlay :to-be nil)
+                  (expect copilot-chat--thinking-timer :to-be nil))))
+          (kill-buffer buf))))
+
+    (it "removes the indicator when the turn is cancelled"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p nil)
+                (setq copilot-chat--request-id 42))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "begin"))))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc-notify)
+              (copilot-chat-stop)
+              (with-current-buffer buf
+                (expect copilot-chat--thinking-overlay :to-be nil)
+                (expect copilot-chat--thinking-timer :to-be nil)))
+          (kill-buffer buf))))
+
+    (it "removes the indicator when the turn errors"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p nil))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "begin"))))
+              (copilot-chat--handle-request-error "boom" "turn")
+              (with-current-buffer buf
+                (expect copilot-chat--thinking-overlay :to-be nil)
+                (expect copilot-chat--thinking-timer :to-be nil)))
+          (kill-buffer buf))))
+
+    (it "does nothing when the indicator is disabled"
+      (let ((buf (get-buffer-create "*copilot-chat-test-thinking-off*"))
+            (copilot-chat-show-thinking-indicator nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p nil))
+              (let ((copilot-chat--active-buffers
+                     (list (cons "test-token" buf))))
+                (copilot-chat--handle-progress
+                 (list :token "test-token"
+                       :value (list :kind "begin")))
+                (with-current-buffer buf
+                  (expect copilot-chat--thinking-overlay :to-be nil)
+                  (expect copilot-chat--thinking-timer :to-be nil))))
+          (kill-buffer buf)))))
+
+  ;;
+  ;; Sticky scrollback
+  ;;
+
+  (describe "sticky scrollback"
+    (it "follows the stream in a window parked at the end"
+      (let ((buf (get-buffer-create "*copilot-chat-test-sticky-follow*"))
+            (other (get-buffer-create "*copilot-chat-test-sticky-other*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t)
+                (let ((inhibit-read-only t))
+                  (insert "You:\nhi\n\nCopilot:\n")))
+              (set-window-buffer (selected-window) other)
+              (let ((win (split-window)))
+                (set-window-buffer win buf)
+                ;; Park this window's point at the very end: it is following.
+                (with-current-buffer buf
+                  (set-window-point win (point-max)))
+                (let ((copilot-chat--active-buffers
+                       (list (cons "test-token" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "test-token"
+                         :value (list :kind "report"
+                                      :reply "streamed line\n"))))
+                (with-current-buffer buf
+                  (expect (window-point win) :to-equal (point-max)))))
+          (delete-other-windows)
+          (kill-buffer buf)
+          (kill-buffer other))))
+
+    (it "leaves a window scrolled up untouched"
+      (let ((buf (get-buffer-create "*copilot-chat-test-sticky-scrolled*"))
+            (other (get-buffer-create "*copilot-chat-test-sticky-other2*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--streaming-p t)
+                (let ((inhibit-read-only t))
+                  (insert "You:\nhi\n\nCopilot:\nline\nline\nline\n")))
+              (set-window-buffer (selected-window) other)
+              (let ((win (split-window)))
+                (set-window-buffer win buf)
+                ;; Scroll this window up to re-read the top of the buffer.
+                (with-current-buffer buf
+                  (set-window-point win 3))
+                (let ((copilot-chat--active-buffers
+                       (list (cons "test-token" buf))))
+                  (copilot-chat--handle-progress
+                   (list :token "test-token"
+                         :value (list :kind "report"
+                                      :reply "streamed line\n"))))
+                ;; The stream did not yank the window down to the bottom.
+                (expect (window-point win) :to-equal 3)))
+          (delete-other-windows)
+          (kill-buffer buf)
+          (kill-buffer other)))))
+
+  ;;
   ;; Turn-end desktop notification
   ;;
 


### PR DESCRIPTION
Two feedback improvements while a response streams:

- An in-buffer thinking indicator: between sending and the first token, the chat showed a dead `Copilot:` label with no sign anything was happening. Now a small spinner animates there and vanishes on the first chunk. It rides an overlay `after-string` (streamed text can't eat it), its timer self-cancels if the buffer dies, and teardown funnels through `copilot-chat--end-streaming`, so end, cancel, error, and destroy all clean it up with no leaked timer. Disable with `copilot-chat-show-thinking-indicator`.
- Sticky scrollback: scrolling up to re-read a long streaming response no longer yanks you back to the bottom. Only windows already at the bottom follow the stream.

The adversarial review caught that the sticky-scroll fix, as first written, was defeated for the selected window: the bare `goto-char (point-max)` moved buffer point (which is the selected window's point) to the bottom before the snapshot-based scroll ran, so the feature only worked for non-selected windows, exactly the wrong way round. The inserts are now wrapped in `save-excursion`, and a new test covers the selected-window case the original tests missed.

598 specs pass, checkdoc clean, no new compile warnings.