### PR TITLE
Add BYOK key and model management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@
 - Add `copilot-panel-accept-completion` to insert a solution from the `*copilot-panel*` buffer back into the buffer that requested it. Move to a suggestion and press `RET` or `C-c C-c`; previously the panel could only be read, never accepted from.
 - Add `copilot-chat-compact` (in the `copilot-menu` chat section) to compact the current chat conversation on demand: it asks the server to summarize the discussion so far, reclaiming token budget while the conversation continues. The visible transcript is left as-is, and it reports how many turns were compacted along with the resulting context usage.
 - `copilot-chat-select-model` now flags premium and policy-locked models in the completion list, and selecting a policy-locked one prompts to accept its terms and enables it on the server (via `copilot/setModelPolicy`) before switching, instead of leaving you to hit an error on the next message.
-- Add support for using Bring Your Own Key (BYOK) models in chat: `copilot-chat-select-model` lists your registered BYOK models (tagged `[BYOK: PROVIDER]`) alongside Copilot's own, and selecting one routes chat turns to that provider using your own API key. Using a BYOK model needs a BYOK-eligible Copilot account.
+- Add Bring Your Own Key (BYOK) support, letting you use your own model-provider API keys (Anthropic, OpenAI, Gemini, Groq, OpenRouter, Azure) in chat:
+  - `copilot-chat-byok-add-key` saves a provider API key (read without echoing and held by the language server, never stored or shown by copilot.el), and `copilot-chat-byok-add-model` registers a model to use with it.
+  - `copilot-chat-byok-list`, `copilot-chat-byok-remove-model`, and `copilot-chat-byok-remove-key` manage what you have registered.
+  - `copilot-chat-select-model` lists your registered BYOK models (tagged `[BYOK: PROVIDER]`) alongside Copilot's own, and selecting one routes chat turns to that provider using your key.
+  - Using a BYOK model needs a BYOK-eligible Copilot account; otherwise the server rejects the turn.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -523,6 +523,11 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-select-completion-model` | Choose which model to use for completions |
 | `copilot-chat-select-model` | Choose which model to use for chat |
 | `copilot-chat-select-mode` | Choose the chat mode (Ask, Agent, InlineAgent, ...) |
+| `copilot-chat-byok-add-key` | Save your own API key for a model provider (BYOK) |
+| `copilot-chat-byok-add-model` | Register a BYOK model to use in chat |
+| `copilot-chat-byok-list` | List your registered BYOK models |
+| `copilot-chat-byok-remove-model` | Remove a registered BYOK model |
+| `copilot-chat-byok-remove-key` | Delete a provider's stored BYOK API key |
 | **Completion** | |
 | `copilot-mode` | Toggle automatic completions in the current buffer |
 | `copilot-complete` | Trigger a completion at point |
@@ -762,11 +767,36 @@ accepted). Selecting a policy-locked model prompts you to accept its terms and
 enables it on the server before switching, so you no longer have to leave Emacs
 to unlock a model in the GitHub settings.
 
-Any Bring Your Own Key (BYOK) models you have registered are listed too, tagged
-`[BYOK: PROVIDER]`. Selecting one routes your chat turns to that provider using
-your own API key (held by the language server), rather than through Copilot's
-models. Using a BYOK model requires a BYOK-eligible Copilot account; without one
-the server rejects the turn with a "BYOK is disabled for this account" error.
+#### Bring Your Own Key (BYOK)
+
+You can use your own model-provider API keys (Anthropic, OpenAI, Gemini, Groq,
+OpenRouter, Azure) in chat instead of Copilot's models:
+
+1. `copilot-chat-byok-add-key` saves a provider's API key. The key is read
+   without echoing and handed to the language server, which stores it;
+   copilot.el never keeps or displays it. (Azure keys are stored per model, so
+   it asks for a model id.)
+2. `copilot-chat-byok-add-model` registers a model for that provider (id,
+   display name, and whether it supports tool calls and vision; Azure also needs
+   a deployment URL).
+3. The model then shows up in `copilot-chat-select-model`, tagged
+   `[BYOK: PROVIDER]`. Selecting it routes your chat turns to that provider using
+   your key.
+
+`copilot-chat-byok-list` shows what you have registered, and
+`copilot-chat-byok-remove-model` / `copilot-chat-byok-remove-key` remove a model
+or a provider's key.
+
+Using a BYOK model requires a BYOK-eligible Copilot account; without one the
+server rejects the turn with a "BYOK is disabled for this account" error.
+Registering keys and models works regardless.
+
+> [!NOTE]
+>
+> If you turn on protocol logging (set `copilot-log-max` to a positive value),
+> the JSON-RPC request bodies, including a BYOK key you are saving, are written
+> to the `*copilot events*` buffer in plaintext. Keep logging off (the default)
+> when saving keys.
 
 ### Public code references
 

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -4066,6 +4066,151 @@ Selecting a BYOK model routes future turns to that provider."
       (copilot-chat--set-model model-id)
       (message "Copilot Chat: Model set to %s" model-id)))))
 
+;;
+;; Bring Your Own Key (BYOK) management
+;;
+
+(defconst copilot-chat--byok-providers
+  '("Anthropic" "OpenAI" "Gemini" "Groq" "OpenRouter" "Azure")
+  "Built-in provider names the language server accepts for BYOK.
+Azure stores its key per model (`saveApiKey' needs a model id and
+`deleteApiKey' is unsupported); the rest use one key per provider.")
+
+(defun copilot-chat--byok-read-provider (&optional prompt providers)
+  "Read a built-in BYOK provider name with completion.
+PROMPT defaults to \"Provider: \"; PROVIDERS defaults to
+`copilot-chat--byok-providers'."
+  (completing-read (or prompt "Provider: ")
+                   (or providers copilot-chat--byok-providers)
+                   nil t))
+
+(defun copilot-chat--byok-request (method params success-message)
+  "Send a BYOK METHOD request with PARAMS and report the outcome.
+Show SUCCESS-MESSAGE (or the server's own message) on success and the
+server error otherwise.  Issue the request from an always-live buffer so
+`copilot--async-request' does not drop the reply if the buffer the
+command ran from is gone by the time it arrives."
+  (with-current-buffer (get-buffer-create " *copilot-chat-one-shot*")
+    (copilot--async-request
+     method params
+     :success-fn
+     (lambda (result)
+       (message "Copilot Chat: %s"
+                (or (and (listp result) (plist-get result :message))
+                    success-message)))
+     :error-fn
+     (lambda (err)
+       (message "Copilot Chat: %s"
+                (or (copilot-chat--error-text err) "BYOK request failed")))
+     :timeout 15
+     :timeout-fn
+     (lambda () (message "Copilot Chat: BYOK request timed out")))))
+
+(defun copilot-chat-byok-add-key ()
+  "Save a Bring Your Own Key API key for a provider.
+The key is read without echoing and handed to the language server, which
+stores it; copilot.el never keeps or displays it.  Azure keys are stored
+per model, so a model id is requested for that provider."
+  (interactive)
+  (let* ((provider (copilot-chat--byok-read-provider))
+         (azure (equal provider "Azure"))
+         (model-id (and azure
+                        (read-string "Model id (required for Azure): ")))
+         (key (read-passwd (format "%s API key: " provider))))
+    (when (string-empty-p (string-trim key))
+      (user-error "Copilot Chat: API key must not be empty"))
+    (when (and azure (string-empty-p (string-trim (or model-id ""))))
+      (user-error "Copilot Chat: A model id is required for Azure"))
+    (copilot-chat--byok-request
+     'copilot/byok/saveApiKey
+     (append (list :providerName provider :apiKey key)
+             (and azure (list :modelId model-id)))
+     (format "Saved API key for %s" provider))))
+
+(defun copilot-chat-byok-add-model ()
+  "Register a Bring Your Own Key model so it appears in model selection.
+Prompts for the provider, model id, display name, and tool-call/vision
+support.  Azure additionally needs a deployment URL.  Save the provider's
+API key first with `copilot-chat-byok-add-key'."
+  (interactive)
+  (let ((provider (copilot-chat--byok-read-provider))
+        (model-id (read-string "Model id: ")))
+    ;; Validate the id before asking the rest, so a blank entry fails fast.
+    (when (string-empty-p (string-trim model-id))
+      (user-error "Copilot Chat: Model id must not be empty"))
+    (let* ((azure (equal provider "Azure"))
+           (deployment
+            (and azure (read-string "Deployment URL (required for Azure): ")))
+           (name (read-string (format "Display name (default %s): " model-id)
+                              nil nil model-id))
+           (tool-calling (y-or-n-p "Model supports tool calls? "))
+           (vision (y-or-n-p "Model supports vision? ")))
+      (when (and azure (string-empty-p (string-trim (or deployment ""))))
+        (user-error "Copilot Chat: A deployment URL is required for Azure"))
+      (copilot-chat--byok-request
+       'copilot/byok/saveModel
+       (append
+        (list :providerName provider :modelId model-id
+              :isRegistered t :isCustomModel :json-false
+              :modelCapabilities (list :name name
+                                       :toolCalling (if tool-calling t :json-false)
+                                       :vision (if vision t :json-false)))
+        (and azure (list :deploymentUrl deployment)))
+       (format "Registered model %s for %s" model-id provider)))))
+
+(defun copilot-chat--byok-pick-model (prompt)
+  "Read a registered BYOK model with completion using PROMPT.
+Return the model plist, or signal a `user-error' when none are
+registered."
+  (let* ((models (copilot-chat--byok-models))
+         (choices (mapcar (lambda (m)
+                            (cons (format "%s (%s)"
+                                          (plist-get m :modelId)
+                                          (plist-get m :providerName))
+                                  m))
+                          models)))
+    (unless choices
+      (user-error "Copilot Chat: No registered BYOK models"))
+    (cdr (assoc (completing-read prompt choices nil t) choices))))
+
+(defun copilot-chat-byok-remove-model ()
+  "Remove a registered Bring Your Own Key model."
+  (interactive)
+  (let ((model (copilot-chat--byok-pick-model "Remove BYOK model: ")))
+    (copilot-chat--byok-request
+     'copilot/byok/deleteModel
+     (list :providerName (plist-get model :providerName)
+           :modelId (plist-get model :modelId))
+     (format "Removed model %s" (plist-get model :modelId)))))
+
+(defun copilot-chat-byok-remove-key ()
+  "Delete the stored Bring Your Own Key API key for a provider.
+Also removes that provider's model configurations.  Azure is omitted:
+its keys are stored per model, so remove Azure entries with
+`copilot-chat-byok-remove-model' instead."
+  (interactive)
+  (let ((provider (copilot-chat--byok-read-provider
+                   "Provider: " (remove "Azure" copilot-chat--byok-providers))))
+    (when (yes-or-no-p
+           (format "Delete the stored API key and models for %s? " provider))
+      (copilot-chat--byok-request
+       'copilot/byok/deleteApiKey
+       (list :providerName provider)
+       (format "Deleted API key for %s" provider)))))
+
+(defun copilot-chat-byok-list ()
+  "List your registered Bring Your Own Key models."
+  (interactive)
+  (let ((models (copilot-chat--byok-models)))
+    (if (null models)
+        (message "Copilot Chat: No registered BYOK models")
+      (message "Copilot Chat: BYOK models: %s"
+               (mapconcat (lambda (m)
+                            (format "%s (%s)"
+                                    (plist-get m :modelId)
+                                    (plist-get m :providerName)))
+                          models ", ")))))
+
 ;;;###autoload
 (defun copilot-chat-apply-preset (name)
   "Apply the Copilot Chat preset named NAME from `copilot-chat-presets'.

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -3767,6 +3767,160 @@
         (expect (car choice)
                 :to-equal "Claude Opus (opus) [BYOK: Anthropic]"))))
 
+  (describe "BYOK management"
+    (it "add-key sends saveApiKey with the provider and key"
+      (let ((captured nil))
+        (spy-on 'copilot-chat--byok-read-provider :and-return-value "Anthropic")
+        (spy-on 'read-passwd :and-return-value "sk-test")
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured (list method params)) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-add-key)
+        (expect (nth 0 captured) :to-equal 'copilot/byok/saveApiKey)
+        (expect (plist-get (nth 1 captured) :providerName) :to-equal "Anthropic")
+        (expect (plist-get (nth 1 captured) :apiKey) :to-equal "sk-test")
+        (expect (plist-member (nth 1 captured) :modelId) :to-be nil)))
+
+    (it "add-key includes the model id for Azure"
+      (let ((captured nil))
+        (spy-on 'copilot-chat--byok-read-provider :and-return-value "Azure")
+        (spy-on 'read-string :and-return-value "gpt-4o")
+        (spy-on 'read-passwd :and-return-value "sk")
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn _method params &rest _args)
+                  (setq captured params) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-add-key)
+        (expect (plist-get captured :modelId) :to-equal "gpt-4o")))
+
+    (it "add-key errors on an empty key without sending"
+      (spy-on 'copilot-chat--byok-read-provider :and-return-value "OpenAI")
+      (spy-on 'read-passwd :and-return-value "   ")
+      (spy-on 'jsonrpc--async-request-1)
+      (expect (copilot-chat-byok-add-key) :to-throw 'user-error)
+      (expect 'jsonrpc--async-request-1 :not :to-have-been-called))
+
+    (it "add-model sends saveModel with capabilities"
+      (let ((captured nil))
+        (spy-on 'copilot-chat--byok-read-provider :and-return-value "Anthropic")
+        (spy-on 'read-string :and-call-fake
+                (lambda (prompt &rest _)
+                  (if (string-prefix-p "Model id" prompt)
+                      "claude-opus-4-8" "Claude Opus")))
+        (spy-on 'y-or-n-p :and-return-value t)
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured (list method params)) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-add-model)
+        (expect (nth 0 captured) :to-equal 'copilot/byok/saveModel)
+        (let ((p (nth 1 captured)))
+          (expect (plist-get p :providerName) :to-equal "Anthropic")
+          (expect (plist-get p :modelId) :to-equal "claude-opus-4-8")
+          (expect (plist-get p :isRegistered) :to-be t)
+          (expect (plist-get p :isCustomModel) :to-be :json-false)
+          (expect (plist-get (plist-get p :modelCapabilities) :name)
+                  :to-equal "Claude Opus")
+          (expect (plist-get (plist-get p :modelCapabilities) :toolCalling)
+                  :to-be t)
+          (expect (plist-member p :deploymentUrl) :to-be nil))))
+
+    (it "remove-model sends deleteModel for the picked model"
+      (let ((captured nil))
+        (spy-on 'copilot-chat--byok-models :and-return-value
+                (list (list :modelId "m1" :providerName "Anthropic"
+                            :isRegistered t)))
+        (spy-on 'completing-read :and-return-value "m1 (Anthropic)")
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured (list method params)) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-remove-model)
+        (expect (nth 0 captured) :to-equal 'copilot/byok/deleteModel)
+        (expect (plist-get (nth 1 captured) :modelId) :to-equal "m1")
+        (expect (plist-get (nth 1 captured) :providerName) :to-equal "Anthropic")))
+
+    (it "remove-model errors when there are no BYOK models"
+      (spy-on 'copilot-chat--byok-models :and-return-value nil)
+      (expect (copilot-chat-byok-remove-model) :to-throw 'user-error))
+
+    (it "add-model errors on an empty model id before prompting further"
+      (spy-on 'copilot-chat--byok-read-provider :and-return-value "Anthropic")
+      (spy-on 'read-string :and-return-value "  ")
+      (spy-on 'y-or-n-p)
+      (spy-on 'jsonrpc--async-request-1)
+      (expect (copilot-chat-byok-add-model) :to-throw 'user-error)
+      (expect 'y-or-n-p :not :to-have-been-called)
+      (expect 'jsonrpc--async-request-1 :not :to-have-been-called))
+
+    (it "remove-key omits Azure from the provider choices"
+      (let ((captured-providers nil))
+        (spy-on 'completing-read
+                :and-call-fake
+                (lambda (_prompt providers &rest _args)
+                  (setq captured-providers providers)
+                  "OpenAI"))
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (spy-on 'message)
+        (copilot-chat-byok-remove-key)
+        (expect captured-providers :not :to-contain "Azure")
+        (expect captured-providers :to-contain "OpenAI")))
+
+    (it "remove-key sends deleteApiKey after confirmation"
+      (let ((captured nil))
+        (spy-on 'copilot-chat--byok-read-provider :and-return-value "OpenAI")
+        (spy-on 'yes-or-no-p :and-return-value t)
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured (list method params)) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-remove-key)
+        (expect (nth 0 captured) :to-equal 'copilot/byok/deleteApiKey)
+        (expect (plist-get (nth 1 captured) :providerName) :to-equal "OpenAI")))
+
+    (it "remove-key sends nothing when declined"
+      (spy-on 'copilot-chat--byok-read-provider :and-return-value "OpenAI")
+      (spy-on 'yes-or-no-p :and-return-value nil)
+      (spy-on 'jsonrpc--async-request-1)
+      (spy-on 'message)
+      (copilot-chat-byok-remove-key)
+      (expect 'jsonrpc--async-request-1 :not :to-have-been-called))
+
+    (it "list reports the registered models"
+      (spy-on 'copilot-chat--byok-models :and-return-value
+              (list (list :modelId "m1" :providerName "Anthropic")))
+      (spy-on 'message)
+      (copilot-chat-byok-list)
+      (expect 'message :to-have-been-called-with
+              "Copilot Chat: BYOK models: %s" "m1 (Anthropic)"))
+
+    (it "list reports when there are none"
+      (spy-on 'copilot-chat--byok-models :and-return-value nil)
+      (spy-on 'message)
+      (copilot-chat-byok-list)
+      (expect 'message :to-have-been-called-with
+              "Copilot Chat: No registered BYOK models"))
+
+    (it "byok-request prefers the server's message on success"
+      (let ((captured nil))
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn _method _params &rest args)
+                  (setq captured args) (list 1)))
+        (spy-on 'message)
+        (copilot-chat--byok-request 'copilot/byok/saveApiKey
+                                    '(:providerName "X") "fallback")
+        (funcall (plist-get captured :success-fn)
+                 '(:success t :message "server says ok"))
+        (expect 'message :to-have-been-called-with
+                "Copilot Chat: %s" "server says ok"))))
+
   (describe "copilot-chat--model-annotation"
     (it "returns an empty string for an unrestricted model"
       (expect (copilot-chat--model-annotation '(:id "m")) :to-equal ""))


### PR DESCRIPTION
Second of two BYOK PRs. Stacked on #535 (the chat integration); this adds the commands to register and manage what the picker surfaces.

- `copilot-chat-byok-add-key` -> `copilot/byok/saveApiKey`. The key is read with `read-passwd` (no echo) and handed to the language server, which stores it. copilot.el never keeps or displays a key, and never calls `listApiKeys` (which echoes keys back in plaintext). Azure keys are per-model, so it asks for a model id.
- `copilot-chat-byok-add-model` -> `copilot/byok/saveModel` (id, display name, tool-call/vision capabilities; Azure also needs a deployment URL).
- `copilot-chat-byok-list`, `copilot-chat-byok-remove-model` (`deleteModel`), `copilot-chat-byok-remove-key` (`deleteApiKey`, with confirmation).

All schemas verified against the 1.517.0 bundle. Requests go through a small shared helper that issues from the always-live ` *copilot-chat-one-shot*` buffer (so a killed origin buffer can't drop the reply) and reports the server's own success/error message.

Security posture: keys are write-only from the client's side; nothing is logged, displayed, or read back. The plaintext-on-disk storage is the server's (`byok.json`, mode 0600), out of our hands.

Tests cover each command's request shape (including Azure's modelId/deploymentUrl), the empty-key guard, the no-models and declined-confirmation paths, list output, and the shared helper preferring the server message. README and CHANGELOG updated (the BYOK entry now covers the full add -> use flow).

Note: depends on #535; will rebase onto main once that lands.