### PR TITLE
Let the copilot panel accept a solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `copilot-chat-rate-response` (`C-c C-t`), along with `copilot-chat-thumbs-up` and `copilot-chat-thumbs-down`, sends good/bad feedback about the current response to GitHub.
 - Show an animated thinking indicator under the `Copilot:` label while a reply is being prepared, so the gap before the first streamed chunk no longer looks dead; it disappears the moment the reply starts (or the turn ends, is cancelled, or errors) and is disabled with `copilot-chat-show-thinking-indicator`.
 - Keep manual scrollback sticky while a reply streams: a chat window is only auto-scrolled to follow new output when it is already at the bottom, so scrolling up to re-read an earlier part of a long response no longer fights the stream.
+- Add `copilot-panel-accept-completion` to insert a solution from the `*copilot-panel*` buffer back into the buffer that requested it. Move to a suggestion and press `RET` or `C-c C-c`; previously the panel could only be read, never accepted from.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ To customize when completions trigger, see `copilot-enable-predicates` and `copi
 
 Alternatively, you can call `copilot-complete` manually and use `copilot-clear-overlay` in `post-command-hook` to dismiss completions.
 
+`copilot-panel-complete` opens a `*copilot-panel*` buffer listing several suggestions for the point at once, sorted by score. Move to the one you want and press `RET` (or `C-c C-c`) to insert it back at the position you invoked the command from.
+
 ### Chat
 
 `copilot-chat` opens an interactive chat with GitHub Copilot using the `conversation/*` LSP methods. The chat buffer streams responses in real time and automatically provides the current buffer as context.
@@ -523,6 +525,7 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-mode` | Toggle automatic completions in the current buffer |
 | `copilot-complete` | Trigger a completion at point |
 | `copilot-panel-complete` | Show a panel buffer with multiple completion suggestions |
+| `copilot-panel-accept-completion` | Insert the panel solution at point (`RET`/`C-c C-c` in the panel) |
 | `copilot-accept-completion` | Accept the current completion |
 | `copilot-accept-completion-by-word` | Accept the next N words (prefix arg) |
 | `copilot-accept-completion-by-line` | Accept the next N lines (prefix arg) |

--- a/copilot.el
+++ b/copilot.el
@@ -1236,6 +1236,17 @@ TRIGGER-KIND is 1 for invoked, 2 for automatic (default)."
 (defvar copilot--panel-lang nil
   "Language of current panel solutions.")
 
+(defvar-local copilot--panel-target nil
+  "Marker in the buffer that requested the current panel solutions.
+Points at the position where an accepted solution is inserted.")
+
+(defvar-local copilot--panel-solutions nil
+  "Hash table mapping a solution's SHA to its raw completion text.
+The panel renders each solution as an Org source block, but the text
+is recovered from this table rather than by re-parsing the block, so a
+completion that itself contains Org markup (a `#+END_SRC' line, a
+`*'-heading line) round-trips intact.")
+
 (defvar copilot--request-handlers (make-hash-table :test 'equal)
   "Hash table storing request handlers.")
 
@@ -1283,19 +1294,23 @@ Each request METHOD can have only one HANDLER."
  (lambda (msg)
    (copilot--dbind (((:completionText completion-text)) ((:score completion-score))) msg
      (with-current-buffer "*copilot-panel*"
-       (unless (member (secure-hash 'sha256 completion-text)
-                       (org-map-entries (lambda () (org-entry-get nil "SHA"))))
-         (save-excursion
-           (goto-char (point-max))
-           (insert "* Solution\n"
-                   "  :PROPERTIES:\n"
-                   "  :SCORE: " (number-to-string completion-score) "\n"
-                   "  :SHA: " (secure-hash 'sha256 completion-text) "\n"
-                   "  :END:\n"
-                   "#+BEGIN_SRC " copilot--panel-lang "\n"
-                   completion-text "\n#+END_SRC\n\n")
-           (goto-char (point-min))
-           (org-sort-entries nil ?R nil nil "SCORE")))))))
+       (let ((sha (secure-hash 'sha256 completion-text)))
+         (unless (member sha (org-map-entries (lambda () (org-entry-get nil "SHA"))))
+           (unless (hash-table-p copilot--panel-solutions)
+             (setq copilot--panel-solutions (make-hash-table :test 'equal)))
+           (puthash sha completion-text copilot--panel-solutions)
+           (let ((inhibit-read-only t))
+             (save-excursion
+               (goto-char (point-max))
+               (insert "* Solution\n"
+                       "  :PROPERTIES:\n"
+                       "  :SCORE: " (number-to-string completion-score) "\n"
+                       "  :SHA: " sha "\n"
+                       "  :END:\n"
+                       "#+BEGIN_SRC " copilot--panel-lang "\n"
+                       completion-text "\n#+END_SRC\n\n")
+               (goto-char (point-min))
+               (org-sort-entries nil ?R nil nil "SCORE")))))))))
 
 (copilot-on-notification
  'PanelSolutionsDone
@@ -1303,9 +1318,10 @@ Each request METHOD can have only one HANDLER."
    (copilot--log 'info "Finished synthesizing solutions.")
    (display-buffer "*copilot-panel*")
    (with-current-buffer "*copilot-panel*"
-     (save-excursion
-       (goto-char (point-max))
-       (insert "End of solutions.\n")))))
+     (let ((inhibit-read-only t))
+       (save-excursion
+         (goto-char (point-max))
+         (insert "End of solutions.\n"))))))
 
 (copilot-on-notification
  'didChangeStatus
@@ -1507,19 +1523,67 @@ publicly available code), unrelated to Emacs `xref' cross-references."
                                         (copilot--log 'warning "Copilot server timeout."))))
 
 
+(declare-function org-back-to-heading "org")
+
+(defun copilot--panel-solution-at-point ()
+  "Return the completion text of the panel solution at point, or nil.
+The text is recovered from `copilot--panel-solutions' by the SHA
+recorded on the enclosing heading, so a solution containing Org markup
+is returned verbatim rather than by re-parsing its source block."
+  (when (hash-table-p copilot--panel-solutions)
+    (save-excursion
+      (when (ignore-errors (org-back-to-heading t) t)
+        (let ((sha (org-entry-get nil "SHA")))
+          (and sha (gethash sha copilot--panel-solutions)))))))
+
+(defun copilot-panel-accept-completion ()
+  "Insert the panel solution at point into the buffer that requested it.
+Meant to be called from the *copilot-panel* buffer populated by
+`copilot-panel-complete'."
+  (interactive)
+  (let ((text (copilot--panel-solution-at-point))
+        (target copilot--panel-target))
+    (unless text
+      (user-error "No Copilot solution at point"))
+    (unless (and (markerp target) (buffer-live-p (marker-buffer target)))
+      (user-error "The buffer this panel came from is no longer available"))
+    (quit-window)
+    (pop-to-buffer (marker-buffer target))
+    (goto-char target)
+    (insert text)
+    (message "Copilot: inserted solution")))
+
+(defvar copilot-panel-mode-map
+  (let ((map (make-sparse-keymap)))
+    (keymap-set map "RET" #'copilot-panel-accept-completion)
+    (keymap-set map "C-c C-c" #'copilot-panel-accept-completion)
+    map)
+  "Keymap for `copilot-panel-mode'.")
+
+(define-minor-mode copilot-panel-mode
+  "Minor mode for the *copilot-panel* buffer.
+Accept the solution at point with \\[copilot-panel-accept-completion]."
+  :lighter " Copilot-Panel"
+  :keymap copilot-panel-mode-map)
+
 (defun copilot-panel-complete ()
-  "Pop a buffer with a list of suggested completions based on the current file ."
+  "Pop a buffer with a list of suggested completions based on the current file."
   (interactive)
   (require 'org)
   (setq copilot--last-doc-version copilot--doc-version)
   (setq copilot--panel-lang (copilot--get-language-id))
-
-  (copilot--get-panel-completions
-   (jsonrpc-lambda (&key solutionCountTarget)
-     (copilot--log 'info "Synthesizing %d solutions..." solutionCountTarget)))
-  (with-current-buffer (get-buffer-create "*copilot-panel*")
-    (org-mode)
-    (erase-buffer)))
+  (let ((target (point-marker)))
+    (copilot--get-panel-completions
+     (jsonrpc-lambda (&key solutionCountTarget)
+       (copilot--log 'info "Synthesizing %d solutions..." solutionCountTarget)))
+    (with-current-buffer (get-buffer-create "*copilot-panel*")
+      (org-mode)
+      (copilot-panel-mode 1)
+      (let ((inhibit-read-only t))
+        (erase-buffer))
+      (setq buffer-read-only t)
+      (setq copilot--panel-solutions (make-hash-table :test 'equal))
+      (setq copilot--panel-target target))))
 
 ;;
 ;; UI

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -1404,6 +1404,124 @@
               :to-be 'copilot-previous-completion)))
 
   ;;
+  ;; copilot-panel-accept-completion
+  ;;
+
+  (describe "copilot panel accept"
+    ;; Render TEXT into the current buffer exactly as the `PanelSolution'
+    ;; handler does: register it in the SHA table and splice it into a
+    ;; heading + source block.  Recovery keys off the SHA, never the block.
+    (defun copilot-test--panel-insert (text)
+      (require 'org)
+      (unless (hash-table-p copilot--panel-solutions)
+        (setq copilot--panel-solutions (make-hash-table :test 'equal)))
+      (let ((sha (secure-hash 'sha256 text)))
+        (puthash sha text copilot--panel-solutions)
+        (insert "* Solution\n"
+                "  :PROPERTIES:\n"
+                "  :SCORE: 0.9\n"
+                "  :SHA: " sha "\n"
+                "  :END:\n"
+                "#+BEGIN_SRC emacs-lisp\n"
+                text "\n#+END_SRC\n\n")))
+
+    (it "extracts the solution text at the heading"
+      (with-temp-buffer
+        (org-mode)
+        (copilot-test--panel-insert "(+ a b)")
+        (goto-char (point-min))
+        (expect (copilot--panel-solution-at-point) :to-equal "(+ a b)")))
+
+    (it "extracts the solution when point is inside the src block"
+      (with-temp-buffer
+        (org-mode)
+        (copilot-test--panel-insert "(+ a b)")
+        (goto-char (point-min))
+        (search-forward "(+ a b)")
+        (expect (copilot--panel-solution-at-point) :to-equal "(+ a b)")))
+
+    (it "round-trips a multi-line solution verbatim"
+      (with-temp-buffer
+        (org-mode)
+        (let ((text "(defun add (a b)\n  (+ a b))"))
+          (copilot-test--panel-insert text)
+          (goto-char (point-min))
+          (expect (copilot--panel-solution-at-point) :to-equal text))))
+
+    (it "round-trips a solution containing a #+END_SRC line"
+      ;; A naive re-parse of the Org block would treat the embedded
+      ;; #+END_SRC as the terminator and silently truncate the text.
+      (with-temp-buffer
+        (org-mode)
+        (let ((text "line1\n#+END_SRC\nline2"))
+          (copilot-test--panel-insert text)
+          (goto-char (point-min))
+          (expect (copilot--panel-solution-at-point) :to-equal text))))
+
+    (it "round-trips a solution whose lines look like Org headings"
+      ;; A naive re-parse would see these as headings and fail to find a
+      ;; src block, refusing to accept the (perfectly valid) solution.
+      (with-temp-buffer
+        (org-mode)
+        (let ((text "* item one\n* item two"))
+          (copilot-test--panel-insert text)
+          (goto-char (point-min))
+          (expect (copilot--panel-solution-at-point) :to-equal text))))
+
+    (it "returns nil when point is not on a solution"
+      (with-temp-buffer
+        (org-mode)
+        (setq copilot--panel-solutions (make-hash-table :test 'equal))
+        (insert "No solutions yet.\n")
+        (goto-char (point-min))
+        (expect (copilot--panel-solution-at-point) :to-be nil)))
+
+    (it "returns nil when no solutions have been recorded"
+      (with-temp-buffer
+        (org-mode)
+        (setq copilot--panel-solutions nil)
+        (insert "* Solution\n  :PROPERTIES:\n  :SHA: abc\n  :END:\n")
+        (goto-char (point-min))
+        (expect (copilot--panel-solution-at-point) :to-be nil)))
+
+    (it "inserts the solution into the originating buffer at the marker"
+      (let ((target (generate-new-buffer "copilot-panel-target"))
+            (panel (get-buffer-create "*copilot-panel*"))
+            (marker nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer target
+                (insert "prefix ")
+                (setq marker (point-marker))
+                (insert " suffix"))
+              (with-current-buffer panel
+                (org-mode)
+                (copilot-panel-mode)
+                (copilot-test--panel-insert "(+ a b)")
+                (setq copilot--panel-target marker)
+                (goto-char (point-min))
+                (switch-to-buffer panel)
+                (copilot-panel-accept-completion))
+              (expect (with-current-buffer target (buffer-string))
+                      :to-equal "prefix (+ a b) suffix"))
+          (kill-buffer target)
+          (when (buffer-live-p panel) (kill-buffer panel)))))
+
+    (it "errors when the origin buffer is gone"
+      (with-temp-buffer
+        (org-mode)
+        (copilot-test--panel-insert "(+ a b)")
+        (goto-char (point-min))
+        (setq-local copilot--panel-target nil)
+        (expect (copilot-panel-accept-completion) :to-throw 'user-error)))
+
+    (it "binds RET and C-c C-c to accept"
+      (expect (keymap-lookup copilot-panel-mode-map "RET")
+              :to-be 'copilot-panel-accept-completion)
+      (expect (keymap-lookup copilot-panel-mode-map "C-c C-c")
+              :to-be 'copilot-panel-accept-completion)))
+
+  ;;
   ;; copilot-accept-completion
   ;;
 


### PR DESCRIPTION
`copilot-panel-complete` pops a `*copilot-panel*` buffer listing several suggestions for point, sorted by score, but there was no way to act on one: you had to read a solution and retype it into your buffer by hand.

This adds `copilot-panel-accept-completion`, bound to `RET` and `C-c C-c` in the panel via a small `copilot-panel-mode`. Move to the solution you want and press the key; the code block for that entry is inserted back at the exact position `copilot-panel-complete` was invoked from (tracked with a marker, so edits elsewhere in the source buffer meanwhile are fine), and the panel is dismissed.

The panel buffer is now read-only so `RET`/`C-c C-c` aren't swallowed by `self-insert`/`org-return`; the two solution inserters bind `inhibit-read-only` so the async `PanelSolution`/`PanelSolutionsDone` notifications can still populate it.

Tests cover extraction (heading and in-block), the nil case, insertion at the marker, the missing-origin error, and the keymap. README and CHANGELOG updated.