### PR TITLE
Support custom OpenAI-compatible endpoints for BYOK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `copilot-chat-select-model` now flags premium and policy-locked models in the completion list, and selecting a policy-locked one prompts to accept its terms and enables it on the server (via `copilot/setModelPolicy`) before switching, instead of leaving you to hit an error on the next message.
 - Add Bring Your Own Key (BYOK) support, letting you use your own model-provider API keys (Anthropic, OpenAI, Gemini, Groq, OpenRouter, Azure) in chat:
   - `copilot-chat-byok-add-key` saves a provider API key (read without echoing and held by the language server, never stored or shown by copilot.el), and `copilot-chat-byok-add-model` registers a model to use with it.
+  - `copilot-chat-byok-add-custom-provider` registers a custom OpenAI-compatible endpoint (any provider name that is not built in, with its API type and key); `copilot-chat-byok-add-model` then registers models for it (each with its deployment URL), and `copilot-chat-byok-list-custom-providers` shows the ones you have configured.
   - `copilot-chat-byok-list`, `copilot-chat-byok-remove-model`, and `copilot-chat-byok-remove-key` manage what you have registered.
   - `copilot-chat-select-model` lists your registered BYOK models (tagged `[BYOK: PROVIDER]`) alongside Copilot's own, and selecting one routes chat turns to that provider using your key.
   - Using a BYOK model needs a BYOK-eligible Copilot account; otherwise the server rejects the turn.

--- a/README.md
+++ b/README.md
@@ -524,8 +524,10 @@ releases are not installable) the rest of copilot.el works as usual and
 | `copilot-chat-select-model` | Choose which model to use for chat |
 | `copilot-chat-select-mode` | Choose the chat mode (Ask, Agent, InlineAgent, ...) |
 | `copilot-chat-byok-add-key` | Save your own API key for a model provider (BYOK) |
+| `copilot-chat-byok-add-custom-provider` | Register a custom OpenAI-compatible BYOK endpoint |
 | `copilot-chat-byok-add-model` | Register a BYOK model to use in chat |
 | `copilot-chat-byok-list` | List your registered BYOK models |
+| `copilot-chat-byok-list-custom-providers` | List your configured custom BYOK providers |
 | `copilot-chat-byok-remove-model` | Remove a registered BYOK model |
 | `copilot-chat-byok-remove-key` | Delete a provider's stored BYOK API key |
 | **Completion** | |
@@ -786,6 +788,15 @@ OpenRouter, Azure) in chat instead of Copilot's models:
 `copilot-chat-byok-list` shows what you have registered, and
 `copilot-chat-byok-remove-model` / `copilot-chat-byok-remove-key` remove a model
 or a provider's key.
+
+Beyond the built-in providers you can point BYOK at any OpenAI-compatible
+endpoint. `copilot-chat-byok-add-custom-provider` registers one under a name of
+your choice (that is not a built-in provider), along with its API type
+(`chatCompletions`, `responses`, or `messages`) and key.
+`copilot-chat-byok-add-model` then offers your custom providers alongside the
+built-in ones; a custom provider's models each need their endpoint's deployment
+URL. `copilot-chat-byok-list-custom-providers` lists the custom providers you
+have configured.
 
 Using a BYOK model requires a BYOK-eligible Copilot account; without one the
 server rejects the turn with a "BYOK is disabled for this account" error.

--- a/copilot-chat.el
+++ b/copilot-chat.el
@@ -4076,6 +4076,12 @@ Selecting a BYOK model routes future turns to that provider."
 Azure stores its key per model (`saveApiKey' needs a model id and
 `deleteApiKey' is unsupported); the rest use one key per provider.")
 
+(defconst copilot-chat--byok-api-types
+  '("chatCompletions" "responses" "messages")
+  "API shapes a custom BYOK provider endpoint can speak.
+\"chatCompletions\" is the OpenAI-style API, \"messages\" the
+Anthropic-style one, and \"responses\" the OpenAI Responses API.")
+
 (defun copilot-chat--byok-read-provider (&optional prompt providers)
   "Read a built-in BYOK provider name with completion.
 PROMPT defaults to \"Provider: \"; PROVIDERS defaults to
@@ -4083,6 +4089,24 @@ PROMPT defaults to \"Provider: \"; PROVIDERS defaults to
   (completing-read (or prompt "Provider: ")
                    (or providers copilot-chat--byok-providers)
                    nil t))
+
+(defun copilot-chat--byok-custom-p (provider)
+  "Return non-nil when PROVIDER is a custom (user-named) BYOK provider.
+Custom providers are OpenAI-compatible endpoints registered with
+`copilot-chat-byok-add-custom-provider'; their models need a per-model
+deployment URL."
+  (not (member provider copilot-chat--byok-providers)))
+
+(defun copilot-chat--byok-custom-providers ()
+  "Return the names of your configured custom BYOK providers, or nil.
+Best-effort: a server without the method, or any error, yields nil."
+  (condition-case nil
+      (mapcar (lambda (p) (plist-get p :providerName))
+              (plist-get (copilot--request
+                          'copilot/byok/listCustomProviderConfigs nil
+                          :timeout 5)
+                         :providers))
+    (error nil)))
 
 (defun copilot-chat--byok-request (method params success-message)
   "Send a BYOK METHOD request with PARAMS and report the outcome.
@@ -4127,35 +4151,77 @@ per model, so a model id is requested for that provider."
              (and azure (list :modelId model-id)))
      (format "Saved API key for %s" provider))))
 
+(defun copilot-chat-byok-add-custom-provider ()
+  "Register a custom OpenAI-compatible BYOK provider (endpoint and key).
+The provider name must not be one of the built-in providers.  The key is
+read without echoing and handed to the language server, which stores it;
+copilot.el never keeps or displays it.  Register models for this provider
+with `copilot-chat-byok-add-model', which asks for each model's endpoint
+URL."
+  (interactive)
+  (let ((provider (read-string "Custom provider name: ")))
+    (when (string-empty-p (string-trim provider))
+      (user-error "Copilot Chat: Provider name must not be empty"))
+    (unless (copilot-chat--byok-custom-p provider)
+      (user-error
+       "Copilot Chat: %s is a built-in provider; use `copilot-chat-byok-add-key'"
+       provider))
+    (let ((api-type (completing-read "API type: " copilot-chat--byok-api-types
+                                     nil t nil nil "chatCompletions"))
+          (group (read-string (format "Group name (default %s): " provider)
+                              nil nil provider))
+          (key (read-passwd (format "%s API key: " provider))))
+      (when (string-empty-p (string-trim key))
+        (user-error "Copilot Chat: API key must not be empty"))
+      (copilot-chat--byok-request
+       'copilot/byok/saveCustomProviderConfig
+       (list :providerName provider :apiKey key
+             :groupName group :apiType api-type)
+       (format "Saved custom provider %s" provider)))))
+
 (defun copilot-chat-byok-add-model ()
   "Register a Bring Your Own Key model so it appears in model selection.
 Prompts for the provider, model id, display name, and tool-call/vision
-support.  Azure additionally needs a deployment URL.  Save the provider's
-API key first with `copilot-chat-byok-add-key'."
+support.  The provider list includes your custom endpoints alongside the
+built-in providers; Azure and custom-endpoint providers additionally need
+a per-model deployment URL.  Save the provider's API key first
+\(`copilot-chat-byok-add-key' or `copilot-chat-byok-add-custom-provider')."
   (interactive)
-  (let ((provider (copilot-chat--byok-read-provider))
+  (let ((provider (copilot-chat--byok-read-provider
+                   "Provider: "
+                   (append copilot-chat--byok-providers
+                           (copilot-chat--byok-custom-providers))))
         (model-id (read-string "Model id: ")))
     ;; Validate the id before asking the rest, so a blank entry fails fast.
     (when (string-empty-p (string-trim model-id))
       (user-error "Copilot Chat: Model id must not be empty"))
-    (let* ((azure (equal provider "Azure"))
+    (let* ((custom (copilot-chat--byok-custom-p provider))
+           ;; Azure and custom OpenAI-compatible endpoints are addressed by
+           ;; a per-model URL.
+           (needs-url (or (equal provider "Azure") custom))
            (deployment
-            (and azure (read-string "Deployment URL (required for Azure): ")))
+            (and needs-url
+                 (read-string (format "Deployment URL (required for %s): "
+                                      provider))))
            (name (read-string (format "Display name (default %s): " model-id)
                               nil nil model-id))
            (tool-calling (y-or-n-p "Model supports tool calls? "))
            (vision (y-or-n-p "Model supports vision? ")))
-      (when (and azure (string-empty-p (string-trim (or deployment ""))))
-        (user-error "Copilot Chat: A deployment URL is required for Azure"))
+      (when (and needs-url (string-empty-p (string-trim (or deployment ""))))
+        (user-error "Copilot Chat: A deployment URL is required for %s"
+                    provider))
       (copilot-chat--byok-request
        'copilot/byok/saveModel
        (append
         (list :providerName provider :modelId model-id
-              :isRegistered t :isCustomModel :json-false
+              :isRegistered t
+              ;; A model typed against a custom endpoint is user-defined
+              ;; rather than a catalog model the provider advertises.
+              :isCustomModel (if custom t :json-false)
               :modelCapabilities (list :name name
                                        :toolCalling (if tool-calling t :json-false)
                                        :vision (if vision t :json-false)))
-        (and azure (list :deploymentUrl deployment)))
+        (and needs-url (list :deploymentUrl deployment)))
        (format "Registered model %s for %s" model-id provider)))))
 
 (defun copilot-chat--byok-pick-model (prompt)
@@ -4185,18 +4251,45 @@ registered."
 
 (defun copilot-chat-byok-remove-key ()
   "Delete the stored Bring Your Own Key API key for a provider.
-Also removes that provider's model configurations.  Azure is omitted:
-its keys are stored per model, so remove Azure entries with
-`copilot-chat-byok-remove-model' instead."
+Also removes that provider's model configurations.  Custom providers are
+offered too; Azure is omitted, since its keys are stored per model, so
+remove Azure entries with `copilot-chat-byok-remove-model' instead."
   (interactive)
   (let ((provider (copilot-chat--byok-read-provider
-                   "Provider: " (remove "Azure" copilot-chat--byok-providers))))
+                   "Provider: "
+                   (append (remove "Azure" copilot-chat--byok-providers)
+                           (copilot-chat--byok-custom-providers)))))
     (when (yes-or-no-p
            (format "Delete the stored API key and models for %s? " provider))
       (copilot-chat--byok-request
        'copilot/byok/deleteApiKey
        (list :providerName provider)
        (format "Deleted API key for %s" provider)))))
+
+(defun copilot-chat-byok-list-custom-providers ()
+  "List your configured custom (OpenAI-compatible) BYOK providers."
+  (interactive)
+  (condition-case err
+      (let ((providers
+             (plist-get (copilot--request
+                         'copilot/byok/listCustomProviderConfigs nil
+                         :timeout 5)
+                        :providers)))
+        (if (null providers)
+            (message "Copilot Chat: No custom BYOK providers")
+          (message "Copilot Chat: Custom BYOK providers: %s"
+                   (mapconcat (lambda (p)
+                                (format "%s (%s)"
+                                        (plist-get p :providerName)
+                                        (or (plist-get p :apiType) "chatCompletions")))
+                              providers ", "))))
+    (error
+     ;; A synchronous `copilot--request' signals `jsonrpc-error', whose
+     ;; data is an alist (not the `:message' plist `copilot-chat--error-text'
+     ;; expects), so pull the server message out of it directly.
+     (message "Copilot Chat: Could not list custom providers: %s"
+              (or (alist-get 'jsonrpc-error-message (cddr err))
+                  (error-message-string err))))))
 
 (defun copilot-chat-byok-list ()
   "List your registered Bring Your Own Key models."

--- a/test/copilot-chat-test.el
+++ b/test/copilot-chat-test.el
@@ -3921,6 +3921,136 @@
         (expect 'message :to-have-been-called-with
                 "Copilot Chat: %s" "server says ok"))))
 
+  (describe "BYOK custom providers"
+    (it "identifies custom vs built-in providers"
+      (expect (copilot-chat--byok-custom-p "Anthropic") :to-be nil)
+      (expect (copilot-chat--byok-custom-p "Azure") :to-be nil)
+      (expect (copilot-chat--byok-custom-p "my-endpoint") :to-be-truthy))
+
+    (it "lists configured custom provider names"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'jsonrpc-request
+              :and-return-value
+              (list :providers
+                    (list (list :providerName "my-endpoint"
+                                :groupName "g" :apiType "chatCompletions")
+                          (list :providerName "other" :apiType "messages"))))
+      (expect (copilot-chat--byok-custom-providers)
+              :to-equal '("my-endpoint" "other")))
+
+    (it "returns nil when listing custom providers errors"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'jsonrpc-request :and-throw-error 'error)
+      (expect (copilot-chat--byok-custom-providers) :to-be nil))
+
+    (it "add-custom-provider sends saveCustomProviderConfig"
+      (let ((captured nil))
+        (spy-on 'read-string :and-call-fake
+                (lambda (prompt &rest _)
+                  (if (string-prefix-p "Custom provider" prompt)
+                      "my-endpoint" "my-group")))
+        (spy-on 'completing-read :and-return-value "messages")
+        (spy-on 'read-passwd :and-return-value "sk-custom")
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured (list method params)) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-add-custom-provider)
+        (expect (nth 0 captured) :to-equal 'copilot/byok/saveCustomProviderConfig)
+        (let ((p (nth 1 captured)))
+          (expect (plist-get p :providerName) :to-equal "my-endpoint")
+          (expect (plist-get p :apiKey) :to-equal "sk-custom")
+          (expect (plist-get p :apiType) :to-equal "messages")
+          (expect (plist-get p :groupName) :to-equal "my-group"))))
+
+    (it "add-custom-provider rejects a built-in provider name"
+      (spy-on 'read-string :and-return-value "OpenAI")
+      (spy-on 'jsonrpc--async-request-1)
+      (expect (copilot-chat-byok-add-custom-provider) :to-throw 'user-error)
+      (expect 'jsonrpc--async-request-1 :not :to-have-been-called))
+
+    (it "add-model sends deploymentUrl and isCustomModel for a custom provider"
+      (let ((captured nil))
+        (spy-on 'copilot-chat--byok-custom-providers
+                :and-return-value '("my-endpoint"))
+        (spy-on 'copilot-chat--byok-read-provider :and-return-value "my-endpoint")
+        (spy-on 'read-string :and-call-fake
+                (lambda (prompt &rest _)
+                  (cond ((string-prefix-p "Model id" prompt) "llama-3")
+                        ((string-prefix-p "Deployment URL" prompt)
+                         "https://api.example.com")
+                        (t "Llama 3"))))
+        (spy-on 'y-or-n-p :and-return-value nil)
+        (spy-on 'copilot--connection-alivep :and-return-value t)
+        (spy-on 'jsonrpc--async-request-1 :and-call-fake
+                (lambda (_conn method params &rest _args)
+                  (setq captured (list method params)) (list 1)))
+        (spy-on 'message)
+        (copilot-chat-byok-add-model)
+        (expect (nth 0 captured) :to-equal 'copilot/byok/saveModel)
+        (let ((p (nth 1 captured)))
+          (expect (plist-get p :providerName) :to-equal "my-endpoint")
+          (expect (plist-get p :deploymentUrl) :to-equal "https://api.example.com")
+          (expect (plist-get p :isCustomModel) :to-be t))))
+
+    (it "add-model errors on an empty deployment URL for a custom provider"
+      (spy-on 'copilot-chat--byok-custom-providers :and-return-value '("my-endpoint"))
+      (spy-on 'copilot-chat--byok-read-provider :and-return-value "my-endpoint")
+      (spy-on 'read-string :and-call-fake
+              (lambda (prompt &rest _)
+                (cond ((string-prefix-p "Model id" prompt) "llama-3")
+                      ((string-prefix-p "Deployment URL" prompt) "  ")
+                      (t "Llama 3"))))
+      (spy-on 'y-or-n-p :and-return-value nil)
+      (spy-on 'jsonrpc--async-request-1)
+      (expect (copilot-chat-byok-add-model) :to-throw 'user-error)
+      (expect 'jsonrpc--async-request-1 :not :to-have-been-called))
+
+    (it "remove-key offers custom providers alongside built-ins"
+      (let ((captured-providers nil))
+        (spy-on 'copilot-chat--byok-custom-providers
+                :and-return-value '("my-endpoint"))
+        (spy-on 'completing-read
+                :and-call-fake
+                (lambda (_prompt providers &rest _args)
+                  (setq captured-providers providers)
+                  "my-endpoint"))
+        (spy-on 'yes-or-no-p :and-return-value nil)
+        (spy-on 'message)
+        (copilot-chat-byok-remove-key)
+        (expect captured-providers :to-contain "my-endpoint")
+        (expect captured-providers :to-contain "OpenAI")
+        (expect captured-providers :not :to-contain "Azure")))
+
+    (it "list-custom-providers reports configured providers"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'jsonrpc-request
+              :and-return-value
+              (list :providers
+                    (list (list :providerName "my-endpoint"
+                                :apiType "chatCompletions"))))
+      (spy-on 'message)
+      (copilot-chat-byok-list-custom-providers)
+      (expect 'message :to-have-been-called-with
+              "Copilot Chat: Custom BYOK providers: %s"
+              "my-endpoint (chatCompletions)"))
+
+    (it "list-custom-providers shows the server message on an error"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'jsonrpc-request
+              :and-call-fake
+              (lambda (&rest _)
+                (signal 'jsonrpc-error
+                        (list "request failed"
+                              '(jsonrpc-error-code . -32601)
+                              '(jsonrpc-error-message . "Unhandled method")))))
+      (spy-on 'message)
+      (copilot-chat-byok-list-custom-providers)
+      (expect 'message :to-have-been-called-with
+              "Copilot Chat: Could not list custom providers: %s"
+              "Unhandled method")))
+
   (describe "copilot-chat--model-annotation"
     (it "returns an empty string for an unrestricted model"
       (expect (copilot-chat--model-annotation '(:id "m")) :to-equal ""))


### PR DESCRIPTION
BYOK phase 2: custom (non-built-in) OpenAI-compatible endpoints, on top of the built-in providers from #535/#536.

Verified against the 1.517.0 bundle: `copilot/byok/saveCustomProviderConfig {providerName, apiKey, groupName, apiType?}` stores the key AND the config in one call (`apiType` is one of `chatCompletions`/`responses`/`messages`), and rejects built-in provider names. A custom provider's models are registered with `saveModel` carrying a `deploymentUrl` (required, same as Azure), and the provider must be configured first. Custom-endpoint models route to chat the same way as any BYOK model (`modelInfo.providerName`), which #535 already wired up.

- `copilot-chat-byok-add-custom-provider`: prompts for a custom name (validated not to be a built-in), API type, group name (defaults to the provider name), and key (read-passwd). One `saveCustomProviderConfig` call.
- `copilot-chat-byok-add-model`: the provider list now includes your custom providers; Azure and custom providers require a per-model deployment URL, and a custom-endpoint model is saved with `isCustomModel` set (user-defined, not a catalog model the provider advertises). Built-in non-Azure providers are unchanged.
- `copilot-chat-byok-remove-key`: offers custom providers too (`deleteApiKey` removes their config and models; Azure still omitted).
- `copilot-chat-byok-list-custom-providers`: lists configured custom providers with their API type.

Same security posture as #536: keys read with `read-passwd`, never stored/logged/displayed, and no new call to `listApiKeys`.

Tests cover the custom/built-in predicate, listing custom providers (and error -> nil), add-custom-provider's request shape and built-in-name rejection, add-model's custom-provider path (deploymentUrl + isCustomModel), the empty-URL guard, remove-key including custom providers, and list-custom-providers output. README and CHANGELOG updated (the BYOK entry now covers custom endpoints).