### PR TITLE
Point login timeouts at proxy/TLS setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Changes
+
+- `copilot-login` waits longer for the language server to authenticate with GitHub, and when it times out it points you at proxy/TLS setup (`copilot-network-proxy`, `NODE_EXTRA_CA_CERTS`) instead of only reporting `Authentication failure: Timed out`, which reads like a credential problem when it is usually a TLS-inspecting proxy or firewall.
+
 ## 0.9.0 (2026-07-06)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -470,6 +470,25 @@ For example:
 (setq copilot-network-proxy '(:host "127.0.0.1" :port 7890))
 ```
 
+#### TLS-inspecting proxies and self-signed certificates
+
+If your network runs a TLS-inspecting proxy or firewall (Zscaler and the like) or uses a self-signed certificate, the language server's own HTTPS connection to GitHub can fail. This usually shows up as `copilot-login` reporting a timeout (`Authentication failure: Timed out`), because the server never manages to reach GitHub. There are two ways to handle it.
+
+Point the language server at your proxy and, when it intercepts TLS, tell it not to verify the proxy's certificate:
+
+```elisp
+(setq copilot-network-proxy '(:host "127.0.0.1" :port 7890 :rejectUnauthorized :json-false))
+```
+
+Or make the server trust your CA by exporting `NODE_EXTRA_CA_CERTS` (pointing at your CA chain in PEM format) **before Emacs starts**, since the server reads it only when it launches:
+
+```sh
+export NODE_EXTRA_CA_CERTS=/path/to/ca-chain.pem
+emacs
+```
+
+Setting it from your Emacs config with `(setenv "NODE_EXTRA_CA_CERTS" "...")` works too, as long as it happens before the server process starts; restart the server (or Emacs) afterward. Note that this is a TLS issue in the language server's HTTP client, not something copilot.el can resolve on its own.
+
 ### Handling server messages
 
 `copilot-on-request` registers a handler for incoming JSON-RPC requests from the language server. Return a JSON-serializable value as the result, or call `jsonrpc-error` for errors. [Read more](https://www.gnu.org/software/emacs/manual/html_node/elisp/JSONRPC-Overview.html).

--- a/copilot.el
+++ b/copilot.el
@@ -853,9 +853,19 @@ automatically, browse to %s." user-code verification-uri))
       (read-from-minibuffer (format "Please open %s in your browser. Press ENTER if you finish authorizing." verification-uri)))
     (copilot--log 'info "Verifying...")
     (condition-case err
-        (copilot--request 'signInConfirm (list :userCode user-code))
+        ;; The server exchanges the device code for a token with GitHub
+        ;; here, so allow more than the default 10s for a slow network.
+        (copilot--request 'signInConfirm (list :userCode user-code) :timeout 30)
       (jsonrpc-error
-       (user-error "Copilot: Authentication failure: %s" (alist-get 'jsonrpc-error-message (cddr err)))))
+       (let ((msg (alist-get 'jsonrpc-error-message (cddr err))))
+         (if (equal msg "Timed out")
+             ;; A client-side timeout here means the server could not reach
+             ;; GitHub, most often a proxy or TLS-inspecting firewall.
+             (user-error "Copilot: Timed out waiting for the language server \
+to authenticate with GitHub.  If you are behind a proxy or a TLS-inspecting \
+firewall, see the README \"Network proxy\" section (configure \
+`copilot-network-proxy' or set NODE_EXTRA_CA_CERTS)")
+           (user-error "Copilot: Authentication failure: %s" msg)))))
     (copilot--dbind (user) (copilot--request 'checkStatus nil)
       (copilot--log 'info "Authenticated as GitHub user %s." user))))
 

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -94,6 +94,38 @@
         (funcall captured-error-fn '(:code -1 :message "test"))
         (expect custom-called :to-be-truthy))))
 
+  (describe "copilot-login"
+    (defun copilot-test--login-with-confirm-error (confirm-message)
+      "Drive `copilot-login' so signInConfirm fails with CONFIRM-MESSAGE.
+Return the resulting `user-error' message string."
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'read-from-minibuffer :and-return-value "")
+      (spy-on 'browse-url)
+      (spy-on 'gui-set-selection)
+      (spy-on 'copilot--log)
+      (spy-on 'jsonrpc-request :and-call-fake
+              (lambda (_conn method &rest _)
+                (pcase method
+                  ('signInInitiate
+                   (list :status "NotSignedIn" :userCode "ABCD-1234"
+                         :verificationUri "https://github.com/login/device"))
+                  ('signInConfirm
+                   (signal 'jsonrpc-error
+                           (list "err" '(jsonrpc-error-code . -32000)
+                                 (cons 'jsonrpc-error-message confirm-message))))
+                  (_ nil))))
+      (condition-case err
+          (progn (copilot-login) nil)
+        (user-error (error-message-string err))))
+
+    (it "gives a proxy/TLS hint when authentication times out"
+      (expect (copilot-test--login-with-confirm-error "Timed out")
+              :to-match "proxy or a TLS-inspecting"))
+
+    (it "reports other authentication errors verbatim"
+      (expect (copilot-test--login-with-confirm-error "Device code expired")
+              :to-match "Authentication failure: Device code expired")))
+
   ;;
   ;; Utility functions
   ;;


### PR DESCRIPTION
Investigating #538: a login failing behind Zscaler with `copilot-login: Copilot: Authentication failure: Timed out`.

The cause isn't a bad credential. `copilot-login` sends `signInConfirm` as a synchronous request with no explicit timeout, so it uses jsonrpc's default 10s. Meanwhile the language server is doing the device-code token exchange with GitHub over HTTPS, which a TLS-inspecting proxy breaks (the server's `AuthManager` log just repeats "no session found, priming token"). At 10s the client times out and jsonrpc signals `jsonrpc-error` with message "Timed out", which we wrapped as "Authentication failure: Timed out" — misleading, since it's a network/TLS problem.

This does two things:
- Gives `signInConfirm` a 30s timeout, so a merely slow network doesn't false-timeout during an interactive login.
- On a timeout specifically, replaces the bare message with one that points at `copilot-network-proxy` (including `:rejectUnauthorized :json-false` for MITM proxies) and `NODE_EXTRA_CA_CERTS`. Other auth errors are still reported verbatim.

Also fills in the README's "Network proxy" section, which only showed a plain host/port, with a subsection on TLS-inspecting proxies and self-signed certificates (the guidance that the closed #419 pointed people to but that wasn't actually written down).

Tests cover both branches: the timeout path yields the proxy/TLS hint, other errors stay verbatim.