### PR TITLE
Route chat to BYOK models from the model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add `copilot-panel-accept-completion` to insert a solution from the `*copilot-panel*` buffer back into the buffer that requested it. Move to a suggestion and press `RET` or `C-c C-c`; previously the panel could only be read, never accepted from.
 - Add `copilot-chat-compact` (in the `copilot-menu` chat section) to compact the current chat conversation on demand: it asks the server to summarize the discussion so far, reclaiming token budget while the conversation continues. The visible transcript is left as-is, and it reports how many turns were compacted along with the resulting context usage.
 - `copilot-chat-select-model` now flags premium and policy-locked models in the completion list, and selecting a policy-locked one prompts to accept its terms and enables it on the server (via `copilot/setModelPolicy`) before switching, instead of leaving you to hit an error on the next message.
+- Add support for using Bring Your Own Key (BYOK) models in chat: `copilot-chat-select-model` lists your registered BYOK models (tagged `[BYOK: PROVIDER]`) alongside Copilot's own, and selecting one routes chat turns to that provider using your own API key. Using a BYOK model needs a BYOK-eligible Copilot account.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -762,6 +762,12 @@ accepted). Selecting a policy-locked model prompts you to accept its terms and
 enables it on the server before switching, so you no longer have to leave Emacs
 to unlock a model in the GitHub settings.
 
+Any Bring Your Own Key (BYOK) models you have registered are listed too, tagged
+`[BYOK: PROVIDER]`. Selecting one routes your chat turns to that provider using
+your own API key (held by the language server), rather than through Copilot's
+models. Using a BYOK model requires a BYOK-eligible Copilot account; without one
+the server rejects the turn with a "BYOK is disabled for this account" error.
+
 ### Public code references
 
 Copilot can detect when a suggestion closely matches publicly available code.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -468,11 +468,30 @@ Tracked separately from `copilot-chat--resolved-model' so that a nil
 result (no usable default) is cached too and not re-queried on every
 message.")
 
+(defvar copilot-chat--model-provider nil
+  "Provider name of the selected BYOK model, or nil for a Copilot model.
+Set alongside `copilot-chat-model' by `copilot-chat-select-model' when a
+Bring Your Own Key model is chosen; sent as `modelInfo.providerName' so
+the server routes the turn to that provider.")
+
 (defun copilot-chat--chat-models ()
   "Return the models the server scopes for the chat panel."
   (seq-filter (lambda (m)
                 (seq-contains-p (plist-get m :scopes) "chat-panel"))
               (copilot--request 'copilot/models nil :timeout 5)))
+
+(defun copilot-chat--byok-models ()
+  "Return the user's registered Bring Your Own Key models, or nil.
+These come from `copilot/byok/listModels' and never appear in
+`copilot/models', so model selection queries them separately.
+Best-effort: a server without the method, or any error, yields nil so
+model selection still works."
+  (condition-case nil
+      (seq-filter (lambda (m) (eq (plist-get m :isRegistered) t))
+                  (plist-get (copilot--request 'copilot/byok/listModels nil
+                                               :timeout 5)
+                             :models))
+    (error nil)))
 
 (defun copilot-chat--resolve-default-model ()
   "Query the server for a default chat model id, or nil.
@@ -665,10 +684,19 @@ never blocks starting a conversation."
 (defun copilot-chat--model-param ()
   "Return request params identifying the chat model to use.
 Send the modern `modelInfo' object alongside the deprecated `model'
-field so both current and older language servers resolve a model.
-Return nil when no model can be resolved, letting the server pick."
+field so both current and older language servers resolve a model.  For a
+Bring Your Own Key model, attach `modelInfo.providerName' so the server
+routes the turn to that provider.  Return nil when no model can be
+resolved, letting the server pick."
   (when-let* ((model (copilot-chat--model)))
-    (list :modelInfo (list :id model)
+    (list :modelInfo (append
+                      (list :id model)
+                      ;; Only tag the provider for an explicit BYOK
+                      ;; selection: a server-resolved default is always a
+                      ;; Copilot model, so a stale provider must not leak
+                      ;; onto it.
+                      (when (and copilot-chat-model copilot-chat--model-provider)
+                        (list :providerName copilot-chat--model-provider)))
           :model model)))
 
 ;;
@@ -3944,11 +3972,15 @@ policy-locked one."
                                      "locked")))))
     (if flags (format " [%s]" (string-join flags ", ")) "")))
 
-(defun copilot-chat--set-model (model-id)
+(defun copilot-chat--set-model (model-id &optional provider)
   "Select MODEL-ID as the chat model and forget any cached default.
-Clearing the cache lets a later nil re-resolve the default from the
-server, mirroring the rest of the model-selection commands."
+PROVIDER is the BYOK provider name when MODEL-ID is a Bring Your Own Key
+model, or nil for a Copilot model; it is tracked so the turn request can
+route to that provider.  Clearing the cache lets a later nil re-resolve
+the default from the server, mirroring the rest of the model-selection
+commands."
   (setq copilot-chat-model model-id
+        copilot-chat--model-provider provider
         copilot-chat--model-resolved nil))
 
 (defun copilot-chat--accept-model-policy (model)
@@ -3991,27 +4023,48 @@ declined prompt leaves the current model untouched."
          (lambda ()
            (message "Copilot Chat: Enabling %s timed out" model-id)))))))
 
+(defun copilot-chat--byok-choice (model)
+  "Return a (display . plist) completion choice for BYOK MODEL.
+The plist carries `:id' and `:byok-provider' so the caller can route the
+selection through `copilot/byok'."
+  (let* ((id (plist-get model :modelId))
+         (provider (plist-get model :providerName))
+         (name (or (plist-get (plist-get model :modelCapabilities) :name) id)))
+    (cons (format "%s (%s) [BYOK: %s]" name id provider)
+          (list :id id :byok-provider provider))))
+
 (defun copilot-chat-select-model ()
   "Interactively select a Copilot Chat model.
-Premium and policy-locked models are flagged in the completion list.
-Selecting a policy-locked model prompts to accept its terms and enables
-it via the server's `copilot/setModelPolicy' before switching; the model
-is selected only once the server confirms."
+Premium and policy-locked models are flagged in the completion list, and
+your registered Bring Your Own Key models are listed too (tagged
+`[BYOK: PROVIDER]').  Selecting a policy-locked model prompts to accept
+its terms and enables it via the server's `copilot/setModelPolicy'
+before switching; the model is selected only once the server confirms.
+Selecting a BYOK model routes future turns to that provider."
   (interactive)
-  (let* ((choices (mapcar (lambda (m)
-                            (cons (format "%s (%s)%s"
-                                          (plist-get m :modelName)
-                                          (plist-get m :id)
-                                          (copilot-chat--model-annotation m))
-                                  m))
-                          (copilot-chat--chat-models)))
+  (let* ((choices (append
+                   (mapcar (lambda (m)
+                             (cons (format "%s (%s)%s"
+                                           (plist-get m :modelName)
+                                           (plist-get m :id)
+                                           (copilot-chat--model-annotation m))
+                                   m))
+                           (copilot-chat--chat-models))
+                   (mapcar #'copilot-chat--byok-choice
+                           (copilot-chat--byok-models))))
          (choice (completing-read "Chat model: " choices nil t))
          (model (cdr (assoc choice choices)))
-         (model-id (plist-get model :id)))
-    (if (copilot-chat--model-locked-p model)
-        (copilot-chat--accept-model-policy model)
+         (model-id (plist-get model :id))
+         (provider (plist-get model :byok-provider)))
+    (cond
+     (provider
+      (copilot-chat--set-model model-id provider)
+      (message "Copilot Chat: Model set to %s (BYOK: %s)" model-id provider))
+     ((copilot-chat--model-locked-p model)
+      (copilot-chat--accept-model-policy model))
+     (t
       (copilot-chat--set-model model-id)
-      (message "Copilot Chat: Model set to %s" model-id))))
+      (message "Copilot Chat: Model set to %s" model-id)))))
 
 ;;;###autoload
 (defun copilot-chat-apply-preset (name)
@@ -4049,6 +4102,10 @@ keys and an example."
          "Copilot Chat: Preset %S has a non-list `:auto-approve-tools'" name))
       (when (plist-member preset :model)
         (setq copilot-chat-model (plist-get preset :model)
+              ;; Presets carry Copilot model ids, so clear any BYOK
+              ;; provider left over from a previous selection; otherwise
+              ;; its `providerName' would ride along with the new id.
+              copilot-chat--model-provider nil
               ;; Forget any cached default so clearing the model later
               ;; re-resolves from the server, mirroring
               ;; `copilot-chat-select-model'.

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -1334,6 +1334,51 @@
                       :to-equal "gpt-4o"))
           (kill-buffer buf))))
 
+    (it "attaches the BYOK provider name to modelInfo"
+      (let ((captured-params nil)
+            (copilot-chat-model "claude-opus-4-8")
+            (copilot-chat--model-provider "Anthropic")
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-get (plist-get captured-params :modelInfo)
+                                 :providerName)
+                      :to-equal "Anthropic")
+              (expect (plist-get (plist-get captured-params :modelInfo) :id)
+                      :to-equal "claude-opus-4-8"))
+          (kill-buffer buf))))
+
+    (it "does not attach a stale provider to a resolved default"
+      (let ((captured-params nil)
+            (copilot-chat-model nil)
+            (copilot-chat--model-provider "Anthropic")
+            (buf (get-buffer-create copilot-chat--buffer-name)))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (copilot-chat-mode))
+              (spy-on 'copilot-chat--default-model :and-return-value "auto")
+              (spy-on 'copilot--connection-alivep :and-return-value t)
+              (spy-on 'jsonrpc--async-request-1
+                      :and-call-fake
+                      (lambda (_conn _method params &rest _args)
+                        (setq captured-params params)
+                        (cons nil nil)))
+              (copilot-chat--create "hello" #'ignore)
+              (expect (plist-member (plist-get captured-params :modelInfo)
+                                    :providerName)
+                      :to-be nil))
+          (kill-buffer buf))))
+
     (it "sends a server-resolved default when copilot-chat-model is nil"
       (let ((captured-params nil)
             (copilot-chat-model nil)
@@ -3541,6 +3586,33 @@
         (copilot-chat-select-model)
         (expect copilot-chat-model :to-equal "claude-3.5-sonnet")))
 
+    (it "selects a BYOK model and records its provider"
+      (let ((copilot-chat-model nil)
+            (copilot-chat--model-provider nil))
+        (spy-on 'copilot-chat--chat-models :and-return-value
+                (list (list :modelName "GPT-4o" :id "gpt-4o"
+                            :scopes (list "chat-panel"))))
+        (spy-on 'copilot-chat--byok-models :and-return-value
+                (list (list :modelId "claude-opus-4-8" :providerName "Anthropic"
+                            :isRegistered t)))
+        (spy-on 'completing-read
+                :and-return-value "claude-opus-4-8 (claude-opus-4-8) [BYOK: Anthropic]")
+        (copilot-chat-select-model)
+        (expect copilot-chat-model :to-equal "claude-opus-4-8")
+        (expect copilot-chat--model-provider :to-equal "Anthropic")))
+
+    (it "clears the provider when switching back to a Copilot model"
+      (let ((copilot-chat-model "claude-opus-4-8")
+            (copilot-chat--model-provider "Anthropic"))
+        (spy-on 'copilot-chat--chat-models :and-return-value
+                (list (list :modelName "GPT-4o" :id "gpt-4o"
+                            :scopes (list "chat-panel"))))
+        (spy-on 'copilot-chat--byok-models :and-return-value nil)
+        (spy-on 'completing-read :and-return-value "GPT-4o (gpt-4o)")
+        (copilot-chat-select-model)
+        (expect copilot-chat-model :to-equal "gpt-4o")
+        (expect copilot-chat--model-provider :to-be nil)))
+
     (it "excludes completion-only models"
       (let ((copilot-chat-model nil)
             (captured-choices nil))
@@ -3659,6 +3731,41 @@
         (copilot-chat-select-model)
         (expect copilot-chat-model :to-equal "previous")
         (expect 'jsonrpc--async-request-1 :not :to-have-been-called))))
+
+  (describe "copilot-chat--byok-models"
+    (it "returns only registered models from copilot/byok/listModels"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'jsonrpc-request
+              :and-return-value
+              (list :models
+                    (list (list :modelId "m1" :providerName "Anthropic"
+                                :isRegistered t)
+                          (list :modelId "m2" :providerName "OpenAI"
+                                :isRegistered :json-false))))
+      (let ((models (copilot-chat--byok-models)))
+        (expect (length models) :to-equal 1)
+        (expect (plist-get (car models) :modelId) :to-equal "m1")))
+
+    (it "returns nil when the request errors (e.g. old server)"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'jsonrpc-request :and-throw-error 'error)
+      (expect (copilot-chat--byok-models) :to-be nil)))
+
+  (describe "copilot-chat--byok-choice"
+    (it "formats the display and carries id and provider"
+      (let ((choice (copilot-chat--byok-choice
+                     '(:modelId "claude-opus-4-8" :providerName "Anthropic"))))
+        (expect (car choice)
+                :to-equal "claude-opus-4-8 (claude-opus-4-8) [BYOK: Anthropic]")
+        (expect (plist-get (cdr choice) :id) :to-equal "claude-opus-4-8")
+        (expect (plist-get (cdr choice) :byok-provider) :to-equal "Anthropic")))
+
+    (it "prefers the capability name for the display label"
+      (let ((choice (copilot-chat--byok-choice
+                     '(:modelId "opus" :providerName "Anthropic"
+                       :modelCapabilities (:name "Claude Opus")))))
+        (expect (car choice)
+                :to-equal "Claude Opus (opus) [BYOK: Anthropic]"))))
 
   (describe "copilot-chat--model-annotation"
     (it "returns an empty string for an unrestricted model"
@@ -4877,6 +4984,13 @@
             (copilot-chat--model-resolved t))
         (copilot-chat-apply-preset "ask-off")
         (expect copilot-chat--model-resolved :to-be t)))
+
+    (it "clears a stale BYOK provider when it sets the model"
+      (let ((copilot-chat-model "byok-model")
+            (copilot-chat--model-provider "Anthropic"))
+        (copilot-chat-apply-preset "fast")
+        (expect copilot-chat-model :to-equal "gpt-4o")
+        (expect copilot-chat--model-provider :to-be nil)))
 
     (it "rejects a non-list :auto-approve-tools without mutating anything"
       (let ((copilot-chat-presets '(("bad" . (:model "m"


### PR DESCRIPTION
First of two PRs adding Bring Your Own Key (BYOK) support (built-in providers: Anthropic, OpenAI, Gemini, Groq, OpenRouter, Azure). This one is the chat integration; the management commands (add/list/remove keys and models) follow in a second PR.

Verified against the 1.517.0 bundle: BYOK models never appear in `copilot/models` (that handler maps CAPI metadata only). They come from `copilot/byok/listModels`, and the chat path uses one by sending `modelInfo.providerName` on `conversation/create`/`conversation/turn` (the `resolveTurnModelInfo` server code reads `modelInfo.providerName ?? modelProviderName`). copilot.el previously sent `{modelInfo:{id}, model}` with no provider, so a BYOK model would have been treated as a CAPI id and failed to resolve.

Changes:
- `copilot-chat-select-model` now also lists registered BYOK models (from `copilot/byok/listModels`, best-effort so an old server without the method doesn't break selection), tagged `[BYOK: PROVIDER]`.
- Selecting a BYOK model tracks its provider in `copilot-chat--model-provider` alongside `copilot-chat-model`; selecting a Copilot model clears it.
- `copilot-chat--model-param` attaches `modelInfo.providerName` **only** for an explicit BYOK selection (guarded on `copilot-chat-model` being set), so a server-resolved default can never pick up a stale provider.

Note: using a BYOK model needs a BYOK-eligible account (the server gates the turn on a `client_byok` token; not something the client can advertise around). Storing/listing keys is ungated, which the follow-up PR builds on.

Tests: model-param attaches/omits providerName correctly (incl. the stale-default guard), byok-models filters to registered and degrades to nil on error, byok-choice formatting, and the picker's BYOK-select and switch-back-clears-provider paths. README and CHANGELOG updated.