### PR TITLE
Bind TAB in copilot-completion-map by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Show an animated thinking indicator under the `Copilot:` label while a reply is being prepared, so the gap before the first streamed chunk no longer looks dead; it disappears the moment the reply starts (or the turn ends, is cancelled, or errors) and is disabled with `copilot-chat-show-thinking-indicator`.
 - Keep manual scrollback sticky while a reply streams: a chat window is only auto-scrolled to follow new output when it is already at the bottom, so scrolling up to re-read an earlier part of a long response no longer fights the stream.
 
+### Changes
+
+- `copilot-mode` now binds `TAB` (accept the suggestion), `C-TAB` (accept by word), and `M-n`/`M-p` (cycle suggestions) in `copilot-completion-map`, so inline completion works out of the box. The bindings act only while a suggestion overlay is visible; rebind or clear the map to change them.
+
 ## 0.8.0 (2026-07-04)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ When a suggestion is pending:
 
 > [!NOTE]
 >
-> `copilot-nes-mode` predefines **TAB** and **C-g**, whereas `copilot-mode` ships no completion keybindings and leaves `copilot-completion-map` for you to populate. In both cases the bindings only take effect while a suggestion (or completion) is pending and otherwise fall through to their usual commands, so the predefined NES keys are safe to leave enabled.
+> Both `copilot-nes-mode` and `copilot-mode` ship default keybindings: NES predefines **TAB** and **C-g**, and `copilot-mode` predefines **TAB** (accept) plus a few more in `copilot-completion-map` (see [Keybindings](#keybindings)). In both cases the bindings only take effect while a suggestion (or completion) is pending and otherwise fall through to their usual commands, so they are safe to leave enabled.
 
 Customization variables:
 - **`copilot-nes-idle-delay`** — seconds of idle time before requesting a suggestion (default `0.5`)
@@ -391,7 +391,7 @@ Customization variables:
 
 ### Keybindings
 
-`copilot-mode` does not set any keybindings by default. Use `copilot-completion-map` (active while a completion overlay is visible) to bind keys:
+`copilot-mode` binds these keys in `copilot-completion-map`, active only while a completion overlay is visible (they otherwise fall through to their usual commands):
 
 ```elisp
 (keymap-set copilot-completion-map "<tab>" #'copilot-accept-completion)
@@ -402,11 +402,15 @@ Customization variables:
 (keymap-set copilot-completion-map "M-p" #'copilot-previous-completion)
 ```
 
+To change them, rebind the keys you want or clear the map, for example `(keymap-unset copilot-completion-map "TAB")`. The alternatives below are drop-in replacements.
+
 #### Fish-style keybindings
 
-If you use `company-mode` or `corfu`, TAB is already taken. An alternative inspired by Fish shell avoids the conflict entirely — right-arrow accepts, and forward-word/end-of-line accept partially:
+If you use `company-mode` or `corfu`, TAB is already taken. An alternative inspired by Fish shell avoids the conflict entirely — right-arrow accepts, and forward-word/end-of-line accept partially. Unbind the default TAB first, then:
 
 ```elisp
+(keymap-unset copilot-completion-map "<tab>")
+(keymap-unset copilot-completion-map "TAB")
 (keymap-set copilot-completion-map "<right>" #'copilot-accept-completion)
 (keymap-set copilot-completion-map "C-f" #'copilot-accept-completion)
 (keymap-set copilot-completion-map "M-<right>" #'copilot-accept-completion-by-word)

--- a/copilot.el
+++ b/copilot.el
@@ -1538,8 +1538,20 @@ publicly available code), unrelated to Emacs `xref' cross-references."
   "Posn information without overlay.
 To work around posn problems with after-string property.")
 
-(defconst copilot-completion-map (make-sparse-keymap)
-  "Keymap for Copilot completion overlay.")
+(defconst copilot-completion-map
+  (let ((map (make-sparse-keymap)))
+    (keymap-set map "<tab>" #'copilot-accept-completion)
+    (keymap-set map "TAB" #'copilot-accept-completion)
+    (keymap-set map "C-<tab>" #'copilot-accept-completion-by-word)
+    (keymap-set map "C-TAB" #'copilot-accept-completion-by-word)
+    (keymap-set map "M-n" #'copilot-next-completion)
+    (keymap-set map "M-p" #'copilot-previous-completion)
+    map)
+  "Keymap for Copilot completion overlay.
+These bindings are active only while a completion overlay is
+visible and otherwise fall through to their usual commands.  To
+disable them, rebind or clear this map, for example
+\(keymap-unset copilot-completion-map \"TAB\").")
 
 (defun copilot--posn-advice (&rest args)
   "Remap posn if in `copilot-mode' with ARGS."

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -1381,6 +1381,29 @@
           (expect (nth 2 result) :to-equal "lib)"))))))
 
   ;;
+  ;; copilot-completion-map
+  ;;
+
+  (describe "copilot-completion-map"
+    (it "binds TAB to accept the completion"
+      (expect (keymap-lookup copilot-completion-map "TAB")
+              :to-be 'copilot-accept-completion)
+      (expect (keymap-lookup copilot-completion-map "<tab>")
+              :to-be 'copilot-accept-completion))
+
+    (it "binds C-TAB to accept by word"
+      (expect (keymap-lookup copilot-completion-map "C-TAB")
+              :to-be 'copilot-accept-completion-by-word)
+      (expect (keymap-lookup copilot-completion-map "C-<tab>")
+              :to-be 'copilot-accept-completion-by-word))
+
+    (it "binds M-n/M-p to cycle completions"
+      (expect (keymap-lookup copilot-completion-map "M-n")
+              :to-be 'copilot-next-completion)
+      (expect (keymap-lookup copilot-completion-map "M-p")
+              :to-be 'copilot-previous-completion)))
+
+  ;;
   ;; copilot-accept-completion
   ;;
 


### PR DESCRIPTION
`copilot-mode` shipped with an empty `copilot-completion-map`, so a new user saw ghost text but TAB did nothing until they read the README and populated the map themselves. `copilot-nes-mode` already predefines TAB and C-g the exact same way, so the "no default bindings" stance was inconsistent within the package.

This populates `copilot-completion-map` with the canonical set the README already recommended:

- `TAB` / `<tab>` accept the suggestion
- `C-TAB` / `C-<tab>` accept by word
- `M-n` / `M-p` cycle suggestions

The bindings are overlay-scoped: they only take effect while a suggestion overlay is visible and otherwise fall through to the usual commands, so normal TAB indentation is untouched when nothing is pending. corfu/company users who want TAB free can clear it with `(keymap-unset copilot-completion-map "TAB")`, and the README's Fish-style section now shows that.

README and CHANGELOG updated; added a keymap regression test.