### PR TITLE
Unlock policy-locked chat models from copilot-chat-select-model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Keep manual scrollback sticky while a reply streams: a chat window is only auto-scrolled to follow new output when it is already at the bottom, so scrolling up to re-read an earlier part of a long response no longer fights the stream.
 - Add `copilot-panel-accept-completion` to insert a solution from the `*copilot-panel*` buffer back into the buffer that requested it. Move to a suggestion and press `RET` or `C-c C-c`; previously the panel could only be read, never accepted from.
 - Add `copilot-chat-compact` (in the `copilot-menu` chat section) to compact the current chat conversation on demand: it asks the server to summarize the discussion so far, reclaiming token budget while the conversation continues. The visible transcript is left as-is, and it reports how many turns were compacted along with the resulting context usage.
+- `copilot-chat-select-model` now flags premium and policy-locked models in the completion list, and selecting a policy-locked one prompts to accept its terms and enables it on the server (via `copilot/setModelPolicy`) before switching, instead of leaving you to hit an error on the next message.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -756,6 +756,12 @@ default from the server (its designated chat default, or an `auto` model)
 rather than leaving the model unset, which some servers answer with an empty
 reply.
 
+The completion list flags premium models (billed against your premium-request
+quota) and policy-locked ones (models whose provider terms you have not yet
+accepted). Selecting a policy-locked model prompts you to accept its terms and
+enables it on the server before switching, so you no longer have to leave Emacs
+to unlock a model in the GitHub settings.
+
 ### Public code references
 
 Copilot can detect when a suggestion closely matches publicly available code.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -3847,20 +3847,94 @@ turns since the last compaction, which is reported but not an error."
          :timeout-fn
          (lambda () (message "Copilot Chat: Compaction timed out")))))))
 
+(defun copilot-chat--model-locked-p (model)
+  "Return non-nil when MODEL is policy-locked (its terms are unaccepted).
+A model is locked when it carries a `:policy' whose `:state' is not
+\"enabled\"; a model with no policy is unrestricted.  A present policy
+with a missing or non-\"enabled\" state counts as locked, so a
+malformed entry errs toward asking for consent rather than silently
+using a gated model."
+  (let ((policy (plist-get model :policy)))
+    (and policy (not (equal (plist-get policy :state) "enabled")))))
+
+(defun copilot-chat--model-annotation (model)
+  "Return a bracketed marker string for MODEL, or an empty string.
+Flags a premium model (billed against the premium-request quota) and a
+policy-locked one."
+  (let* ((premium (eq (plist-get (plist-get model :billing) :is_premium) t))
+         (flags (delq nil (list (and premium "premium")
+                                (and (copilot-chat--model-locked-p model)
+                                     "locked")))))
+    (if flags (format " [%s]" (string-join flags ", ")) "")))
+
+(defun copilot-chat--set-model (model-id)
+  "Select MODEL-ID as the chat model and forget any cached default.
+Clearing the cache lets a later nil re-resolve the default from the
+server, mirroring the rest of the model-selection commands."
+  (setq copilot-chat-model model-id
+        copilot-chat--model-resolved nil))
+
+(defun copilot-chat--accept-model-policy (model)
+  "Ask to accept MODEL's policy terms and, on yes, enable it on the server.
+Prompt with the model's `:terms', then send `copilot/setModelPolicy' to
+accept them; the model is selected only once the server confirms.  A
+declined prompt leaves the current model untouched."
+  (let* ((model-id (plist-get model :id))
+         (terms (plist-get (plist-get model :policy) :terms)))
+    (if (not (yes-or-no-p
+              (format "Model %s requires accepting its terms%s.  Enable it? "
+                      model-id
+                      (if (and (stringp terms) (not (string-empty-p terms)))
+                          (format " (%s)" terms)
+                        ""))))
+        (message "Copilot Chat: %s left disabled" model-id)
+      (message "Copilot Chat: Enabling %s..." model-id)
+      ;; `copilot--async-request' drops its success handler when the
+      ;; buffer current at call time has been killed by the time the
+      ;; reply arrives.  Selecting a model touches only globals, so issue
+      ;; the request from a buffer that is always live; otherwise killing
+      ;; the buffer M-x was run from within the request window would let
+      ;; the server accept the policy while `copilot-chat-model' never
+      ;; updates.  This mirrors the one-shot conversation requests.
+      (with-current-buffer (get-buffer-create " *copilot-chat-one-shot*")
+        (copilot--async-request
+         'copilot/setModelPolicy
+         (list :model model-id :status "enabled")
+         :success-fn
+         (lambda (_result)
+           (copilot-chat--set-model model-id)
+           (message "Copilot Chat: Enabled and selected %s" model-id))
+         :error-fn
+         (lambda (err)
+           (message "Copilot Chat: Could not enable %s: %s"
+                    model-id
+                    (or (copilot-chat--error-text err) "unknown error")))
+         :timeout 30
+         :timeout-fn
+         (lambda ()
+           (message "Copilot Chat: Enabling %s timed out" model-id)))))))
+
 (defun copilot-chat-select-model ()
-  "Interactively select a Copilot Chat model."
+  "Interactively select a Copilot Chat model.
+Premium and policy-locked models are flagged in the completion list.
+Selecting a policy-locked model prompts to accept its terms and enables
+it via the server's `copilot/setModelPolicy' before switching; the model
+is selected only once the server confirms."
   (interactive)
   (let* ((choices (mapcar (lambda (m)
-                            (cons (format "%s (%s)" (plist-get m :modelName) (plist-get m :id))
-                                  (plist-get m :id)))
+                            (cons (format "%s (%s)%s"
+                                          (plist-get m :modelName)
+                                          (plist-get m :id)
+                                          (copilot-chat--model-annotation m))
+                                  m))
                           (copilot-chat--chat-models)))
          (choice (completing-read "Chat model: " choices nil t))
-         (model-id (cdr (assoc choice choices))))
-    (setq copilot-chat-model model-id
-          ;; Forget any cached default so clearing the model later
-          ;; re-resolves from the server.
-          copilot-chat--model-resolved nil)
-    (message "Copilot Chat: Model set to %s" model-id)))
+         (model (cdr (assoc choice choices)))
+         (model-id (plist-get model :id)))
+    (if (copilot-chat--model-locked-p model)
+        (copilot-chat--accept-model-policy model)
+      (copilot-chat--set-model model-id)
+      (message "Copilot Chat: Model set to %s" model-id))))
 
 ;;;###autoload
 (defun copilot-chat-apply-preset (name)

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -3558,7 +3558,131 @@
                   "GPT-4o (gpt-4o)"))
         (copilot-chat-select-model)
         (expect (length captured-choices) :to-equal 1)
-        (expect (cdar captured-choices) :to-equal "gpt-4o"))))
+        ;; Each choice maps its display string to the model plist now.
+        (expect (plist-get (cdar captured-choices) :id) :to-equal "gpt-4o")))
+
+    (it "flags premium and policy-locked models in the completion list"
+      (let ((copilot-chat-model nil)
+            (captured-choices nil))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc-request
+                :and-return-value
+                (list (list :modelName "Plain" :id "plain"
+                            :scopes (list "chat-panel"))
+                      (list :modelName "Premium" :id "premium"
+                            :scopes (list "chat-panel")
+                            :billing (list :is_premium t :multiplier 1))
+                      (list :modelName "Locked" :id "locked"
+                            :scopes (list "chat-panel")
+                            :policy (list :state "unconfigured" :terms "T&C"))
+                      (list :modelName "Both" :id "both"
+                            :scopes (list "chat-panel")
+                            :billing (list :is_premium t)
+                            :policy (list :state "unconfigured" :terms "T&C"))))
+        (spy-on 'completing-read
+                :and-call-fake
+                (lambda (_prompt choices &rest _args)
+                  (setq captured-choices choices)
+                  "Plain (plain)"))
+        (copilot-chat-select-model)
+        (expect (mapcar #'car captured-choices)
+                :to-equal '("Plain (plain)"
+                            "Premium (premium) [premium]"
+                            "Locked (locked) [locked]"
+                            "Both (both) [premium, locked]"))))
+
+    (it "enables a policy-locked model via setModelPolicy on consent"
+      (let ((copilot-chat-model nil)
+            (captured nil))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc-request
+                :and-return-value
+                (list (list :modelName "Locked" :id "locked"
+                            :scopes (list "chat-panel")
+                            :policy (list :state "unconfigured" :terms "T&C"))))
+        (spy-on 'completing-read :and-return-value "Locked (locked) [locked]")
+        (spy-on 'yes-or-no-p :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest args)
+                  (setq captured (list method params args))
+                  (list 1)))
+        (spy-on 'message)
+        (copilot-chat-select-model)
+        ;; The model is not set until the server confirms.
+        (expect copilot-chat-model :to-be nil)
+        (expect (nth 0 captured) :to-equal 'copilot/setModelPolicy)
+        (expect (plist-get (nth 1 captured) :model) :to-equal "locked")
+        (expect (plist-get (nth 1 captured) :status) :to-equal "enabled")
+        ;; Firing the success callback selects the model.
+        (funcall (plist-get (nth 2 captured) :success-fn) "OK")
+        (expect copilot-chat-model :to-equal "locked")))
+
+    (it "records the unlock even if the origin buffer is killed"
+      ;; The request is issued from a persistent buffer, so killing the
+      ;; buffer M-x ran from before the reply arrives must not drop the
+      ;; server-accepted unlock.
+      (let ((copilot-chat-model nil)
+            (captured nil)
+            (origin (generate-new-buffer "copilot-select-origin")))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc-request
+                :and-return-value
+                (list (list :modelName "Locked" :id "locked"
+                            :scopes (list "chat-panel")
+                            :policy (list :state "unconfigured" :terms "T&C"))))
+        (spy-on 'completing-read :and-return-value "Locked (locked) [locked]")
+        (spy-on 'yes-or-no-p :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (setq captured args)
+                  (list 1)))
+        (spy-on 'message)
+        (with-current-buffer origin
+          (copilot-chat-select-model))
+        (kill-buffer origin)
+        ;; The wrapped success-fn is bound to a live buffer, so it runs.
+        (funcall (plist-get captured :success-fn) "OK")
+        (expect copilot-chat-model :to-equal "locked")))
+
+    (it "leaves the model untouched when the terms prompt is declined"
+      (let ((copilot-chat-model "previous"))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc-request
+                :and-return-value
+                (list (list :modelName "Locked" :id "locked"
+                            :scopes (list "chat-panel")
+                            :policy (list :state "unconfigured" :terms "T&C"))))
+        (spy-on 'completing-read :and-return-value "Locked (locked) [locked]")
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (spy-on 'jsonrpc--async-request-1)
+        (spy-on 'message)
+        (copilot-chat-select-model)
+        (expect copilot-chat-model :to-equal "previous")
+        (expect 'jsonrpc--async-request-1 :not :to-have-been-called))))
+
+  (describe "copilot-chat--model-annotation"
+    (it "returns an empty string for an unrestricted model"
+      (expect (copilot-chat--model-annotation '(:id "m")) :to-equal ""))
+
+    (it "does not flag a model whose policy is already enabled"
+      (expect (copilot-chat--model-annotation
+               '(:id "m" :policy (:state "enabled" :terms "T")))
+              :to-equal ""))
+
+    (it "flags a locked model"
+      (expect (copilot-chat--model-annotation
+               '(:id "m" :policy (:state "unconfigured" :terms "T")))
+              :to-equal " [locked]"))
+
+    (it "flags a premium model"
+      (expect (copilot-chat--model-annotation
+               '(:id "m" :billing (:is_premium t)))
+              :to-equal " [premium]"))
+
+    (it "does not flag a non-premium billing entry"
+      (expect (copilot-chat--model-annotation
+               '(:id "m" :billing (:is_premium :json-false)))
+              :to-equal "")))
 
   (describe "copilot-chat--handle-mcp-tools"
     (before-each (setq copilot-chat--mcp-servers nil


### PR DESCRIPTION
The `copilot/models` response already tells us which models are gated: each entry can carry `policy: {state, terms}` (verified in the 1.517.0 bundle; locked when `state` != `"enabled"`) and `billing: {is_premium, multiplier, ...}`. And the server exposes a real `copilot/setModelPolicy {model, status: "enabled"}` request (registered handler; it POSTs the acceptance to GitHub's backend and refetches metadata).

This uses both:
- `copilot-chat-select-model` now flags **premium** and **policy-locked** models in the completion list, e.g. `Claude Opus 4.8 (claude-opus-4-8) [premium, locked]`.
- Selecting a policy-locked model prompts with its `terms` and, on consent, sends `copilot/setModelPolicy` to accept them on the server. The model is switched only once the server confirms; declining leaves the current model untouched.

Before this, a policy-locked model could be selected but would just error on the next message, with no in-Emacs way to accept the terms.

Tests cover the annotation for plain/premium/locked/both, the unlocked path, the locked-consent path (asserts the request shape and that the model is set only from the success callback), and the declined path (nothing sent, model unchanged). README and CHANGELOG updated.