### PR TITLE
Fail login early on an empty device code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - `copilot-login` waits longer for the language server to authenticate with GitHub, and when it times out it points you at proxy/TLS setup (`copilot-network-proxy`, `NODE_EXTRA_CA_CERTS`) instead of only reporting `Authentication failure: Timed out`, which reads like a credential problem when it is usually a TLS-inspecting proxy or firewall.
+- `copilot-login` now stops early with a clear message when the language server returns an empty device code (a sign the request to GitHub was blocked by a proxy or firewall), rather than copying an empty code and timing out later.
 
 ## 0.9.0 (2026-07-06)
 

--- a/copilot.el
+++ b/copilot.el
@@ -841,6 +841,16 @@ You can change the installed version with `M-x copilot-reinstall-server` or remo
       (copilot--request 'signInInitiate nil)
     (when (string-equal status "AlreadySignedIn")
       (user-error "Copilot: Already signed in as %s" user))
+    ;; The language server fills in the one-time code from GitHub's
+    ;; device-code endpoint; an empty one means that request never
+    ;; reached GitHub (typically a proxy or TLS-inspecting firewall
+    ;; answering in its place), so there is no device flow to confirm.
+    ;; Bail out with a clear message instead of copying an empty code and
+    ;; timing out later on `signInConfirm'.
+    (when (or (null user-code) (string-empty-p user-code))
+      (user-error "Copilot: The language server could not get a device code \
+from GitHub, most likely because a proxy or firewall is blocking it.  See the \
+README \"Network proxy\" section"))
     (if (display-graphic-p)
         (progn
           (gui-set-selection 'CLIPBOARD user-code)

--- a/test/copilot-test.el
+++ b/test/copilot-test.el
@@ -124,7 +124,26 @@ Return the resulting `user-error' message string."
 
     (it "reports other authentication errors verbatim"
       (expect (copilot-test--login-with-confirm-error "Device code expired")
-              :to-match "Authentication failure: Device code expired")))
+              :to-match "Authentication failure: Device code expired"))
+
+    (it "aborts early when the device code comes back empty"
+      (spy-on 'copilot--connection-alivep :and-return-value t)
+      (spy-on 'read-from-minibuffer :and-return-value "")
+      (spy-on 'gui-set-selection)
+      (spy-on 'browse-url)
+      (spy-on 'copilot--log)
+      (spy-on 'jsonrpc-request :and-call-fake
+              (lambda (_conn method &rest _)
+                (pcase method
+                  ('signInInitiate
+                   (list :status "PromptUserDeviceFlow" :userCode ""
+                         :verificationUri "https://github.com/login/device"))
+                  ;; The guard must fire before signInConfirm is sent.
+                  (_ (error "signInConfirm should not be reached")))))
+      (let ((msg (condition-case err
+                     (progn (copilot-login) nil)
+                   (user-error (error-message-string err)))))
+        (expect msg :to-match "could not get a device code"))))
 
   ;;
   ;; Utility functions


### PR DESCRIPTION
Follow-up from #538. The reporter's events log showed `signInInitiate` succeeding but returning an **empty** `userCode`:

```
signInInitiate[2] -> :status "PromptUserDeviceFlow" :userCode "" :verificationUri "https://github.com/login/device"
signInConfirm[3]  -> :userCode ""
[3] timed-out request 'signInConfirm'
```

From the bundle, `signInInitiate` returns `userCode: c.user_code` where `c` is GitHub's `login/device/code` response, so an empty code means a proxy or firewall answered in GitHub's place (the request never really reached GitHub). copilot.el then copied an empty code to the clipboard and only failed ~30s later when `signInConfirm` timed out, which reads like a credential problem.

This detects the empty `userCode` right after `signInInitiate` and stops with a message naming the likely cause, before any prompt or clipboard copy. Pairs with #539 (which already improved the `signInConfirm` timeout message and documented proxy/TLS setup).

Test drives `signInInitiate` to return an empty code and asserts login aborts with the clear message and never sends `signInConfirm`.
