### PR TITLE
Add copilot-chat-compact to reclaim conversation context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show an animated thinking indicator under the `Copilot:` label while a reply is being prepared, so the gap before the first streamed chunk no longer looks dead; it disappears the moment the reply starts (or the turn ends, is cancelled, or errors) and is disabled with `copilot-chat-show-thinking-indicator`.
 - Keep manual scrollback sticky while a reply streams: a chat window is only auto-scrolled to follow new output when it is already at the bottom, so scrolling up to re-read an earlier part of a long response no longer fights the stream.
 - Add `copilot-panel-accept-completion` to insert a solution from the `*copilot-panel*` buffer back into the buffer that requested it. Move to a suggestion and press `RET` or `C-c C-c`; previously the panel could only be read, never accepted from.
+- Add `copilot-chat-compact` (in the `copilot-menu` chat section) to compact the current chat conversation on demand: it asks the server to summarize the discussion so far, reclaiming token budget while the conversation continues. The visible transcript is left as-is, and it reports how many turns were compacted along with the resulting context usage.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ When a turn finishes and you have looked away from the chat, copilot.el raises a
 
 Chat sessions can be persisted across Emacs restarts. Set `copilot-chat-save-history` to `t` (it is off by default, since transcripts land on disk in plain text) and the whole session is saved after each completed turn, one file per workspace under `copilot-chat-history-directory` (`~/.emacs.d/copilot-chat-history/` by default). `M-x copilot-chat-restore` brings the saved conversation back: the transcript reappears in the chat buffer, and the next message continues it with the full context (the saved turns are replayed to the server when the new conversation starts). `copilot-chat-clear-history` deletes the current workspace's saved history; `copilot-chat-reset` clears only the live session and leaves the file alone.
 
+On a long-running conversation, `copilot-chat-compact` asks the server to summarize the discussion so far, reclaiming token budget while the conversation continues (the visible transcript is left as-is). The server already compacts automatically as the context fills; this triggers the same summarization on demand and reports how many turns were compacted and the resulting context usage. It is a no-op when there have been no new turns since the last compaction.
+
 `copilot-chat-rewrite` rewrites the active region according to a free-form instruction (e.g. "make it iterative"). The rewritten code is shown as a diff-style preview against the region and applied only after you confirm, so nothing is changed behind your back; the region is tracked with markers, so edits elsewhere in the buffer while the request is in flight are fine, while edits to the region itself drop the rewrite. The instruction preamble can be customized via `copilot-chat-rewrite-prompt`, the applied code is re-indented unless `copilot-chat-rewrite-indent` is set to `nil`, and a pending rewrite can be cancelled with `copilot-chat-stop`. Like `copilot-chat-insert-commit-message`, it runs outside the chat panel and never disturbs an ongoing conversation.
 
 `copilot-chat-insert-commit-message` generates a commit message from the staged changes and inserts it at point. It is meant to be called from a commit message buffer (e.g. Magit's `COMMIT_EDITMSG` or any `git-commit` buffer), but works from any buffer inside a git repository. It runs outside the chat panel, so it never disturbs an ongoing conversation; the instruction sent along with the diff can be customized via `copilot-chat-commit-message-prompt`.
@@ -554,6 +556,7 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-chat-review-region` | Review the selected code with native Copilot Code Review |
 | `copilot-chat-stop` | Cancel streaming, or reset the conversation if idle |
 | `copilot-chat-reset` | Destroy the current conversation and clear the chat buffer |
+| `copilot-chat-compact` | Compact the conversation on the server to reclaim context |
 | `copilot-chat-restore` | Restore the saved chat for the current workspace |
 | `copilot-chat-clear-history` | Delete the saved chat history for the current workspace |
 | `copilot-chat-insert-commit-message` | Generate a commit message for the staged changes and insert it at point |

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -3789,6 +3789,64 @@ well; the saved history file on disk, if any, is left untouched (see
       (let ((inhibit-read-only t))
         (erase-buffer)))))
 
+(defun copilot-chat--context-usage-string (context-info)
+  "Return a short \" (context N% used)\" note from CONTEXT-INFO, or \"\".
+CONTEXT-INFO is the server's post-compaction context report; its
+`:utilizationPercentage' is used when present."
+  (let ((pct (and context-info
+                  (plist-get context-info :utilizationPercentage))))
+    (if (numberp pct)
+        (format " (context %s%% used)"
+                (string-trim-right (format "%.1f" pct) "\\.0"))
+      "")))
+
+(defun copilot-chat-compact ()
+  "Compact the current chat conversation to reclaim context.
+Ask the language server to summarize the conversation so far (via its
+`conversation/compress' method), freeing token budget while the
+conversation continues.  The visible transcript is left untouched; only
+the server-side context that the next message is built from is
+compressed.  The server also compacts on its own as the context fills;
+this triggers the same summarization on demand.
+
+Signal a `user-error' when there is no active conversation or while a
+response is streaming.  The server declines when there have been no new
+turns since the last compaction, which is reported but not an error."
+  (interactive)
+  (let ((chat-buf (get-buffer copilot-chat--buffer-name)))
+    (unless (and chat-buf (buffer-live-p chat-buf)
+                 (buffer-local-value 'copilot-chat--conversation-id chat-buf))
+      (user-error "Copilot Chat: No active conversation to compact"))
+    (with-current-buffer chat-buf
+      (when (or copilot-chat--streaming-p copilot-chat--current-request)
+        (user-error "Copilot Chat: A response is currently being streamed"))
+      (unless (copilot--connection-alivep)
+        (user-error "Copilot Chat: Not connected to the language server"))
+      (let ((conv-id copilot-chat--conversation-id))
+        (message "Copilot Chat: Compacting conversation...")
+        (copilot--async-request
+         'conversation/compress
+         (list :conversationId conv-id)
+         :success-fn
+         (lambda (result)
+           (if (eq (plist-get result :success) t)
+               (let ((turns (or (plist-get result :turnCount) 0)))
+                 (message "Copilot Chat: Compacted %d turn%s%s"
+                          turns (if (= turns 1) "" "s")
+                          (copilot-chat--context-usage-string
+                           (plist-get result :contextInfo))))
+             (message "Copilot Chat: Nothing to compact (%s)"
+                      (or (copilot-chat--error-text (plist-get result :error))
+                          "no new turns since the last compaction"))))
+         :error-fn
+         (lambda (err)
+           (copilot--log 'error "Chat compaction failed: %S" err)
+           (message "Copilot Chat: Compaction failed: %s"
+                    (or (copilot-chat--error-text err) "unknown error")))
+         :timeout 130
+         :timeout-fn
+         (lambda () (message "Copilot Chat: Compaction timed out")))))))
+
 (defun copilot-chat-select-model ()
   "Interactively select a Copilot Chat model."
   (interactive)

--- a/copilot-menu.el
+++ b/copilot-menu.el
@@ -117,6 +117,7 @@ the boolean)."
        ("/" "Slash command" copilot-chat-slash-command)
        ("f" "Attach file as context" copilot-chat-add-file-reference)
        ("k" "Clear pending context" copilot-chat-clear-references)
+       ("C" "Compact conversation" copilot-chat-compact)
        ("m" copilot-chat-select-model
         :description copilot-menu--chat-model-description)]
       ["Agent"

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1059,6 +1059,96 @@
       (copilot-chat-reset)))
 
   ;;
+  ;; Compaction
+  ;;
+
+  (describe "copilot-chat--context-usage-string"
+    (it "returns an empty string for nil context-info"
+      (expect (copilot-chat--context-usage-string nil) :to-equal ""))
+
+    (it "drops a trailing .0 from a whole-number percentage"
+      (expect (copilot-chat--context-usage-string '(:utilizationPercentage 42.0))
+              :to-equal " (context 42% used)"))
+
+    (it "keeps a fractional percentage"
+      (expect (copilot-chat--context-usage-string '(:utilizationPercentage 42.5))
+              :to-equal " (context 42.5% used)"))
+
+    (it "ignores a non-numeric percentage"
+      (expect (copilot-chat--context-usage-string '(:utilizationPercentage nil))
+              :to-equal "")))
+
+  (describe "copilot-chat-compact"
+    (it "errors when there is no active conversation"
+      (when (get-buffer copilot-chat--buffer-name)
+        (kill-buffer copilot-chat--buffer-name))
+      (expect (copilot-chat-compact) :to-throw 'user-error))
+
+    (it "errors while a response is streaming"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"
+                      copilot-chat--streaming-p t))
+              (expect (copilot-chat-compact) :to-throw 'user-error))
+          (kill-buffer buf))))
+
+    (it "sends conversation/compress and reports the turn count on success"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name))
+            (captured nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"
+                      copilot-chat--streaming-p nil
+                      copilot-chat--current-request nil))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              ;; `copilot--async-request' is a macro; mock the inner
+              ;; primitive it expands to and capture the wrapped success-fn.
+              (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                      (lambda (_conn method params &rest args)
+                        (setq captured (list method params args))
+                        (list 1)))
+              (spy-on 'message)
+              (copilot-chat-compact)
+              (expect (nth 0 captured) :to-equal 'conversation/compress)
+              (expect (plist-get (nth 1 captured) :conversationId)
+                      :to-equal "conv-1")
+              (funcall (plist-get (nth 2 captured) :success-fn)
+                       '(:success t :turnCount 3
+                                  :contextInfo (:utilizationPercentage 50.0)))
+              (expect 'message :to-have-been-called-with
+                      "Copilot Chat: Compacted %d turn%s%s"
+                      3 "s" " (context 50% used)"))
+          (kill-buffer buf))))
+
+    (it "reports nothing to compact when the server declines"
+      (let ((buf (get-buffer-create copilot-chat--buffer-name))
+            (captured nil))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode)
+                (setq copilot-chat--conversation-id "conv-1"))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                      (lambda (_conn method params &rest args)
+                        (setq captured (list method params args))
+                        (list 1)))
+              (spy-on 'message)
+              (copilot-chat-compact)
+              (funcall (plist-get (nth 2 captured) :success-fn)
+                       '(:success :json-false
+                                  :error "No new turns since last compression"))
+              (expect 'message :to-have-been-called-with
+                      "Copilot Chat: Nothing to compact (%s)"
+                      "No new turns since last compression"))
+          (kill-buffer buf)))))
+
+  ;;
   ;; Destroy
   ;;
 

--- a/test/copilot-menu-test.el
+++ b/test/copilot-menu-test.el
@@ -31,6 +31,23 @@ optional description string)."
       (funcall walk copilot-menu--definition))
     (nreverse commands)))
 
+(defun copilot-menu-test--layout-keys ()
+  "Collect every suffix key string from `copilot-menu--definition'.
+A transient prefix has a single flat keymap, so these must be unique
+across the whole menu."
+  (let (keys)
+    (letrec ((walk
+              (lambda (x)
+                (cond
+                 ((vectorp x) (mapc walk x))
+                 ((and (consp x) (stringp (car x)))
+                  (let ((cand (if (stringp (nth 1 x)) (nth 2 x) (nth 1 x))))
+                    (when (and cand (symbolp cand))
+                      (push (car x) keys))))
+                 ((proper-list-p x) (mapc walk x))))))
+      (funcall walk copilot-menu--definition))
+    (nreverse keys)))
+
 (describe "copilot-menu"
   (it "is defined as a transient prefix when transient is available"
     (assume (featurep 'transient) "transient is not available")
@@ -55,6 +72,7 @@ optional description string)."
                          copilot-chat-slash-command
                          copilot-chat-add-file-reference
                          copilot-chat-clear-references
+                         copilot-chat-compact
                          copilot-chat-select-model
                          copilot-menu-toggle-agent-mode
                          copilot-chat-select-mode
@@ -71,7 +89,19 @@ optional description string)."
         (expect commands :to-contain command))
       ;; Exactly these, so a future suffix shape the walker doesn't
       ;; understand cannot silently drop commands from the check.
-      (expect (length commands) :to-equal 21)))
+      (expect (length commands) :to-equal 22)))
+
+  (it "binds every suffix to a distinct key"
+    ;; A transient prefix has a single flat keymap; a duplicate key
+    ;; silently shadows an earlier command (see the `c'/`C' split for
+    ;; complete vs compact).
+    (let* ((keys (copilot-menu-test--layout-keys))
+           (dups (seq-uniq
+                  (seq-filter (lambda (k) (> (seq-count (lambda (o) (equal o k))
+                                                        keys)
+                                             1))
+                              keys))))
+      (expect dups :to-equal nil)))
 
   (describe "copilot-menu-toggle-agent-mode"
     (it "flips copilot-chat-use-agent-mode"


### PR DESCRIPTION
The language server exposes a `conversation/compress` method (verified in the 1.517.0 bundle: registered handler, params `{conversationId}`, result `{success, turnCount, contextInfo, ...}`). It summarizes the conversation so far and reclaims token budget while the conversation continues.

`copilot-chat-compact` wires it up (also in the `copilot-menu` chat section):
- Guards on an active, non-streaming conversation and a live connection.
- Sends `conversation/compress` with the active conversation id and a long timeout (the summarization is an LLM call; the 10s jsonrpc default would drop it).
- On success reports the turn count and resulting context usage; when the server declines (no new turns since the last compaction) it says so without erroring.

Worth knowing: the server already auto-compacts as the context fills (hard cap, idle, token limit). This is just an on-demand trigger of the same partition-compression machinery (`reason: "manual"`), so it coexists rather than fights it. The visible transcript is untouched; only the server-side context the next message is built from is compressed.

Tests cover the percentage formatter, both guards, the request shape, and the success / declined message paths. README and CHANGELOG updated.